### PR TITLE
ux: session badge shows TV/mode; watcher diagnostics collapsed by default

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -111,7 +111,7 @@ export default function App() {
         <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
           {session?.id && (
             <>
-              <div className="session-badge">{session.id}</div>
+              <div className="session-badge" title={`Session ${session.id}`}>{session.tv} — {session.mode}</div>
               <button
                 onClick={handleStartOver}
                 style={{ fontSize: '0.72rem', padding: '3px 10px', background: 'transparent', border: '1px solid var(--border)', borderRadius: 4, color: 'var(--muted)', cursor: 'pointer' }}

--- a/frontend/src/components/WatchFolder.jsx
+++ b/frontend/src/components/WatchFolder.jsx
@@ -3,11 +3,17 @@ import { fmtDateTime, measurementTimeSummary } from '../utils/fmt';
 
 export function WatchFolder({ watchStatus, onStart, onStop, defaultPath }) {
   const [path, setPath] = useState(defaultPath || '');
+  const [diagOpen, setDiagOpen] = useState(false);
 
   // Sync input to defaultPath once it resolves from localStorage (only when not watching)
   useEffect(() => {
     if (defaultPath && !watchStatus.watching) setPath(defaultPath);
   }, [defaultPath, watchStatus.watching]);
+
+  // Auto-expand diagnostics when there's an error
+  useEffect(() => {
+    if (watchStatus.error) setDiagOpen(true);
+  }, [watchStatus.error]);
   const ws = watchStatus;
 
   const dotCls = ws.watching ? 'dot-active' : ws.error ? 'dot-error' : 'dot-inactive';
@@ -58,18 +64,26 @@ export function WatchFolder({ watchStatus, onStart, onStop, defaultPath }) {
         </div>
       )}
       <div className="mt-3">
-        <div className="text-sm muted" style={{ marginBottom: 6 }}>Watcher diagnostics</div>
-        <table className="data-table">
-          <tbody>
-            {diagRows.map(([label, value]) => (
-              <tr key={label}><td>{label}</td><td>{value}</td></tr>
-            ))}
-            {diagnostics.last_attempt?.detail && (
-              <tr><td>Attempt detail</td><td>{diagnostics.last_attempt.detail}</td></tr>
-            )}
-            {ws.error && <tr><td>Current error</td><td>{ws.error}</td></tr>}
-          </tbody>
-        </table>
+        <button
+          className="text-sm muted"
+          onClick={() => setDiagOpen(o => !o)}
+          style={{ background: 'none', border: 'none', padding: 0, cursor: 'pointer', color: 'var(--muted)', fontFamily: 'inherit' }}
+        >
+          {diagOpen ? '▾' : '▸'} Watcher diagnostics
+        </button>
+        {diagOpen && (
+          <table className="data-table" style={{ marginTop: 6 }}>
+            <tbody>
+              {diagRows.map(([label, value]) => (
+                <tr key={label}><td>{label}</td><td>{value}</td></tr>
+              ))}
+              {diagnostics.last_attempt?.detail && (
+                <tr><td>Attempt detail</td><td>{diagnostics.last_attempt.detail}</td></tr>
+              )}
+              {ws.error && <tr><td>Current error</td><td>{ws.error}</td></tr>}
+            </tbody>
+          </table>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -161,6 +161,7 @@ body {
   font-size: 0.72rem; color: var(--muted);
   background: var(--surface2); border: 1px solid var(--border);
   border-radius: 4px; padding: 3px 10px; font-family: monospace;
+  max-width: 220px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
 
 /* ── ΔE pills ────────────────────────────────────────────────────────────────── */


### PR DESCRIPTION
## Summary

- **Session badge** now shows `{TV model} — {mode}` (e.g. `Sony U8G — HDR10`) instead of the raw session ID. The ID is preserved in the `title` attribute for debugging. Added `max-width` + ellipsis to handle long TV names. (closes #37)
- **Watcher diagnostics** table is collapsed by default behind a `▸ Watcher diagnostics` toggle. Auto-expands when an error is present so issues surface without a manual click. (closes #39)

## Test plan

- [ ] Start a calibration session and confirm the header badge shows TV model and mode
- [ ] Hover the badge and confirm the tooltip shows the raw session ID
- [ ] On a measurement step, confirm the watcher diagnostics are collapsed on load
- [ ] Click `▸ Watcher diagnostics` to expand, `▾` to collapse
- [ ] Simulate a watch error (bad path) and confirm diagnostics auto-expand

🤖 Generated with [Claude Code](https://claude.com/claude-code)