### PR TITLE
feat: Auto-trigger LLM analysis after measurement import (closes #14)

### DIFF
--- a/server.py
+++ b/server.py
@@ -438,6 +438,38 @@ def _run_llm_background(
         _llm_broadcast(sid, {"event": "llm_error", "data": str(exc)})
 
 
+def _maybe_trigger_llm(sid: str, session: Dict[str, Any]) -> None:
+    """Fire a background LLM analysis if the session has LLM configured and measurements."""
+    llm_cfg_dict = session.get("llm_config", {})
+    if not (llm_cfg_dict.get("endpoint") and llm_cfg_dict.get("model")):
+        return
+
+    all_measurements = (
+        session.get("pre_measurements", [])
+        + session.get("wb_measurements", [])
+        + session.get("gamma_measurements", [])
+        + session.get("cms_measurements", [])
+        + session.get("post_measurements", [])
+    )
+    if not all_measurements:
+        return
+
+    patches = [_measurement_to_patch(m) for m in all_measurements]
+    cfg = _session_to_analysis_config(session)
+    llm_cfg = LLMConfig(
+        endpoint=llm_cfg_dict.get("endpoint", ""),
+        model=llm_cfg_dict.get("model", ""),
+        api_key=llm_cfg_dict.get("api_key", ""),
+        temperature=float(llm_cfg_dict.get("temperature", 0.2)),
+        timeout=float(llm_cfg_dict.get("timeout", 30.0)),
+    )
+    threading.Thread(
+        target=_run_llm_background,
+        args=(sid, patches, cfg, session.get("step", "baseline"), llm_cfg),
+        daemon=True,
+    ).start()
+
+
 @app.get("/api/profiles")
 def list_profiles():
     return [{"key": key, "name": profile.name} for key, profile in TV_PROFILES.items()]
@@ -690,6 +722,7 @@ async def import_zro_csv(sid: str, file: UploadFile = File(...)):
     except Exception as exc:
         raise HTTPException(400, f"Could not read uploaded file: {exc}") from exc
     session, import_meta = store.import_zro_bytes(sid, file.filename, contents)
+    _maybe_trigger_llm(sid, session)
     return {"session": _session_view(session), "import_summary": import_meta}
 
 
@@ -700,6 +733,7 @@ async def import_generic_csv(sid: str, file: UploadFile = File(...)):
     except Exception as exc:
         raise HTTPException(400, f"Could not read uploaded file: {exc}") from exc
     session, import_meta = store.import_generic_bytes(sid, file.filename, contents)
+    _maybe_trigger_llm(sid, session)
     return {"session": _session_view(session), "import_summary": import_meta}
 
 

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -1296,3 +1296,63 @@ class TestLLMIntegration:
     def test_llm_stream_invalid_session_returns_404(self, client):
         resp = client.get("/api/session/nosuchsid/llm/stream")
         assert resp.status_code == 404
+
+    def _advance_to_pre_grayscale(self, client, sid):
+        """Advance session to pre_grayscale step so ZRO imports populate measurements."""
+        client.post(f"/api/session/{sid}/mode", json={"mode": "SDR"})
+        client.post(f"/api/session/{sid}/prepared")
+
+    def test_import_zro_auto_triggers_llm_when_configured(
+        self, client, session_id, monkeypatch
+    ):
+        self._advance_to_pre_grayscale(client, session_id)
+        client.post(f"/api/session/{session_id}/llm/configure",
+                    json={"endpoint": "http://localhost:4000", "model": "gpt-4o"})
+        monkeypatch.setattr(server_module, "_call_llm", lambda *a, **kw: "Check white balance.")
+
+        q = server_module._llm_subscribe(session_id)
+        csv = _make_zro_csv(_grayscale_rows())
+        resp = _upload_csv(client, session_id, csv)
+        assert resp.status_code == 200
+
+        payload = q.get(timeout=2.0)
+        assert payload["event"] == "llm_insight"
+        assert "white balance" in payload["data"]
+        server_module._llm_unsubscribe(session_id, q)
+
+    def test_import_zro_no_llm_configured_does_not_trigger(
+        self, client, session_id, monkeypatch
+    ):
+        self._advance_to_pre_grayscale(client, session_id)
+        fired = []
+        monkeypatch.setattr(server_module, "_call_llm", lambda *a, **kw: fired.append(1) or "x")
+
+        csv = _make_zro_csv(_grayscale_rows())
+        resp = _upload_csv(client, session_id, csv)
+        assert resp.status_code == 200
+
+        import time; time.sleep(0.1)
+        assert fired == [], "LLM should not fire when not configured"
+
+    def test_import_generic_auto_triggers_llm_when_configured(
+        self, client, session_id, monkeypatch
+    ):
+        self._advance_to_pre_grayscale(client, session_id)
+        # Populate measurements via ZRO import first
+        _upload_csv(client, session_id, _make_zro_csv(_grayscale_rows()))
+
+        client.post(f"/api/session/{session_id}/llm/configure",
+                    json={"endpoint": "http://localhost:4000", "model": "gpt-4o"})
+        monkeypatch.setattr(server_module, "_call_llm", lambda *a, **kw: "Adjust gain.")
+
+        q = server_module._llm_subscribe(session_id)
+        # Generic import also triggers LLM because measurements already exist in session
+        resp = client.post(
+            f"/api/session/{session_id}/import/generic",
+            files={"file": ("test.csv", b"R,G,B,Y,x,y\n", "text/csv")},
+        )
+        assert resp.status_code == 200
+
+        payload = q.get(timeout=2.0)
+        assert payload["event"] in ("llm_insight", "llm_error")
+        server_module._llm_unsubscribe(session_id, q)


### PR DESCRIPTION
## Summary

- Adds `_maybe_trigger_llm(sid, session)` helper that checks if LLM is configured and measurements exist, then fires a background thread
- Wires it into `POST /api/session/{sid}/import/zro` and `POST /api/session/{sid}/import/generic` so analysis fires automatically after each import
- Silent degradation: if LLM is unconfigured or no measurements exist, import behaves exactly as before

## Test plan

- [x] ZRO import auto-triggers LLM when configured — asserts `llm_insight` event arrives
- [x] ZRO import does not trigger LLM when unconfigured
- [x] Generic import auto-triggers LLM when session has measurements
- [x] 446/446 tests passing

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)