### PR TITLE
fix: resolve issues #25, #26, #27, #28

### DIFF
--- a/calcore/analysis.py
+++ b/calcore/analysis.py
@@ -75,8 +75,8 @@ def analyze(patches: List[Patch], cfg: AnalysisConfig) -> Summary:
                 if 0.20 <= n <= 0.80:
                     gray_pq_err_mid.append(pq_err_pct)
             else:
-                rel = min(meas_y, measured_peak_y) / measured_peak_y
-                if rel > 0:
+                if 0 < meas_y < measured_peak_y:
+                    rel = meas_y / measured_peak_y
                     gamma_val = math.log(rel) / math.log(n)
                     if 0.20 <= n <= 0.80:
                         gray_gamma_mid.append(gamma_val)

--- a/frontend/src/pages/Prepare.jsx
+++ b/frontend/src/pages/Prepare.jsx
@@ -174,34 +174,6 @@ export function Prepare({ session, dogegenStatus, onConfirmPrepared, onPrev, onS
             ))}
           </div>
 
-          {availableRamps.length > 0 && (
-            <>
-              <div className="text-sm" style={{ marginBottom: 8 }}>
-                <strong>Grayscale ramp density</strong>
-              </div>
-              <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-                {availableRamps.map(opt => (
-                  <label
-                    key={opt.steps}
-                    style={{ display: 'flex', alignItems: 'flex-start', gap: 10, cursor: 'pointer' }}
-                  >
-                    <input
-                      type="radio"
-                      name="ramp"
-                      value={opt.steps}
-                      checked={selectedSteps === opt.steps}
-                      onChange={() => handleRampChange(opt.steps)}
-                      style={{ marginTop: 2, flexShrink: 0 }}
-                    />
-                    <span>
-                      <span className="text-sm"><strong>{opt.label}</strong></span>
-                      <span className="text-sm muted" style={{ display: 'block' }}>{opt.summary}</span>
-                    </span>
-                  </label>
-                ))}
-              </div>
-            </>
-          )}
         </Card>
       )}
 

--- a/frontend/src/pages/Report.jsx
+++ b/frontend/src/pages/Report.jsx
@@ -63,7 +63,7 @@ export function Report({ session, onPrev }) {
             <StatCard
               value={report.improvement_pct != null ? report.improvement_pct.toFixed(1) + '%' : '—'}
               label="Improvement"
-              color={report.improvement_pct > 0 ? 'green' : ''}
+              color={report.improvement_pct != null && report.improvement_pct > 0 ? 'green' : ''}
             />
           </div>
 

--- a/frontend/src/pages/SelectMode.jsx
+++ b/frontend/src/pages/SelectMode.jsx
@@ -11,7 +11,7 @@ const DEFAULT_MODES = [
 export function SelectMode({ session, onConfirmMode }) {
   const modes = session.modes || DEFAULT_MODES;
   const [selectedMode, setSelectedMode] = useState(session.mode || null);
-  const [sdrPeakNits, setSdrPeakNits] = useState(120);
+  const [sdrPeakNits, setSdrPeakNits] = useState(session.sdr_peak_nits || 120);
 
   const ambientGuide = session.sdr_ambient_guide || [];
 


### PR DESCRIPTION
## Summary

Four independent bug fixes bundled in one PR.

- **Fixes #25** — Remove duplicate grayscale ramp radio buttons from the LightSpace Connect card in `Prepare.jsx`. Both the LightSpace Connect card and the always-visible Grayscale Ramp card were rendering `name="ramp"` radio inputs, causing them to share an HTML radio group and interfere with each other. The LightSpace Connect card now only handles tier selection; ramp density is exclusively owned by the Grayscale Ramp card.

- **Fixes #26** — Add null guard to `improvement_pct` color prop in `Report.jsx`. `null > 0` evaluates to `false` in JS rather than producing a neutral/absent color, so sessions without post-cal data showed incorrect styling on the Improvement stat card.

- **Fixes #27** — Fix gamma calculation in `calcore/analysis.py` to skip patches where `meas_y >= measured_peak_y` instead of clamping with `min()`. The old clamp set `rel = 1.0`, making `log(1) / log(n) = 0.0`, which silently injected a bogus gamma reading for any patch affected by ABL or measurement overshoot — corrupting the midtone gamma average used by the guidance engine.

- **Fixes #28** — Initialise `sdrPeakNits` from `session.sdr_peak_nits` in `SelectMode.jsx`. The backend already stores and returns this value; the frontend was ignoring it and always defaulting to 120 nits, causing the user's previously confirmed target to be silently overwritten when navigating back.

## Test plan

- [ ] **#25**: Switch to LightSpace Connect generator on Prepare page — verify only one set of ramp radio buttons is visible and selection works correctly
- [ ] **#26**: Load a session with no post-cal data — Improvement stat card should show neutral styling (no green)
- [ ] **#27**: Import a ZRO CSV where a mid-grey patch measures higher Y than the 100% white patch — verify that patch is excluded from gamma average rather than contributing gamma=0.0
- [ ] **#28**: Confirm SDR mode at a non-default nits value, navigate back, verify the slider shows the previously chosen value

🤖 Generated with [Claude Code](https://claude.com/claude-code)