### PR TITLE
feat: Add AiInsightPanel for real-time LLM coaching (closes #16)

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,45 @@
+# Frontend Source
+
+This directory is reserved for the React source tree that produces
+`static/assets/index.js` and `static/assets/index.css`.
+
+The original React source has not yet been committed to this repository
+(see project README). The compiled assets in `static/assets/` are the
+canonical served frontend.
+
+## AiInsightPanel
+
+The AI Calibration Coach panel lives in `static/assets/ai-panel.js` and
+`static/assets/ai-panel.css`. It is a standalone native ES module — no
+build step required — that overlays the compiled React app.
+
+### Architecture
+
+```
+static/assets/
+  index.js       # Compiled React app (source not yet in repo)
+  index.css      # Compiled Tailwind CSS
+  ai-panel.js    # AiInsightPanel — vanilla ES module (this issue)
+  ai-panel.css   # Panel styles
+```
+
+### How the panel works
+
+1. On load it calls `GET /api/session` to find the current session.
+2. It subscribes to `GET /events/{sid}` (SSE) to receive session updates.
+3. When `session.step` is one of `white_balance`, `gamma`, `color_tuner`,
+   or `post_grayscale` **and** `session.llm_config.endpoint` + `.model`
+   are both set, the panel becomes visible.
+4. It opens `GET /api/session/{sid}/llm/stream` (SSE) and shows a spinner.
+5. On `llm_insight` it renders the markdown-formatted coaching text.
+6. On `llm_error` it renders a dismissable error state with a Retry button.
+7. The panel can be collapsed (toggle ▼/▲) or fully dismissed (✕).
+   Dismissal resets automatically when the step changes.
+
+### When to migrate to React
+
+Once the React source tree is added to this directory, the `AiInsightPanel`
+should be ported to a proper React component with a `useLlmStream` hook and
+mounted inside the `white_balance`, `gamma`, `color_tuner`, and
+`post_grayscale` step pages. The standalone files in `static/assets/` can
+then be removed.

--- a/static/assets/ai-panel.css
+++ b/static/assets/ai-panel.css
@@ -1,0 +1,218 @@
+/* =========================================================
+   AI Calibration Coach panel
+   Positioned as a fixed overlay in the bottom-right corner.
+   ========================================================= */
+
+#ai-insight-panel {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  z-index: 9999;
+  width: 380px;
+  max-width: calc(100vw - 48px);
+  background: #1a1f2e;
+  border: 1px solid #2d3550;
+  border-radius: 10px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  font-size: 0.875rem;
+  color: #d1d9f0;
+  overflow: hidden;
+}
+
+/* ----- Header ----- */
+
+.ai-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 14px;
+  background: #1e2538;
+  border-bottom: 1px solid #2d3550;
+  user-select: none;
+}
+
+.ai-panel-title {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-weight: 600;
+  font-size: 0.8125rem;
+  letter-spacing: 0.01em;
+  color: #a8b4e8;
+}
+
+.ai-panel-icon {
+  color: #7b8fd4;
+  font-size: 0.75rem;
+}
+
+.ai-panel-actions {
+  display: flex;
+  gap: 4px;
+}
+
+.ai-panel-toggle,
+.ai-panel-dismiss {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: #7b8fd4;
+  font-size: 0.75rem;
+  padding: 3px 6px;
+  border-radius: 4px;
+  line-height: 1;
+  transition: background 0.15s, color 0.15s;
+}
+
+.ai-panel-toggle:hover,
+.ai-panel-dismiss:hover {
+  background: #2d3550;
+  color: #d1d9f0;
+}
+
+/* ----- Body ----- */
+
+.ai-panel-body {
+  padding: 14px;
+  max-height: 320px;
+  overflow-y: auto;
+}
+
+/* ----- Spinner ----- */
+
+.ai-panel-spinner-wrap {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 0;
+}
+
+.ai-panel-spinner {
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  border: 2px solid #2d3550;
+  border-top-color: #7b8fd4;
+  border-radius: 50%;
+  flex-shrink: 0;
+  animation: ai-spin 0.8s linear infinite;
+}
+
+@keyframes ai-spin {
+  to { transform: rotate(360deg); }
+}
+
+.ai-panel-spinner-label {
+  color: #7b8fd4;
+  font-size: 0.8125rem;
+}
+
+/* ----- Metadata (phase / timestamp) ----- */
+
+.ai-panel-meta {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 10px;
+  font-size: 0.75rem;
+}
+
+.ai-panel-phase {
+  background: #2d3550;
+  color: #a8b4e8;
+  border-radius: 4px;
+  padding: 2px 7px;
+  text-transform: capitalize;
+}
+
+.ai-panel-time {
+  color: #556;
+}
+
+/* ----- Markdown output ----- */
+
+.ai-panel-markdown {
+  line-height: 1.6;
+}
+
+.ai-panel-markdown p {
+  margin: 0 0 6px;
+}
+
+.ai-panel-markdown p:last-child {
+  margin-bottom: 0;
+}
+
+.ai-panel-markdown br {
+  display: block;
+  content: '';
+  margin-top: 4px;
+}
+
+.ai-panel-markdown blockquote {
+  margin: 8px 0;
+  padding: 8px 12px;
+  border-left: 3px solid #7b8fd4;
+  background: #1e2538;
+  border-radius: 0 6px 6px 0;
+}
+
+.ai-panel-markdown blockquote p {
+  margin: 0 0 4px;
+}
+
+.ai-panel-markdown blockquote p:last-child {
+  margin-bottom: 0;
+}
+
+.ai-panel-markdown strong {
+  color: #c5cef5;
+  font-weight: 600;
+}
+
+.ai-panel-markdown em {
+  color: #b0bde8;
+  font-style: italic;
+}
+
+.ai-panel-markdown code {
+  font-family: ui-monospace, 'Cascadia Code', Menlo, monospace;
+  background: #111827;
+  padding: 1px 5px;
+  border-radius: 3px;
+  font-size: 0.8125rem;
+}
+
+/* ----- Error state ----- */
+
+.ai-panel-error {
+  padding: 8px 0;
+}
+
+.ai-panel-error strong {
+  color: #f87171;
+  display: block;
+  margin-bottom: 6px;
+}
+
+.ai-panel-error p {
+  color: #9ca3af;
+  font-size: 0.8125rem;
+  margin: 0 0 10px;
+  word-break: break-word;
+}
+
+.ai-panel-retry-btn {
+  background: #2d3550;
+  border: 1px solid #3d4a70;
+  color: #a8b4e8;
+  font-size: 0.8rem;
+  padding: 4px 12px;
+  border-radius: 5px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.ai-panel-retry-btn:hover {
+  background: #3d4a70;
+}

--- a/static/assets/ai-panel.js
+++ b/static/assets/ai-panel.js
@@ -1,0 +1,385 @@
+/**
+ * AiInsightPanel — native ES module (no build step required).
+ *
+ * Mounts an "AI Calibration Coach" panel that:
+ *  - is hidden when no LLM is configured on the session
+ *  - shows a loading spinner while an LLM call is in-flight
+ *  - renders the markdown-formatted llm_insight text on arrival
+ *  - shows a dismissable error state on llm_error
+ *  - collapses/expands via a toggle button
+ *  - fully dismisses until the calibration step changes
+ *
+ * SSE subscriptions:
+ *  /events/{sid}                   → session updates (step changes, new imports)
+ *  /api/session/{sid}/llm/stream   → llm_insight / llm_error events
+ */
+
+/** Steps where the panel should appear. */
+const AI_STEPS = new Set(['white_balance', 'gamma', 'color_tuner', 'post_grayscale']);
+
+/** Timeout (ms) before we stop showing the spinner with no response. */
+const SPINNER_TIMEOUT_MS = 40_000;
+
+// ---------------------------------------------------------------------------
+// Minimal markdown → safe HTML converter (handles the LLM output format)
+// ---------------------------------------------------------------------------
+
+function markdownToHtml(text) {
+  if (!text) return '';
+
+  // Escape HTML entities first.
+  let html = text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+
+  // Process line by line so we can group blockquotes.
+  const lines = html.split('\n');
+  const out = [];
+  let inBlockquote = false;
+
+  for (const rawLine of lines) {
+    // Blockquote: lines starting with &gt; (escaped >)
+    if (rawLine.startsWith('&gt; ') || rawLine === '&gt;') {
+      const inner = rawLine.startsWith('&gt; ') ? rawLine.slice(5) : '';
+      if (!inBlockquote) {
+        out.push('<blockquote>');
+        inBlockquote = true;
+      }
+      out.push(`<p>${inlineMarkdown(inner)}</p>`);
+    } else {
+      if (inBlockquote) {
+        out.push('</blockquote>');
+        inBlockquote = false;
+      }
+      if (rawLine.trim() === '') {
+        out.push('<br>');
+      } else {
+        out.push(`<p>${inlineMarkdown(rawLine)}</p>`);
+      }
+    }
+  }
+  if (inBlockquote) out.push('</blockquote>');
+
+  return out.join('\n');
+}
+
+/** Apply inline markdown: **bold**, *italic*, `code`. */
+function inlineMarkdown(text) {
+  return text
+    .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+    .replace(/\*(.+?)\*/g, '<em>$1</em>')
+    .replace(/`(.+?)`/g, '<code>$1</code>');
+}
+
+// ---------------------------------------------------------------------------
+// Panel implementation
+// ---------------------------------------------------------------------------
+
+class AiInsightPanel {
+  constructor() {
+    /** @type {object|null} Latest session object from the API */
+    this.session = null;
+    /** @type {EventSource|null} */
+    this._sessionEs = null;
+    /** @type {EventSource|null} */
+    this._llmEs = null;
+    /** @type {{text:string, phase:string, timestamp:string}|null} */
+    this._insight = null;
+    /** @type {string|null} */
+    this._error = null;
+    /** Whether the LLM stream is open and awaiting a response. */
+    this._loading = false;
+    /** Timer handle for spinner timeout. */
+    this._spinnerTimer = null;
+    /** Whether the user collapsed the panel body. */
+    this._collapsed = false;
+    /** Whether the user fully dismissed the panel (resets on step change). */
+    this._dismissed = false;
+    /** The session step when the panel was last dismissed. */
+    this._dismissedOnStep = null;
+    /** Import count at the time the LLM stream was last opened. */
+    this._importCount = 0;
+
+    this._el = this._createElement();
+    document.body.appendChild(this._el);
+
+    // Start by loading the current session, then subscribe to SSE.
+    this._initSession();
+  }
+
+  // -------------------------------------------------------------------------
+  // Initialisation
+  // -------------------------------------------------------------------------
+
+  async _initSession() {
+    try {
+      const res = await fetch('/api/session');
+      if (res.ok) {
+        const session = await res.json();
+        if (session?.id) {
+          this._onSession(session);
+          this._openSessionStream(session.id);
+          return;
+        }
+      }
+    } catch (_) { /* ignore */ }
+
+    // No session yet — retry after a short delay.
+    setTimeout(() => this._initSession(), 3000);
+  }
+
+  _openSessionStream(sid) {
+    if (this._sessionEs) {
+      this._sessionEs.close();
+      this._sessionEs = null;
+    }
+    const es = new EventSource(`/events/${sid}`);
+    es.addEventListener('session', (e) => {
+      try { this._onSession(JSON.parse(e.data)); } catch (_) { /* ignore */ }
+    });
+    es.onerror = () => {
+      // Connection dropped — retry init after a delay.
+      es.close();
+      this._sessionEs = null;
+      setTimeout(() => this._initSession(), 5000);
+    };
+    this._sessionEs = es;
+  }
+
+  // -------------------------------------------------------------------------
+  // Session state handling
+  // -------------------------------------------------------------------------
+
+  _onSession(session) {
+    const prevStep = this.session?.step;
+    const prevId = this.session?.id;
+    this.session = session;
+
+    const step = session.step;
+    const llmCfg = session.llm_config || {};
+    const llmConfigured = !!(llmCfg.endpoint && llmCfg.model);
+    const onTargetStep = AI_STEPS.has(step);
+
+    // Reset dismiss when the step changes.
+    if (step !== this._dismissedOnStep) {
+      this._dismissed = false;
+    }
+
+    if (onTargetStep && llmConfigured && !this._dismissed) {
+      // Check whether a new import arrived (should re-trigger LLM stream).
+      const importCount = (session.zro_imports || []).length;
+      const newImport = importCount > this._importCount;
+
+      // Open (or re-open) the LLM stream when:
+      //  - session ID changed (new session), or
+      //  - this is the first time we're on this step, or
+      //  - a new import was detected (new LLM call in-flight).
+      if (!this._llmEs || prevId !== session.id || newImport) {
+        this._importCount = importCount;
+        if (newImport) {
+          // Clear previous insight so the spinner shows for the new call.
+          this._insight = null;
+          this._error = null;
+        }
+        this._openLlmStream(session.id);
+      }
+      this._render(true);
+    } else {
+      this._closeLlmStream();
+      this._render(false);
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // LLM SSE stream
+  // -------------------------------------------------------------------------
+
+  _openLlmStream(sid) {
+    this._closeLlmStream();
+    this._loading = true;
+    this._clearSpinnerTimer();
+    this._spinnerTimer = setTimeout(() => {
+      // If we haven't received anything, stop the spinner gracefully.
+      if (this._loading) {
+        this._loading = false;
+        this._render(true);
+      }
+    }, SPINNER_TIMEOUT_MS);
+
+    const es = new EventSource(`/api/session/${sid}/llm/stream`);
+
+    es.addEventListener('llm_insight', (e) => {
+      try {
+        const data = JSON.parse(e.data);
+        // data is {phase, text, timestamp}
+        this._insight = typeof data === 'object' ? data : { text: data, phase: '', timestamp: '' };
+      } catch (_) {
+        this._insight = { text: String(e.data), phase: '', timestamp: '' };
+      }
+      this._loading = false;
+      this._clearSpinnerTimer();
+      this._render(true);
+    });
+
+    es.addEventListener('llm_error', (e) => {
+      try {
+        this._error = JSON.parse(e.data);
+      } catch (_) {
+        this._error = String(e.data);
+      }
+      this._loading = false;
+      this._clearSpinnerTimer();
+      this._render(true);
+    });
+
+    es.onerror = () => {
+      // Connection error — stop spinner but keep panel visible.
+      this._loading = false;
+      this._clearSpinnerTimer();
+      this._render(true);
+    };
+
+    this._llmEs = es;
+  }
+
+  _closeLlmStream() {
+    if (this._llmEs) {
+      this._llmEs.close();
+      this._llmEs = null;
+    }
+    this._clearSpinnerTimer();
+    this._loading = false;
+  }
+
+  _clearSpinnerTimer() {
+    if (this._spinnerTimer !== null) {
+      clearTimeout(this._spinnerTimer);
+      this._spinnerTimer = null;
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // DOM creation and rendering
+  // -------------------------------------------------------------------------
+
+  _createElement() {
+    const el = document.createElement('div');
+    el.id = 'ai-insight-panel';
+    el.style.display = 'none';
+    return el;
+  }
+
+  _render(visible) {
+    if (!visible) {
+      this._el.style.display = 'none';
+      return;
+    }
+    this._el.style.display = 'block';
+
+    const isCollapsed = this._collapsed;
+    const hasInsight = !!this._insight;
+    const hasError = !!this._error;
+    const isLoading = this._loading;
+
+    // ---- Body content ----
+    let bodyHtml = '';
+    if (isLoading && !hasInsight) {
+      bodyHtml = `
+        <div class="ai-panel-spinner-wrap">
+          <span class="ai-panel-spinner"></span>
+          <span class="ai-panel-spinner-label">Analysing measurements…</span>
+        </div>`;
+    } else if (hasError) {
+      bodyHtml = `
+        <div class="ai-panel-error">
+          <strong>Analysis error</strong>
+          <p>${escapeHtml(String(this._error))}</p>
+          <button class="ai-panel-retry-btn">Retry</button>
+        </div>`;
+    } else if (hasInsight) {
+      const { text = '', phase = '', timestamp = '' } = this._insight;
+      const phaseLabel = phase ? `<span class="ai-panel-phase">${escapeHtml(phase.replace(/_/g, ' '))}</span>` : '';
+      const timeLabel = timestamp
+        ? `<span class="ai-panel-time">${escapeHtml(new Date(timestamp).toLocaleTimeString())}</span>`
+        : '';
+      const meta = (phaseLabel || timeLabel)
+        ? `<div class="ai-panel-meta">${phaseLabel}${timeLabel}</div>` : '';
+      bodyHtml = `
+        ${meta}
+        <div class="ai-panel-markdown">${markdownToHtml(text)}</div>`;
+    } else {
+      bodyHtml = `
+        <div class="ai-panel-spinner-wrap">
+          <span class="ai-panel-spinner-label">Waiting for LLM analysis…</span>
+        </div>`;
+    }
+
+    this._el.innerHTML = `
+      <div class="ai-panel-header">
+        <div class="ai-panel-title">
+          <span class="ai-panel-icon">✦</span>
+          AI Calibration Coach
+        </div>
+        <div class="ai-panel-actions">
+          <button class="ai-panel-toggle" aria-label="${isCollapsed ? 'Expand' : 'Collapse'}" title="${isCollapsed ? 'Expand' : 'Collapse'}">
+            ${isCollapsed ? '▲' : '▼'}
+          </button>
+          <button class="ai-panel-dismiss" aria-label="Dismiss" title="Dismiss panel">✕</button>
+        </div>
+      </div>
+      ${isCollapsed ? '' : `<div class="ai-panel-body">${bodyHtml}</div>`}
+    `;
+
+    // Wire up buttons.
+    this._el.querySelector('.ai-panel-toggle').addEventListener('click', () => {
+      this._collapsed = !this._collapsed;
+      this._render(true);
+    });
+
+    this._el.querySelector('.ai-panel-dismiss').addEventListener('click', () => {
+      this._dismissed = true;
+      this._dismissedOnStep = this.session?.step || null;
+      this._closeLlmStream();
+      this._render(false);
+    });
+
+    const retryBtn = this._el.querySelector('.ai-panel-retry-btn');
+    if (retryBtn) {
+      retryBtn.addEventListener('click', () => {
+        this._error = null;
+        this._insight = null;
+        if (this.session?.id) {
+          this._openLlmStream(this.session.id);
+        }
+        this._render(true);
+      });
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function escapeHtml(str) {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+// ---------------------------------------------------------------------------
+// Bootstrap
+// ---------------------------------------------------------------------------
+
+function init() {
+  new AiInsightPanel();
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', init);
+} else {
+  init();
+}

--- a/static/index.html
+++ b/static/index.html
@@ -7,6 +7,9 @@
     <title>ZRO Calibration Helper</title>
     <script type="module" crossorigin src="/assets/index.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index.css">
+    <!-- AI Calibration Coach panel (no build step required) -->
+    <link rel="stylesheet" href="/assets/ai-panel.css">
+    <script type="module" src="/assets/ai-panel.js"></script>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary

- Adds `AiInsightPanel` — a collapsible "AI Calibration Coach" overlay panel that subscribes to `GET /api/session/{sid}/llm/stream` and surfaces LLM coaching text in real time
- Panel is active on the `white_balance`, `gamma`, `color_tuner`, and `post_grayscale` steps; hidden on all others and when no LLM is configured
- Session state is tracked via a second subscription to `GET /events/{sid}` (same endpoint the main app uses, multi-subscriber safe)

## Files

| File | Purpose |
|---|---|
| `static/assets/ai-panel.js` | Standalone ES module — the full `AiInsightPanel` implementation |
| `static/assets/ai-panel.css` | Dark-themed panel styles (fixed, bottom-right overlay) |
| `static/index.html` | +2 lines to load the new stylesheet and module |
| `frontend/README.md` | Documents architecture and future React migration path |

## Acceptance criteria

- [x] Panel is hidden when no LLM is configured (`llm_config.endpoint` + `.model` must both be set)
- [x] Panel shows spinner between import and `llm_insight` arrival — `zro_imports.length` is tracked; a new import resets to loading state and re-opens the SSE stream
- [x] Panel renders LLM text (markdown) on `llm_insight` — handles the `> **Step…**` blockquote format, `**bold**`, `*italic*`, and `` `code` ``
- [x] Panel shows a dismissable error state on `llm_error` — includes a Retry button that re-opens the stream
- [x] Panel collapses/expands via toggle (▼/▲) and can be fully dismissed (✕); dismiss auto-resets when the step changes

## Architecture note

The React source tree is not yet in this repo and Node.js is not available in the dev environment, so the panel is implemented as a native ES module overlay rather than a compiled React component. `frontend/README.md` documents exactly what to port once the source tree is added.

## Test plan

- [ ] Start the backend: `uvicorn server:app --port 8000`
- [ ] Open `http://localhost:8000`, create a session, advance to **White Balance**
- [ ] Configure LLM via `POST /api/session/{sid}/llm/configure`
- [ ] Upload a ZRO CSV — panel should appear with spinner, then show coaching text
- [ ] Collapse and expand with ▼/▲; dismiss with ✕; advance step and confirm panel reappears
- [ ] Verify panel is absent on `pre_grayscale`, `luminance`, and `report` steps
- [ ] Run `pytest -q` — all 99 tests should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)