### PR TITLE
fix: include phase and timestamp in llm_insight SSE payload (closes #15)

### DIFF
--- a/server.py
+++ b/server.py
@@ -433,7 +433,14 @@ def _run_llm_background(
     try:
         summary = _calcore_analyze(patches, cfg)
         result = _call_llm(summary, cfg, phase, llm_cfg)
-        _llm_broadcast(sid, {"event": "llm_insight", "data": result})
+        _llm_broadcast(sid, {
+            "event": "llm_insight",
+            "data": {
+                "phase": phase,
+                "text": result,
+                "timestamp": datetime.utcnow().isoformat() + "Z",
+            },
+        })
     except Exception as exc:
         _llm_broadcast(sid, {"event": "llm_error", "data": str(exc)})
 

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -1260,7 +1260,10 @@ class TestLLMIntegration:
 
         payload = q.get(timeout=2.0)
         assert payload["event"] == "llm_insight"
-        assert "Adjust" in payload["data"]
+        data = payload["data"]
+        assert data["phase"] == "select_mode"
+        assert "Adjust" in data["text"]
+        assert data["timestamp"].endswith("Z")
         server_module._llm_unsubscribe(session_id, q)
 
     def test_llm_run_error_broadcasts_llm_error_event(
@@ -1317,7 +1320,7 @@ class TestLLMIntegration:
 
         payload = q.get(timeout=2.0)
         assert payload["event"] == "llm_insight"
-        assert "white balance" in payload["data"]
+        assert "white balance" in payload["data"]["text"]
         server_module._llm_unsubscribe(session_id, q)
 
     def test_import_zro_no_llm_configured_does_not_trigger(


### PR DESCRIPTION
Broadcast a structured JSON object {phase, text, timestamp} instead of a raw string, matching the spec from issue #3. Updated two tests to assert the new payload shape.