### PR TITLE
fix: add missing dogegenStatus prop to Gamma, WhiteBalance, ColorTuner, PostGrayscale

### DIFF
--- a/frontend/src/pages/ColorTuner.jsx
+++ b/frontend/src/pages/ColorTuner.jsx
@@ -71,7 +71,7 @@ function ActionPlanWithAdb({ plan, title, adbStatus, onAdbApply }) {
   );
 }
 
-export function ColorTuner({ session, watchStatus, watchDefaultPath, bridgeStatus, bridgeUrl, adbStatus, onUpload, onStartWatch, onStopWatch, onSaveBridgeUrl, onMeasure, onAdbApply, onAdbReset, onAdbDeploy, onRefreshAdb, onNext, onPrev }) {
+export function ColorTuner({ session, watchStatus, watchDefaultPath, bridgeStatus, bridgeUrl, dogegenStatus, adbStatus, onUpload, onStartWatch, onStopWatch, onSaveBridgeUrl, onMeasure, onAdbApply, onAdbReset, onAdbDeploy, onRefreshAdb, onNext, onPrev }) {
   const cd = session.cms_data || {};
   const plan = cd.control_plan || [];
   const meas = cd.measurements || [];

--- a/frontend/src/pages/Gamma.jsx
+++ b/frontend/src/pages/Gamma.jsx
@@ -9,7 +9,7 @@ import { ZroInstructions } from '../components/ZroInstructions';
 import { GammaChart } from '../charts/GammaChart';
 import { QualityGate } from '../components/QualityGate';
 
-export function Gamma({ session, watchStatus, watchDefaultPath, bridgeStatus, bridgeUrl, onUpload, onStartWatch, onStopWatch, onSaveBridgeUrl, onMeasure, onSetGammaWorkflow, onNext, onPrev }) {
+export function Gamma({ session, watchStatus, watchDefaultPath, bridgeStatus, bridgeUrl, dogegenStatus, onUpload, onStartWatch, onStopWatch, onSaveBridgeUrl, onMeasure, onSetGammaWorkflow, onNext, onPrev }) {
   const gd = session.gamma_data || {};
   const plan      = gd.control_plan || [];
   const meas      = gd.measurements || [];

--- a/frontend/src/pages/PostGrayscale.jsx
+++ b/frontend/src/pages/PostGrayscale.jsx
@@ -8,7 +8,7 @@ import { ZroInstructions } from '../components/ZroInstructions';
 import { DeChart } from '../charts/DeChart';
 import { QualityGate } from '../components/QualityGate';
 
-export function PostGrayscale({ session, watchStatus, watchDefaultPath, bridgeStatus, bridgeUrl, onUpload, onStartWatch, onStopWatch, onSaveBridgeUrl, onMeasure, onNext, onPrev }) {
+export function PostGrayscale({ session, watchStatus, watchDefaultPath, bridgeStatus, bridgeUrl, dogegenStatus, onUpload, onStartWatch, onStopWatch, onSaveBridgeUrl, onMeasure, onNext, onPrev }) {
   const gd = session.grayscale_data || {};
   const done  = gd.done || 0;
   const total = gd.total || 11;

--- a/frontend/src/pages/WhiteBalance.jsx
+++ b/frontend/src/pages/WhiteBalance.jsx
@@ -29,7 +29,7 @@ function DeMeasCard({ label, measurement, hasFlag }) {
   );
 }
 
-export function WhiteBalance({ session, watchStatus, watchDefaultPath, bridgeStatus, bridgeUrl, onUpload, onStartWatch, onStopWatch, onSaveBridgeUrl, onMeasure, onNext, onPrev }) {
+export function WhiteBalance({ session, watchStatus, watchDefaultPath, bridgeStatus, bridgeUrl, dogegenStatus, onUpload, onStartWatch, onStopWatch, onSaveBridgeUrl, onMeasure, onNext, onPrev }) {
   const wd = session.wb_data || {};
   const plan   = wd.control_plan || [];
   const hints  = wd.hints || null;


### PR DESCRIPTION
## Summary

- Fixes #23
- `dogegenStatus` was included in `stepProps` in `App.jsx` but not destructured in 4 measurement step pages, causing it to always be `undefined` when passed to `<BridgeCard>`
- Adds `dogegenStatus` to the props signature of `Gamma`, `WhiteBalance`, `ColorTuner`, and `PostGrayscale`

## Test plan

- [ ] Navigate to the Gamma step — BridgeCard should render without crashing and reflect Dogegen status correctly
- [ ] Same check for White Balance, Color Tuner, and Post-Cal Grayscale steps
- [ ] Verify `dogegenStatus?.running` / `dogegenStatus?.ready` display correctly in the bridge card when Dogegen is started/stopped

🤖 Generated with [Claude Code](https://claude.com/claude-code)