### PR TITLE
ux: four small UX improvements (modal, sortable table, quality gate animation, badge scroll)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(command -v gh)",
+      "Read(//c/Users/jwebe/AppData/Local/**)",
+      "Read(//c/Program Files/GitHub CLI/**)"
+    ]
+  }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useSession } from './hooks/useSession';
 import { Setup }         from './pages/Setup';
 import { SelectMode }    from './pages/SelectMode';
@@ -9,6 +10,7 @@ import { Gamma }         from './pages/Gamma';
 import { ColorTuner }    from './pages/ColorTuner';
 import { PostGrayscale } from './pages/PostGrayscale';
 import { Report }        from './pages/Report';
+import { ConfirmModal }  from './components/ConfirmModal';
 
 function QualityDot({ gate }) {
   if (!gate) return null;
@@ -42,12 +44,27 @@ function ProgressBar({ session }) {
   );
 }
 
+function scrollToCard(id) {
+  const el = document.getElementById(id);
+  if (!el) return;
+  el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  el.classList.remove('card-pulse');
+  void el.offsetWidth;
+  el.classList.add('card-pulse');
+  setTimeout(() => el.classList.remove('card-pulse'), 900);
+}
+
 export default function App() {
   const sess = useSession();
   const { session, profiles, watchStatus, watchDefaultPath, bridgeStatus, bridgeUrl, dogegenStatus, adbStatus, loading } = sess;
+  const [showStartOver, setShowStartOver] = useState(false);
 
   function handleStartOver() {
-    if (!confirm('Start over? This will discard all measurements for this session.')) return;
+    setShowStartOver(true);
+  }
+
+  function handleConfirmStartOver() {
+    setShowStartOver(false);
     sess.deleteSession();
   }
 
@@ -99,6 +116,15 @@ export default function App() {
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
+      {showStartOver && (
+        <ConfirmModal
+          title="Discard this calibration session?"
+          body={`${session?.tv} — ${session?.mode}\nAll measurements will be permanently deleted.`}
+          confirmLabel="Discard session"
+          onConfirm={handleConfirmStartOver}
+          onCancel={() => setShowStartOver(false)}
+        />
+      )}
       {/* Header */}
       <header className="header">
         <div style={{ display: 'flex', alignItems: 'center', gap: 14 }}>
@@ -121,19 +147,19 @@ export default function App() {
             </>
           )}
           {watchStatus.watching && (
-            <div className="badge badge-watch">● WATCHING</div>
+            <button className="badge badge-watch" onClick={() => scrollToCard('watch-folder')} style={{ cursor: 'pointer', border: 'none', background: 'none', padding: 0 }}>● WATCHING</button>
           )}
           {(bridgeOk || bridgeConfigured) && (
-            <div style={{ display: 'flex', alignItems: 'center', gap: 5, fontSize: '0.72rem', color: bridgeOk ? 'var(--green)' : 'var(--red)', cursor: 'default' }}>
+            <button onClick={() => scrollToCard('bridge-card')} style={{ display: 'flex', alignItems: 'center', gap: 5, fontSize: '0.72rem', color: bridgeOk ? 'var(--green)' : 'var(--red)', cursor: 'pointer', background: 'none', border: 'none', padding: 0, fontFamily: 'inherit' }}>
               <span style={{ width: 8, height: 8, borderRadius: '50%', background: bridgeOk ? 'var(--green)' : 'var(--muted)', flexShrink: 0 }} />
               Bridge
-            </div>
+            </button>
           )}
           {(dogegenRunning || dogegenConfigured) && (
-            <div style={{ display: 'flex', alignItems: 'center', gap: 5, fontSize: '0.72rem', color: dogegenRunning ? 'var(--green)' : 'var(--red)', cursor: 'default' }}>
+            <button onClick={() => scrollToCard('dogegen-card')} style={{ display: 'flex', alignItems: 'center', gap: 5, fontSize: '0.72rem', color: dogegenRunning ? 'var(--green)' : 'var(--red)', cursor: 'pointer', background: 'none', border: 'none', padding: 0, fontFamily: 'inherit' }}>
               <span style={{ width: 8, height: 8, borderRadius: '50%', background: dogegenRunning ? 'var(--green)' : 'var(--muted)', flexShrink: 0 }} />
               Dogegen
-            </div>
+            </button>
           )}
         </div>
       </header>

--- a/frontend/src/components/Card.jsx
+++ b/frontend/src/components/Card.jsx
@@ -1,6 +1,6 @@
-export function Card({ title, children, className = '', style }) {
+export function Card({ title, children, className = '', style, id }) {
   return (
-    <div className={`card ${className}`} style={style}>
+    <div id={id} className={`card ${className}`} style={style}>
       {title && <div className="card-title">{title}</div>}
       {children}
     </div>

--- a/frontend/src/components/ConfirmModal.jsx
+++ b/frontend/src/components/ConfirmModal.jsx
@@ -1,0 +1,14 @@
+export function ConfirmModal({ title, body, confirmLabel = 'Confirm', onConfirm, onCancel }) {
+  return (
+    <div className="modal-backdrop" onClick={onCancel}>
+      <div className="modal" onClick={e => e.stopPropagation()}>
+        <div className="modal-title">{title}</div>
+        {body && <div className="modal-body">{body}</div>}
+        <div className="modal-actions">
+          <button className="btn" onClick={onCancel}>Cancel</button>
+          <button className="btn btn-danger" onClick={onConfirm}>{confirmLabel}</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/MeasurementTable.jsx
+++ b/frontend/src/components/MeasurementTable.jsx
@@ -1,6 +1,27 @@
+import { useState } from 'react';
 import { fmtDe, fmtDateTime } from '../utils/fmt';
 
+const COLUMNS = [
+  { header: 'Label',   key: 'label' },
+  { header: 'Measured', key: 'timestamp' },
+  { header: 'Nits',    key: 'Y' },
+  { header: 'x',       key: 'x' },
+  { header: 'y',       key: 'y' },
+  { header: 'CCT',     key: 'cct' },
+  { header: 'ΔE',      key: 'delta_e' },
+];
+const GAMMA_COL = { header: 'γ', key: 'effective_gamma' };
+
+function getValue(m, key) {
+  if (key === 'label')     return m.label || '';
+  if (key === 'timestamp') return m.timestamp || '';
+  return m[key] ?? null;
+}
+
 export function MeasurementTable({ measurements, includeGamma }) {
+  const [sortCol, setSortCol] = useState(null);
+  const [sortDir, setSortDir] = useState('asc');
+
   if (!measurements?.length) {
     return (
       <div className="muted text-sm" style={{ padding: '12px 0' }}>
@@ -9,9 +30,28 @@ export function MeasurementTable({ measurements, includeGamma }) {
     );
   }
 
-  const headers = ['Label', 'Measured', 'Nits', 'x', 'y', 'CCT', 'ΔE'];
-  if (includeGamma) headers.push('γ');
+  const columns = includeGamma ? [...COLUMNS, GAMMA_COL] : COLUMNS;
+
+  function handleSort(key) {
+    if (sortCol === key) {
+      setSortDir(d => d === 'asc' ? 'desc' : 'asc');
+    } else {
+      setSortCol(key);
+      setSortDir('asc');
+    }
+  }
+
   const rows = [...measurements].sort((a, b) => {
+    if (sortCol) {
+      const av = getValue(a, sortCol);
+      const bv = getValue(b, sortCol);
+      if (av == null && bv == null) return 0;
+      if (av == null) return 1;
+      if (bv == null) return -1;
+      const cmp = typeof av === 'string' ? av.localeCompare(bv) : av - bv;
+      return sortDir === 'asc' ? cmp : -cmp;
+    }
+    // default: sort by stimulus %
     const ap = a.stimulus_pct;
     const bp = b.stimulus_pct;
     if (ap == null && bp == null) return String(a.timestamp || '').localeCompare(String(b.timestamp || ''));
@@ -23,7 +63,19 @@ export function MeasurementTable({ measurements, includeGamma }) {
   return (
     <table className="data-table">
       <thead>
-        <tr>{headers.map(h => <th key={h}>{h}</th>)}</tr>
+        <tr>
+          {columns.map(({ header, key }) => (
+            <th
+              key={key}
+              onClick={() => handleSort(key)}
+              style={{ cursor: 'pointer', userSelect: 'none', whiteSpace: 'nowrap' }}
+              title={`Sort by ${header}`}
+            >
+              {header}
+              {sortCol === key ? (sortDir === 'asc' ? ' ▲' : ' ▼') : ''}
+            </th>
+          ))}
+        </tr>
       </thead>
       <tbody>
         {rows.map((m, i) => (

--- a/frontend/src/components/QualityGate.jsx
+++ b/frontend/src/components/QualityGate.jsx
@@ -1,3 +1,5 @@
+import { useEffect, useRef, useState } from 'react';
+
 /**
  * QualityGate — inline quality gate status banner for a calibration step.
  *
@@ -6,6 +8,20 @@
  *   label — override display label (defaults to gate.label)
  */
 export function QualityGate({ gate, label }) {
+  const hasAnimated = useRef(false);
+  const [animClass, setAnimClass] = useState('');
+
+  useEffect(() => {
+    if (gate?.passed && !hasAnimated.current) {
+      hasAnimated.current = true;
+      setAnimClass('qg-enter');
+    }
+    if (!gate?.passed) {
+      hasAnimated.current = false;
+      setAnimClass('');
+    }
+  }, [gate?.passed]);
+
   if (!gate) return null;
 
   const passed = gate.passed;
@@ -14,15 +30,19 @@ export function QualityGate({ gate, label }) {
   const text   = label || gate.label;
 
   return (
-    <div style={{
-      display: 'flex', alignItems: 'center', gap: 10,
-      padding: '8px 12px',
-      background: passed ? 'rgba(0,200,100,0.08)' : 'rgba(220,50,50,0.08)',
-      border: `1px solid ${color}`,
-      borderRadius: 6,
-      marginBottom: 12,
-    }}>
-      <span style={{ color, fontWeight: 700, fontSize: '1rem', flexShrink: 0 }}>{icon}</span>
+    <div
+      className={animClass}
+      style={{
+        display: 'flex', alignItems: 'center', gap: 10,
+        padding: passed ? '10px 14px' : '8px 12px',
+        background: passed ? 'rgba(34,201,135,0.1)' : 'rgba(220,50,50,0.08)',
+        border: `1px solid ${color}`,
+        borderLeft: passed ? `3px solid ${color}` : `1px solid ${color}`,
+        borderRadius: 6,
+        marginBottom: 12,
+      }}
+    >
+      <span style={{ color, fontWeight: 700, fontSize: passed ? '1.1rem' : '1rem', flexShrink: 0 }}>{icon}</span>
       <span className="text-sm">
         <strong>{text}</strong>
         {' — '}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -333,3 +333,31 @@ select:focus { outline: none; border-color: var(--accent); }
 }
 @keyframes spin { to { transform: rotate(360deg); } }
 hr.divider { border: none; border-top: 1px solid var(--border); margin: 16px 0; }
+
+/* ── ConfirmModal (#36) ──────────────────────────────────────────────────────── */
+.modal-backdrop {
+  position: fixed; inset: 0; background: rgba(0,0,0,0.65);
+  display: flex; align-items: center; justify-content: center; z-index: 1000;
+}
+.modal {
+  background: var(--surface2); border: 1px solid var(--border2);
+  border-radius: var(--radius-lg); padding: 24px; max-width: 420px; width: 90%;
+}
+.modal-title { font-size: 1rem; font-weight: 700; margin-bottom: 10px; }
+.modal-body  { font-size: 0.85rem; color: var(--muted); margin-bottom: 20px; line-height: 1.6; }
+.modal-actions { display: flex; justify-content: flex-end; gap: 10px; }
+
+/* ── QualityGate pass animation (#40) ───────────────────────────────────────── */
+@keyframes qgSlideIn {
+  from { opacity: 0; transform: translateY(-6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+.qg-enter { animation: qgSlideIn 0.35s ease-out; }
+
+/* ── Card highlight pulse (#42) ─────────────────────────────────────────────── */
+@keyframes cardPulse {
+  0%   { box-shadow: 0 0 0 0   rgba(0,180,216,0.55); }
+  70%  { box-shadow: 0 0 0 8px rgba(0,180,216,0);    }
+  100% { box-shadow: 0 0 0 0   rgba(0,180,216,0);    }
+}
+.card-pulse { animation: cardPulse 0.85s ease-out; }

--- a/frontend/src/pages/ColorTuner.jsx
+++ b/frontend/src/pages/ColorTuner.jsx
@@ -132,12 +132,12 @@ export function ColorTuner({ session, watchStatus, watchDefaultPath, bridgeStatu
         </div>
       </Card>
 
-      <Card title="ZRO Bridge">
+      <Card title="ZRO Bridge" id="bridge-card">
         <BridgeCard bridgeStatus={bridgeStatus} bridgeUrl={bridgeUrl} session={session} dogegenStatus={dogegenStatus} onSaveUrl={onSaveBridgeUrl} onMeasure={onMeasure} />
       </Card>
 
       <div className="two-col">
-        <Card title="Auto-Watch Path">
+        <Card title="Auto-Watch Path" id="watch-folder">
           <WatchFolder watchStatus={watchStatus} defaultPath={watchStatus.path || watchDefaultPath} onStart={onStartWatch} onStop={onStopWatch} />
         </Card>
         <Card title="Import ZRO CSV">

--- a/frontend/src/pages/Gamma.jsx
+++ b/frontend/src/pages/Gamma.jsx
@@ -59,12 +59,12 @@ export function Gamma({ session, watchStatus, watchDefaultPath, bridgeStatus, br
         </Card>
       )}
 
-      <Card title="ZRO Bridge">
+      <Card title="ZRO Bridge" id="bridge-card">
         <BridgeCard bridgeStatus={bridgeStatus} bridgeUrl={bridgeUrl} session={session} dogegenStatus={dogegenStatus} onSaveUrl={onSaveBridgeUrl} onMeasure={onMeasure} />
       </Card>
 
       <div className="two-col">
-        <Card title="Auto-Watch Path">
+        <Card title="Auto-Watch Path" id="watch-folder">
           <WatchFolder watchStatus={watchStatus} defaultPath={watchStatus.path || watchDefaultPath} onStart={onStartWatch} onStop={onStopWatch} />
         </Card>
         <Card title="Import ZRO CSV">

--- a/frontend/src/pages/Luminance.jsx
+++ b/frontend/src/pages/Luminance.jsx
@@ -132,12 +132,12 @@ export function Luminance({ session, watchStatus, watchDefaultPath, bridgeStatus
         />
       )}
 
-      <Card title="ZRO Bridge">
+      <Card title="ZRO Bridge" id="bridge-card">
         <BridgeCard bridgeStatus={bridgeStatus} bridgeUrl={bridgeUrl} session={session} dogegenStatus={dogegenStatus} onSaveUrl={onSaveBridgeUrl} onMeasure={onMeasure} />
       </Card>
 
       <div className="two-col">
-        <Card title="Auto-Watch Path">
+        <Card title="Auto-Watch Path" id="watch-folder">
           <WatchFolder watchStatus={watchStatus} defaultPath={watchStatus.path || watchDefaultPath} onStart={onStartWatch} onStop={onStopWatch} />
         </Card>
         <Card title="Import ZRO CSV">

--- a/frontend/src/pages/PostGrayscale.jsx
+++ b/frontend/src/pages/PostGrayscale.jsx
@@ -20,11 +20,11 @@ export function PostGrayscale({ session, watchStatus, watchDefaultPath, bridgeSt
       <ZroInstructions instructions={session.zro_instructions} />
       <QualityGate gate={(session.quality_gates || {}).post_grayscale} />
 
-      <Card title="ZRO Bridge">
+      <Card title="ZRO Bridge" id="bridge-card">
         <BridgeCard bridgeStatus={bridgeStatus} bridgeUrl={bridgeUrl} session={session} dogegenStatus={dogegenStatus} onSaveUrl={onSaveBridgeUrl} onMeasure={onMeasure} />
       </Card>
 
-      <Card title="Auto-Watch Path">
+      <Card title="Auto-Watch Path" id="watch-folder">
         <WatchFolder watchStatus={watchStatus} defaultPath={watchStatus.path || watchDefaultPath} onStart={onStartWatch} onStop={onStopWatch} />
       </Card>
 

--- a/frontend/src/pages/PreGrayscale.jsx
+++ b/frontend/src/pages/PreGrayscale.jsx
@@ -20,7 +20,7 @@ export function PreGrayscale({ session, watchStatus, watchDefaultPath, bridgeSta
     <>
       <ZroInstructions instructions={session.zro_instructions} />
 
-      <Card title="ZRO Bridge">
+      <Card title="ZRO Bridge" id="bridge-card">
         <BridgeCard
           bridgeStatus={bridgeStatus} bridgeUrl={bridgeUrl}
           session={session} dogegenStatus={dogegenStatus}
@@ -29,7 +29,7 @@ export function PreGrayscale({ session, watchStatus, watchDefaultPath, bridgeSta
       </Card>
 
       {session.pattern_generator === 'dogegen' && (
-        <Card title="Dogegen Companion">
+        <Card title="Dogegen Companion" id="dogegen-card">
           <DogegenCard
             dogegenStatus={dogegenStatus}
             session={session}
@@ -40,7 +40,7 @@ export function PreGrayscale({ session, watchStatus, watchDefaultPath, bridgeSta
         </Card>
       )}
 
-      <Card title="Auto-Watch Path">
+      <Card title="Auto-Watch Path" id="watch-folder">
         <WatchFolder
           watchStatus={watchStatus} defaultPath={watchStatus.path || watchDefaultPath}
           onStart={onStartWatch} onStop={onStopWatch}

--- a/frontend/src/pages/Prepare.jsx
+++ b/frontend/src/pages/Prepare.jsx
@@ -219,7 +219,7 @@ export function Prepare({ session, dogegenStatus, onConfirmPrepared, onPrev, onS
               grayscale ramp for pre/post checks.
             </div>
           </Card>
-          <Card title="Dogegen Companion">
+          <Card title="Dogegen Companion" id="dogegen-card">
             <DogegenCard
               dogegenStatus={dogegenStatus}
               session={session}

--- a/frontend/src/pages/WhiteBalance.jsx
+++ b/frontend/src/pages/WhiteBalance.jsx
@@ -72,12 +72,12 @@ export function WhiteBalance({ session, watchStatus, watchDefaultPath, bridgeSta
         </Card>
       )}
 
-      <Card title="ZRO Bridge">
+      <Card title="ZRO Bridge" id="bridge-card">
         <BridgeCard bridgeStatus={bridgeStatus} bridgeUrl={bridgeUrl} session={session} dogegenStatus={dogegenStatus} onSaveUrl={onSaveBridgeUrl} onMeasure={onMeasure} />
       </Card>
 
       <div className="two-col">
-        <Card title="Auto-Watch Path">
+        <Card title="Auto-Watch Path" id="watch-folder">
           <WatchFolder watchStatus={watchStatus} defaultPath={watchStatus.path || watchDefaultPath} onStart={onStartWatch} onStop={onStopWatch} />
         </Card>
         <Card title="Import ZRO CSV">


### PR DESCRIPTION
## Summary

Four independent small UX improvements filed as issues after a UX review:

- **#36 — Start Over modal**: Replaces `window.confirm()` with a `ConfirmModal` component that shows the TV model and mode being discarded, preventing accidental session deletion.
- **#38 — Sortable MeasurementTable**: All column headers are now clickable to sort (ascending/descending). Active sort column shows ▲/▼. Default sort remains by stimulus %. Useful for quickly finding worst ΔE patches.
- **#40 — QualityGate pass animation**: When a gate transitions to passed for the first time, the banner slides in, gains a thicker left accent bar, and a slightly larger checkmark — making the passing event feel like a positive moment rather than a static text update.
- **#42 — Header badge scroll-to-section**: Clicking the Bridge, Dogegen, or Watch badge in the header now smooth-scrolls to and pulse-highlights the corresponding card. Added `id` prop to `Card` component; IDs wired to all 7 measurement-step pages.

## Test plan

- [ ] Click **Start Over** — confirm modal appears with TV/mode, Cancel works, Discard deletes session
- [ ] On any step with measurements, click a column header — rows re-sort, ▲/▼ indicator appears; click again to reverse
- [ ] Import enough measurements to pass a quality gate — confirm the banner slides in smoothly
- [ ] Configure Bridge URL, then click the **Bridge** badge in the header — page scrolls to ZRO Bridge card with cyan pulse
- [ ] Same for Dogegen and Watch badges

🤖 Generated with [Claude Code](https://claude.com/claude-code)