### PR TITLE
fix: add watchStatus.watching to WatchFolder useEffect deps

### DIFF
--- a/frontend/src/components/WatchFolder.jsx
+++ b/frontend/src/components/WatchFolder.jsx
@@ -7,7 +7,7 @@ export function WatchFolder({ watchStatus, onStart, onStop, defaultPath }) {
   // Sync input to defaultPath once it resolves from localStorage (only when not watching)
   useEffect(() => {
     if (defaultPath && !watchStatus.watching) setPath(defaultPath);
-  }, [defaultPath]);
+  }, [defaultPath, watchStatus.watching]);
   const ws = watchStatus;
 
   const dotCls = ws.watching ? 'dot-active' : ws.error ? 'dot-error' : 'dot-inactive';


### PR DESCRIPTION
## Summary

- Fixes #24
- `watchStatus.watching` was used inside the effect but missing from the dependency array
- Without it, the path input would not reset to `defaultPath` when watching stopped (as long as `defaultPath` itself had not changed)

## Test plan

- [ ] Start watching a path, then click Stop — the path input should reset to `defaultPath`
- [ ] Confirm the input does not reset while watching is active

🤖 Generated with [Claude Code](https://claude.com/claude-code)