### PR TITLE
fix: use os.path.exists() for file-path detection in csv_import (closes #30)

### DIFF
--- a/calcore/csv_import.py
+++ b/calcore/csv_import.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import csv
 import io
+import os
 import re
 from typing import List
 
@@ -32,12 +33,12 @@ def parse_measurement_csv(source: str | bytes | io.IOBase) -> List[Patch]:
         raw = source.decode("utf-8-sig")
     elif isinstance(source, str):
         # Distinguish between a file path and raw CSV content.
-        # CSV content always contains a newline; valid file paths rarely do.
-        if "\n" in source or "\t" in source or "," in source:
-            raw = source
-        else:
+        # Use os.path.exists() so paths containing commas are handled correctly.
+        if "\n" not in source and os.path.exists(source):
             with open(source, "r", newline="", encoding="utf-8-sig") as f:
                 raw = f.read()
+        else:
+            raw = source
     else:
         raw = source.read()
         if isinstance(raw, bytes):


### PR DESCRIPTION
## Summary
- Replaces the comma-based heuristic in `calcore/csv_import.py` with `os.path.exists()` to correctly identify file paths that contain commas
- Paths like `/Users/john,jr/log.csv` are now opened as files instead of being silently treated as raw CSV content
- Closes #30

## Test plan
- [ ] Pass a file path containing a comma to `parse_measurement_csv` and verify it is read correctly
- [ ] Pass raw CSV content (multiline string) and verify it is still parsed correctly
- [ ] Pass a plain path without commas and verify no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)