### PR TITLE
ux: clickable progress steps, inline tooltips, collapsible Prepare sections (#35, #41, #44)

### DIFF
--- a/calibrator/session.py
+++ b/calibrator/session.py
@@ -1291,6 +1291,17 @@ class SessionStore:
         self.save_session(sid)
         return session
 
+    def jump_to_step(self, sid: str, target_index: int) -> Dict[str, Any]:
+        session = self.get(sid)
+        current_index = STEPS_ORDER.index(session["step"]) if session["step"] in STEPS_ORDER else 0
+        if target_index >= current_index:
+            raise HTTPException(400, "Can only jump to a completed step")
+        if target_index < 0 or target_index >= len(STEPS_ORDER):
+            raise HTTPException(400, "Invalid step index")
+        session["step"] = STEPS_ORDER[target_index]
+        self.save_session(sid)
+        return session
+
     def prev_step(self, sid: str) -> Dict[str, Any]:
         session = self.get(sid)
         transitions = {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -24,19 +24,25 @@ function QualityDot({ gate }) {
   );
 }
 
-function ProgressBar({ session }) {
+function ProgressBar({ session, onJump }) {
   if (!session?.steps) return null;
   const gates = session.quality_gates || {};
   return (
     <div className="progress-bar">
       {session.steps.map((step, i) => {
-        const cls = i < session.step_index ? 'done' : i === session.step_index ? 'active' : '';
-        const icon = i < session.step_index ? '✓' : i + 1;
+        const done = i < session.step_index;
+        const cls = done ? 'done' : i === session.step_index ? 'active' : '';
+        const icon = done ? '✓' : i + 1;
         return (
-          <div className={`step-tab ${cls}`} key={step.id || i}>
+          <div
+            className={`step-tab ${cls}${done ? ' step-tab-clickable' : ''}`}
+            key={step.id || i}
+            onClick={done ? () => onJump(i) : undefined}
+            title={done ? `Go back to ${step.label}` : undefined}
+          >
             <span className="step-num">{icon}</span>
             {step.label}
-            {i < session.step_index && <QualityDot gate={gates[step.id]} />}
+            {done && <QualityDot gate={gates[step.id]} />}
           </div>
         );
       })}
@@ -165,7 +171,7 @@ export default function App() {
       </header>
 
       {/* Step progress bar */}
-      <ProgressBar session={session} />
+      <ProgressBar session={session} onJump={sess.jumpToStep} />
 
       {/* Main content */}
       <main className="main">

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -31,6 +31,7 @@ export const api = {
     api.post('/api/session', { tv, mode, sdr_peak_nits: sdrPeakNits }),
   nextStep:      (sid)        => api.post(`/api/session/${sid}/next`),
   prevStep:      (sid)        => api.post(`/api/session/${sid}/prev`),
+  jumpToStep:    (sid, step_index) => api.post(`/api/session/${sid}/jump`, { step_index }),
   confirmMode:   (sid, mode, sdrPeakNits) =>
     api.post(`/api/session/${sid}/mode`, { mode, sdr_peak_nits: sdrPeakNits }),
   confirmPrepared: (sid)      => api.post(`/api/session/${sid}/prepared`),

--- a/frontend/src/components/Card.jsx
+++ b/frontend/src/components/Card.jsx
@@ -1,3 +1,5 @@
+import { Tooltip } from './Tooltip';
+
 export function Card({ title, children, className = '', style, id }) {
   return (
     <div id={id} className={`card ${className}`} style={style}>
@@ -7,11 +9,11 @@ export function Card({ title, children, className = '', style, id }) {
   );
 }
 
-export function StatCard({ value, label, color = '' }) {
+export function StatCard({ value, label, color = '', tooltip }) {
   return (
     <div className={`stat-card ${color ? color + '-top' : ''}`}>
       <div className="stat-value">{value}</div>
-      <div className="stat-label">{label}</div>
+      <div className="stat-label">{label}{tooltip && <Tooltip text={tooltip} />}</div>
     </div>
   );
 }

--- a/frontend/src/components/CollapsibleSection.jsx
+++ b/frontend/src/components/CollapsibleSection.jsx
@@ -1,0 +1,30 @@
+import { useState, useEffect } from 'react';
+
+export function CollapsibleSection({ title, storageKey, defaultOpen = false, summary, children }) {
+  const [open, setOpen] = useState(() => {
+    if (storageKey) {
+      const saved = localStorage.getItem(`section:${storageKey}`);
+      if (saved !== null) return saved === 'true';
+    }
+    return defaultOpen;
+  });
+
+  useEffect(() => {
+    if (storageKey) localStorage.setItem(`section:${storageKey}`, open);
+  }, [open, storageKey]);
+
+  return (
+    <div className="collapsible-section">
+      <button
+        className={`collapsible-header${open ? ' open' : ''}`}
+        onClick={() => setOpen(o => !o)}
+        aria-expanded={open}
+      >
+        <span className="collapsible-chevron">{open ? '▾' : '▸'}</span>
+        <span className="collapsible-title">{title}</span>
+        {!open && summary && <span className="collapsible-summary">{summary}</span>}
+      </button>
+      {open && <div className="collapsible-body">{children}</div>}
+    </div>
+  );
+}

--- a/frontend/src/components/MeasurementTable.jsx
+++ b/frontend/src/components/MeasurementTable.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { fmtDe, fmtDateTime } from '../utils/fmt';
+import { Tooltip } from './Tooltip';
 
 const COLUMNS = [
   { header: 'Label',   key: 'label' },
@@ -7,10 +8,10 @@ const COLUMNS = [
   { header: 'Nits',    key: 'Y' },
   { header: 'x',       key: 'x' },
   { header: 'y',       key: 'y' },
-  { header: 'CCT',     key: 'cct' },
-  { header: 'ΔE',      key: 'delta_e' },
+  { header: 'CCT',     key: 'cct',     tooltip: 'Correlated Color Temperature in Kelvin. D65 (the standard white point) is 6504 K.' },
+  { header: 'ΔE',      key: 'delta_e', tooltip: 'Delta E — perceptual color difference. ΔE < 2 is invisible to most viewers; < 1 is excellent.' },
 ];
-const GAMMA_COL = { header: 'γ', key: 'effective_gamma' };
+const GAMMA_COL = { header: 'γ', key: 'effective_gamma', tooltip: 'Effective gamma — the measured power-law exponent at each stimulus step. BT.1886 targets ≈ 2.40.' };
 
 function getValue(m, key) {
   if (key === 'label')     return m.label || '';
@@ -64,7 +65,7 @@ export function MeasurementTable({ measurements, includeGamma }) {
     <table className="data-table">
       <thead>
         <tr>
-          {columns.map(({ header, key }) => (
+          {columns.map(({ header, key, tooltip }) => (
             <th
               key={key}
               onClick={() => handleSort(key)}
@@ -72,6 +73,7 @@ export function MeasurementTable({ measurements, includeGamma }) {
               title={`Sort by ${header}`}
             >
               {header}
+              {tooltip && <Tooltip text={tooltip} />}
               {sortCol === key ? (sortDir === 'asc' ? ' ▲' : ' ▼') : ''}
             </th>
           ))}

--- a/frontend/src/components/Tooltip.jsx
+++ b/frontend/src/components/Tooltip.jsx
@@ -1,0 +1,27 @@
+import { useState } from 'react';
+
+export function Tooltip({ text }) {
+  const [visible, setVisible] = useState(false);
+
+  return (
+    <span className="tooltip-wrap">
+      <span
+        className="tooltip-trigger"
+        tabIndex={0}
+        role="button"
+        aria-label="More information"
+        onMouseEnter={() => setVisible(true)}
+        onMouseLeave={() => setVisible(false)}
+        onFocus={() => setVisible(true)}
+        onBlur={() => setVisible(false)}
+      >
+        ⓘ
+      </span>
+      {visible && (
+        <span className="tooltip-popover" role="tooltip">
+          {text}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/frontend/src/hooks/useSession.js
+++ b/frontend/src/hooks/useSession.js
@@ -128,6 +128,11 @@ export function useSession() {
     setSession(await api.prevStep(session.id));
   }
 
+  async function jumpToStep(stepIndex) {
+    if (!session?.id) return;
+    setSession(await api.jumpToStep(session.id, stepIndex));
+  }
+
   async function confirmMode(mode, sdrPeakNits) {
     if (!session?.id) return;
     setSession(await api.confirmMode(session.id, mode, sdrPeakNits));
@@ -278,7 +283,7 @@ export function useSession() {
 
   return {
     session, profiles, watchStatus, watchDefaultPath, bridgeUrl, bridgeStatus, dogegenStatus, adbStatus, loading,
-    createSession, deleteSession, nextStep, prevStep, confirmMode, confirmPrepared, setGammaWorkflow, setSignalRange, setGrayscaleRamp, setCodeScale, setPatternGenerator, setLightspaceTier,
+    createSession, deleteSession, nextStep, prevStep, jumpToStep, confirmMode, confirmPrepared, setGammaWorkflow, setSignalRange, setGrayscaleRamp, setCodeScale, setPatternGenerator, setLightspaceTier,
     uploadCsv, startWatch, stopWatch,
     saveBridgeUrl, triggerMeasure, refreshBridgeStatus,
     saveDogegenConfig, startDogegen, stopDogegen, refreshDogegenStatus,

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -77,6 +77,8 @@ body {
 }
 .step-tab.done  { color: var(--green); }
 .step-tab.active { color: var(--accent); border-bottom-color: var(--accent); font-weight: 600; }
+.step-tab-clickable { cursor: pointer; }
+.step-tab-clickable:hover { color: var(--accent); background: var(--accent-dim); }
 .step-num {
   width: 17px; height: 17px;
   border-radius: 3px;
@@ -353,6 +355,79 @@ hr.divider { border: none; border-top: 1px solid var(--border); margin: 16px 0; 
   to   { opacity: 1; transform: translateY(0); }
 }
 .qg-enter { animation: qgSlideIn 0.35s ease-out; }
+
+/* ── CollapsibleSection (#44) ───────────────────────────────────────────────── */
+.collapsible-section { margin-bottom: 6px; }
+.collapsible-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 9px 14px;
+  cursor: pointer;
+  text-align: left;
+  color: var(--text);
+  font-family: inherit;
+  font-size: 0.82rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  transition: background 0.15s;
+}
+.collapsible-header:hover { background: var(--surface2); }
+.collapsible-header.open { border-radius: var(--radius) var(--radius) 0 0; border-bottom-color: transparent; }
+.collapsible-chevron { font-size: 0.75rem; color: var(--muted); flex-shrink: 0; width: 12px; }
+.collapsible-title { flex: 1; }
+.collapsible-summary { font-size: 0.74rem; font-weight: 400; color: var(--muted); margin-left: 4px; }
+.collapsible-body {
+  border: 1px solid var(--border);
+  border-top: none;
+  border-radius: 0 0 var(--radius) var(--radius);
+  padding: 14px 14px 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin-bottom: 0;
+}
+.collapsible-body > * { margin-bottom: 0 !important; }
+
+/* ── Tooltip (#41) ──────────────────────────────────────────────────────────── */
+.tooltip-wrap {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  margin-left: 4px;
+}
+.tooltip-trigger {
+  font-size: 0.72rem;
+  color: var(--muted);
+  cursor: default;
+  line-height: 1;
+  user-select: none;
+}
+.tooltip-trigger:focus { outline: 1px dotted var(--muted); outline-offset: 2px; }
+.tooltip-popover {
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--surface3);
+  border: 1px solid var(--border2);
+  border-radius: var(--radius);
+  color: var(--text);
+  font-size: 0.75rem;
+  font-weight: 400;
+  line-height: 1.5;
+  max-width: 260px;
+  min-width: 160px;
+  padding: 7px 10px;
+  pointer-events: none;
+  white-space: normal;
+  z-index: 200;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.4);
+}
 
 /* ── Card highlight pulse (#42) ─────────────────────────────────────────────── */
 @keyframes cardPulse {

--- a/frontend/src/pages/Prepare.jsx
+++ b/frontend/src/pages/Prepare.jsx
@@ -2,6 +2,8 @@ import { useEffect, useState } from 'react';
 import { Card } from '../components/Card';
 import { Button } from '../components/Button';
 import { DogegenCard } from '../components/DogegenCard';
+import { Tooltip } from '../components/Tooltip';
+import { CollapsibleSection } from '../components/CollapsibleSection';
 
 export function Prepare({ session, dogegenStatus, onConfirmPrepared, onPrev, onSetLightspaceTier, onSetGrayscaleRamp, onSetSignalRange, onSetCodeScale, onSetPatternGenerator, onSaveDogegenConfig, onStartDogegen, onStopDogegen, onConfigureLlm, onGetLlmStatus }) {
   const pd = session.prepare_data || {};
@@ -125,312 +127,337 @@ export function Prepare({ session, dogegenStatus, onConfirmPrepared, onPrev, onS
     }
   }
 
+  const measurementSummary = [
+    `${selectedSteps}-step`,
+    selectedSignalRange === 'full' ? 'Full Range' : 'Limited Range',
+    selectedCodeScale === '8bit' ? '8-bit' : selectedCodeScale === '10bit' ? '10-bit' : selectedCodeScale,
+  ].join(' · ');
+
+  const hasChecklistContent = (pd.zro_setup_steps || []).length > 0
+    || pd.service_menu_access
+    || pd.picture_mode
+    || (pd.reset_settings || []).length > 0
+    || (pd.disable_settings || []).length > 0
+    || (pd.configure_settings || []).length > 0;
+
   return (
     <>
-      <Card title="Pattern Generator">
-        <div className="text-sm muted" style={{ marginBottom: 12 }}>
-          Pick the patch generator that is feeding the calibrated HDMI path into the TV.
-          The setup checklist and measurement guidance below will adapt to this choice.
-        </div>
-        <div className="mode-grid">
-          {generatorOptions.map(opt => (
-            <div
-              key={opt.key}
-              className={`mode-card ${selectedGenerator === opt.key ? 'selected' : ''}`}
-              onClick={() => handleGeneratorChange(opt.key)}
-              style={{ cursor: 'pointer' }}
-            >
-              <div className="mode-card-label">{opt.label}</div>
-              <div className="mode-card-desc">{opt.desc}</div>
-            </div>
-          ))}
-        </div>
-      </Card>
-
-      {selectedGenerator === 'lightspace_connect' && (
-        <Card title="LightSpace Connect">
+      {/* Section 1: Hardware — always expanded */}
+      <CollapsibleSection title="Hardware" storageKey="prepare-hardware" defaultOpen>
+        <Card title="Pattern Generator">
           <div className="text-sm muted" style={{ marginBottom: 12 }}>
-            Select your LightSpace Connect tier to configure the grayscale ramp density.
-            A denser ramp gives the guidance engine more data points for better gamma
-            curve fitting and ABL detection.
+            Pick the patch generator that is feeding the calibrated HDMI path into the TV.
+            The setup checklist and measurement guidance below will adapt to this choice.
           </div>
-          <div className="mode-grid" style={{ marginBottom: 12 }}>
-            {['free', 'paid'].map(tier => (
+          <div className="mode-grid">
+            {generatorOptions.map(opt => (
               <div
-                key={tier}
-                className={`mode-card ${selectedTier === tier ? 'selected' : ''}`}
-                onClick={() => handleTierChange(tier)}
+                key={opt.key}
+                className={`mode-card ${selectedGenerator === opt.key ? 'selected' : ''}`}
+                onClick={() => handleGeneratorChange(opt.key)}
                 style={{ cursor: 'pointer' }}
               >
-                <div className="mode-card-label">
-                  {tier === 'free' ? 'Free' : 'Paid'}
-                </div>
-                <div className="mode-card-desc">
-                  {tier === 'free'
-                    ? '25-patch limit — supports 11- and 21-step ramps'
-                    : 'No patch limit — supports up to 51-step ramps'}
-                </div>
+                <div className="mode-card-label">{opt.label}</div>
+                <div className="mode-card-desc">{opt.desc}</div>
               </div>
             ))}
           </div>
-
         </Card>
-      )}
 
-      <Card title="Grayscale Ramp">
-        <div className="text-sm muted" style={{ marginBottom: 12 }}>
-          {selectedGenerator === 'dogegen'
-            ? 'Dogegen works well with a denser grayscale sweep. For HDR10 on the U8G, use the 21-step ramp so the pre/post grayscale pages show the full 0–100% pass in 5% steps.'
-            : 'Choose the grayscale ramp density that matches the LightSpace Connect tier you are using.'}
-        </div>
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-          {availableRamps.map(opt => (
-            <label
-              key={opt.steps}
-              style={{ display: 'flex', alignItems: 'flex-start', gap: 10, cursor: 'pointer' }}
-            >
-              <input
-                type="radio"
-                name="ramp"
-                value={opt.steps}
-                checked={selectedSteps === opt.steps}
-                onChange={() => handleRampChange(opt.steps)}
-                style={{ marginTop: 2, flexShrink: 0 }}
-              />
-              <span>
-                <span className="text-sm"><strong>{opt.label}</strong></span>
-                <span className="text-sm muted" style={{ display: 'block' }}>
-                  {selectedGenerator === 'dogegen' && opt.steps === 21
-                    ? 'Recommended for Dogegen HDR workflows on the U8G.'
-                    : opt.summary}
-                </span>
-              </span>
-            </label>
-          ))}
-        </div>
-      </Card>
-
-      {selectedGenerator === 'dogegen' && (
-        <>
-          <Card title="Dogegen">
-            <div className="text-sm muted">
-              For the recommended HDR10 path, use `ST2084 Rec2020`, `10 bpc`, `RGB 4:4:4 Full`,
-              a `10%` window on black, the app signal range set to `Full`, and the `21-step`
-              grayscale ramp for pre/post checks.
+        {selectedGenerator === 'lightspace_connect' && (
+          <Card title="LightSpace Connect">
+            <div className="text-sm muted" style={{ marginBottom: 12 }}>
+              Select your LightSpace Connect tier to configure the grayscale ramp density.
+              A denser ramp gives the guidance engine more data points for better gamma
+              curve fitting and ABL detection.
             </div>
-          </Card>
-          <Card title="Dogegen Companion" id="dogegen-card">
-            <DogegenCard
-              dogegenStatus={dogegenStatus}
-              session={session}
-              onSaveConfig={onSaveDogegenConfig}
-              onStart={onStartDogegen}
-              onStop={onStopDogegen}
-            />
-          </Card>
-        </>
-      )}
-
-      <Card title="Signal Range">
-        <div className="text-sm muted" style={{ marginBottom: 12 }}>
-          Match this to the patch generator's output signal range. Full Range is common on PC/HDMI
-          generator paths such as Dogegen, while Limited Range is common for TV workflows such as
-          Apple TV + LightSpace Connect. Getting this wrong shifts every stimulus percent and skews
-          gamma readings.
-        </div>
-        {pd.pattern_generator_signal_range_hint && (
-          <div className="text-sm muted" style={{ marginBottom: 12 }}>
-            Current generator hint: {pd.pattern_generator_signal_range_hint}
-          </div>
-        )}
-        <div className="mode-grid">
-          {[
-            { id: 'limited', label: 'Limited Range', desc: '8-bit 16..235 or 10-bit 64..940 (typical TV video path)' },
-            { id: 'full',    label: 'Full Range',    desc: '8-bit 0..255 or 10-bit 0..1023 (recommended for Dogegen HDR on PC)' },
-          ].map(opt => (
-            <div
-              key={opt.id}
-              className={`mode-card ${selectedSignalRange === opt.id ? 'selected' : ''}`}
-              onClick={() => handleSignalRangeChange(opt.id)}
-              style={{ cursor: 'pointer' }}
-            >
-              <div className="mode-card-label">{opt.label}</div>
-              <div className="mode-card-desc">{opt.desc}</div>
-            </div>
-          ))}
-        </div>
-      </Card>
-
-      <Card title="Patch Code Scale">
-        <div className="text-sm muted" style={{ marginBottom: 12 }}>
-          This controls the actual patch code values shown in the workflow. For Dogegen HDR on PC, use
-          `10-bit Codes` so the app shows and interprets `0..1023` values instead of `0..255`.
-        </div>
-        <div className="mode-grid">
-          {codeScaleOptions.map(opt => (
-            <div
-              key={opt.key}
-              className={`mode-card ${selectedCodeScale === opt.key ? 'selected' : ''}`}
-              onClick={() => handleCodeScaleChange(opt.key)}
-              style={{ cursor: 'pointer' }}
-            >
-              <div className="mode-card-label">{opt.label}</div>
-              <div className="mode-card-desc">{opt.desc}</div>
-            </div>
-          ))}
-        </div>
-      </Card>
-
-
-      {(pd.zro_setup_steps || []).length > 0 && (
-        <div className="zro-card">
-          <div className="zro-card-title">ColourSpace Setup — {session.mode}</div>
-          <div className="zro-card-summary">
-            Complete these steps in ColourSpace and your selected patch generator before starting calibration measurements.
-          </div>
-          <ol className="zro-steps">
-            {pd.zro_setup_steps.map((step, i) => (
-              <li className="zro-step" key={i}>
-                <div className="zro-step-num">{i + 1}</div>
-                <div className="zro-step-body">
-                  <div className="zro-step-label">{step.step}</div>
-                  <div className="zro-step-detail">{step.detail}</div>
+            <div className="mode-grid" style={{ marginBottom: 12 }}>
+              {['free', 'paid'].map(tier => (
+                <div
+                  key={tier}
+                  className={`mode-card ${selectedTier === tier ? 'selected' : ''}`}
+                  onClick={() => handleTierChange(tier)}
+                  style={{ cursor: 'pointer' }}
+                >
+                  <div className="mode-card-label">
+                    {tier === 'free' ? 'Free' : 'Paid'}
+                  </div>
+                  <div className="mode-card-desc">
+                    {tier === 'free'
+                      ? '25-patch limit — supports 11- and 21-step ramps'
+                      : 'No patch limit — supports up to 51-step ramps'}
+                  </div>
                 </div>
-              </li>
-            ))}
-          </ol>
-        </div>
-      )}
+              ))}
+            </div>
+          </Card>
+        )}
 
-      {pd.service_menu_access && (
-        <div className="zro-card warning">
-          <div className="zro-card-title">⚠ Service Menu Access</div>
-          <div className="text-sm" style={{ whiteSpace: 'pre-line', lineHeight: 1.6 }}>
-            {pd.service_menu_access}
+        {selectedGenerator === 'dogegen' && (
+          <>
+            <Card title="Dogegen">
+              <div className="text-sm muted">
+                For the recommended HDR10 path, use `ST2084 Rec2020`, `10 bpc`, `RGB 4:4:4 Full`,
+                a `10%` window on black, the app signal range set to `Full`, and the `21-step`
+                grayscale ramp for pre/post checks.
+              </div>
+            </Card>
+            <Card title="Dogegen Companion" id="dogegen-card">
+              <DogegenCard
+                dogegenStatus={dogegenStatus}
+                session={session}
+                onSaveConfig={onSaveDogegenConfig}
+                onStart={onStartDogegen}
+                onStop={onStopDogegen}
+              />
+            </Card>
+          </>
+        )}
+      </CollapsibleSection>
+
+      {/* Section 2: Measurement Settings — collapsed by default, shows summary */}
+      <CollapsibleSection title="Measurement Settings" storageKey="prepare-measurement" defaultOpen={false} summary={measurementSummary}>
+        <Card title={<>Grayscale Ramp <Tooltip text="Number of gray patches measured from 0–100% stimulus. More steps give the guidance engine more data for curve fitting and ABL detection." /></>}>
+          <div className="text-sm muted" style={{ marginBottom: 12 }}>
+            {selectedGenerator === 'dogegen'
+              ? 'Dogegen works well with a denser grayscale sweep. For HDR10 on the U8G, use the 21-step ramp so the pre/post grayscale pages show the full 0–100% pass in 5% steps.'
+              : 'Choose the grayscale ramp density that matches the LightSpace Connect tier you are using.'}
           </div>
-        </div>
-      )}
-
-      <Card title="TV Picture Mode">
-        <div className="text-sm"><strong>{pd.picture_mode || '—'}</strong></div>
-        {pd.wb_menu_path    && <div className="text-sm muted mt-2">White Balance: <span className="accent">{pd.wb_menu_path}</span></div>}
-        {pd.gamma_menu_path && <div className="text-sm muted">Gamma: <span className="accent">{pd.gamma_menu_path}</span></div>}
-        {pd.gamma_note      && <div className="text-sm muted mt-2">{pd.gamma_note}</div>}
-      </Card>
-
-      <div className="two-col">
-        {(pd.reset_settings || []).length > 0 && (
-          <Card title="Reset to Defaults Before Calibrating">
-            <ul className="checklist">
-              {pd.reset_settings.map((item, i) => (
-                <li key={i}>
-                  <span className="checklist-label">{item.setting}</span>
-                  <span className="checklist-value">→ {item.value}</span>
-                </li>
-              ))}
-            </ul>
-          </Card>
-        )}
-        {(pd.disable_settings || []).length > 0 && (
-          <Card title="Disable Before Calibrating">
-            <ul className="checklist">
-              {pd.disable_settings.map((item, i) => (
-                <li key={i}>
-                  <span className="checklist-label">{item.setting}</span>
-                  <span className="checklist-value">→ {item.value}</span>
-                </li>
-              ))}
-            </ul>
-          </Card>
-        )}
-      </div>
-
-      {(pd.configure_settings || []).length > 0 && (
-        <Card title="Configure">
-          <ul className="checklist">
-            {pd.configure_settings.map((item, i) => (
-              <li key={i}>
-                <span className="checklist-label">{item.setting}</span>
-                <span className="checklist-value">→ {item.value}</span>
-              </li>
-            ))}
-          </ul>
-        </Card>
-      )}
-
-      <Card title="AI Assistant">
-        <div className="text-sm muted" style={{ marginBottom: 16 }}>
-          Connect an OpenAI-compatible LLM (e.g. Ollama, LiteLLM) to get real-time coaching
-          after each ZRO import. If unconfigured the rest of the workflow is unaffected.
-        </div>
-        <label style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 16, cursor: 'pointer', userSelect: 'none' }}>
-          <input
-            type="checkbox"
-            checked={llmEnabled}
-            onChange={e => handleLlmToggle(e.target.checked)}
-            style={{ width: 16, height: 16, accentColor: 'var(--accent)', cursor: 'pointer' }}
-          />
-          <span style={{ fontSize: '0.875rem', fontWeight: 500 }}>Enable AI Assistant</span>
-        </label>
-        {llmEnabled && (
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
-              <label style={{ fontSize: '0.78rem', fontWeight: 600, color: 'var(--muted)', textTransform: 'uppercase', letterSpacing: '0.06em' }}>
-                Endpoint URL
-              </label>
-              <input
-                type="url"
-                value={llmEndpoint}
-                onChange={e => setLlmEndpoint(e.target.value)}
-                onBlur={e => handleLlmEndpointBlur(e.target.value)}
-                placeholder="http://localhost:11434/v1"
-                autoComplete="off"
-                spellCheck={false}
-                style={{ background: 'var(--surface2)', border: '1px solid var(--border2)', borderRadius: 'var(--radius)', color: 'var(--text)', fontSize: '0.84rem', padding: '7px 10px', width: '100%', maxWidth: 480, outline: 'none', fontFamily: 'inherit' }}
-              />
-            </div>
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
-              <label style={{ fontSize: '0.78rem', fontWeight: 600, color: 'var(--muted)', textTransform: 'uppercase', letterSpacing: '0.06em' }}>
-                Model name
-              </label>
-              <input
-                type="text"
-                value={llmModel}
-                onChange={e => setLlmModel(e.target.value)}
-                onBlur={e => handleLlmModelBlur(e.target.value)}
-                placeholder="llama3"
-                autoComplete="off"
-                spellCheck={false}
-                style={{ background: 'var(--surface2)', border: '1px solid var(--border2)', borderRadius: 'var(--radius)', color: 'var(--text)', fontSize: '0.84rem', padding: '7px 10px', width: '100%', maxWidth: 480, outline: 'none', fontFamily: 'inherit' }}
-              />
-            </div>
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
-              <label style={{ fontSize: '0.78rem', fontWeight: 600, color: 'var(--muted)', textTransform: 'uppercase', letterSpacing: '0.06em' }}>
-                API key{' '}
-                <span style={{ fontSize: '0.72rem', fontWeight: 400, textTransform: 'none', letterSpacing: 0, color: 'var(--border2)' }}>
-                  (optional — never shown)
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+            {availableRamps.map(opt => (
+              <label
+                key={opt.steps}
+                style={{ display: 'flex', alignItems: 'flex-start', gap: 10, cursor: 'pointer' }}
+              >
+                <input
+                  type="radio"
+                  name="ramp"
+                  value={opt.steps}
+                  checked={selectedSteps === opt.steps}
+                  onChange={() => handleRampChange(opt.steps)}
+                  style={{ marginTop: 2, flexShrink: 0 }}
+                />
+                <span>
+                  <span className="text-sm"><strong>{opt.label}</strong></span>
+                  <span className="text-sm muted" style={{ display: 'block' }}>
+                    {selectedGenerator === 'dogegen' && opt.steps === 21
+                      ? 'Recommended for Dogegen HDR workflows on the U8G.'
+                      : opt.summary}
+                  </span>
                 </span>
               </label>
-              <input
-                type="password"
-                value={llmApiKey}
-                onChange={e => setLlmApiKey(e.target.value)}
-                onBlur={e => handleLlmApiKeyBlur(e.target.value)}
-                placeholder="sk-…"
-                autoComplete="new-password"
-                style={{ background: 'var(--surface2)', border: '1px solid var(--border2)', borderRadius: 'var(--radius)', color: 'var(--text)', fontSize: '0.84rem', padding: '7px 10px', width: '100%', maxWidth: 480, outline: 'none', fontFamily: 'inherit' }}
-              />
-            </div>
-            <div className="btn-group" style={{ marginTop: 2 }}>
-              <Button small onClick={handleTestConnection}>Test Connection</Button>
-              {llmTestStatus === 'testing'    && <span style={{ fontSize: '0.8rem', fontWeight: 600, padding: '5px 10px', borderRadius: 'var(--radius)', color: 'var(--muted)', background: 'var(--surface2)', border: '1px solid var(--border)' }}>Testing…</span>}
-              {llmTestStatus === 'ok'         && <span style={{ fontSize: '0.8rem', fontWeight: 600, padding: '5px 10px', borderRadius: 'var(--radius)', color: 'var(--green)', background: 'var(--green-dim)', border: '1px solid #22c98759' }}>✓ Reachable</span>}
-              {llmTestStatus === 'unreachable'&& <span style={{ fontSize: '0.8rem', fontWeight: 600, padding: '5px 10px', borderRadius: 'var(--radius)', color: 'var(--red)',   background: 'var(--red-dim)',   border: '1px solid #e74c3c4d' }}>✗ Unreachable</span>}
-              {llmTestStatus === 'error'      && <span style={{ fontSize: '0.8rem', fontWeight: 600, padding: '5px 10px', borderRadius: 'var(--radius)', color: 'var(--red)',   background: 'var(--red-dim)',   border: '1px solid #e74c3c4d' }}>✗ Error</span>}
-            </div>
+            ))}
           </div>
-        )}
-      </Card>
+        </Card>
+
+        <Card title={<>Signal Range <Tooltip text="Whether patch codes use full (0–255 / 0–1023) or limited (16–235 / 64–940) range. Getting this wrong shifts every stimulus percent and skews gamma readings." /></>}>
+          <div className="text-sm muted" style={{ marginBottom: 12 }}>
+            Match this to the patch generator's output signal range. Full Range is common on PC/HDMI
+            generator paths such as Dogegen, while Limited Range is common for TV workflows such as
+            Apple TV + LightSpace Connect. Getting this wrong shifts every stimulus percent and skews
+            gamma readings.
+          </div>
+          {pd.pattern_generator_signal_range_hint && (
+            <div className="text-sm muted" style={{ marginBottom: 12 }}>
+              Current generator hint: {pd.pattern_generator_signal_range_hint}
+            </div>
+          )}
+          <div className="mode-grid">
+            {[
+              { id: 'limited', label: 'Limited Range', desc: '8-bit 16..235 or 10-bit 64..940 (typical TV video path)' },
+              { id: 'full',    label: 'Full Range',    desc: '8-bit 0..255 or 10-bit 0..1023 (recommended for Dogegen HDR on PC)' },
+            ].map(opt => (
+              <div
+                key={opt.id}
+                className={`mode-card ${selectedSignalRange === opt.id ? 'selected' : ''}`}
+                onClick={() => handleSignalRangeChange(opt.id)}
+                style={{ cursor: 'pointer' }}
+              >
+                <div className="mode-card-label">{opt.label}</div>
+                <div className="mode-card-desc">{opt.desc}</div>
+              </div>
+            ))}
+          </div>
+        </Card>
+
+        <Card title={<>Patch Code Scale <Tooltip text="Bit depth of patch codes sent to the generator. Use 10-bit for HDR Dogegen paths (0–1023) and 8-bit for standard SDR paths (0–255)." /></>}>
+          <div className="text-sm muted" style={{ marginBottom: 12 }}>
+            This controls the actual patch code values shown in the workflow. For Dogegen HDR on PC, use
+            `10-bit Codes` so the app shows and interprets `0..1023` values instead of `0..255`.
+          </div>
+          <div className="mode-grid">
+            {codeScaleOptions.map(opt => (
+              <div
+                key={opt.key}
+                className={`mode-card ${selectedCodeScale === opt.key ? 'selected' : ''}`}
+                onClick={() => handleCodeScaleChange(opt.key)}
+                style={{ cursor: 'pointer' }}
+              >
+                <div className="mode-card-label">{opt.label}</div>
+                <div className="mode-card-desc">{opt.desc}</div>
+              </div>
+            ))}
+          </div>
+        </Card>
+      </CollapsibleSection>
+
+      {/* Section 3: TV Setup Checklist — collapsed by default, auto-expand if service menu warning */}
+      {hasChecklistContent && (
+        <CollapsibleSection title="TV Setup Checklist" storageKey="prepare-checklist" defaultOpen={!!pd.service_menu_access}>
+          {(pd.zro_setup_steps || []).length > 0 && (
+            <div className="zro-card">
+              <div className="zro-card-title">ColourSpace Setup — {session.mode}</div>
+              <div className="zro-card-summary">
+                Complete these steps in ColourSpace and your selected patch generator before starting calibration measurements.
+              </div>
+              <ol className="zro-steps">
+                {pd.zro_setup_steps.map((step, i) => (
+                  <li className="zro-step" key={i}>
+                    <div className="zro-step-num">{i + 1}</div>
+                    <div className="zro-step-body">
+                      <div className="zro-step-label">{step.step}</div>
+                      <div className="zro-step-detail">{step.detail}</div>
+                    </div>
+                  </li>
+                ))}
+              </ol>
+            </div>
+          )}
+
+          {pd.service_menu_access && (
+            <div className="zro-card warning">
+              <div className="zro-card-title">⚠ Service Menu Access</div>
+              <div className="text-sm" style={{ whiteSpace: 'pre-line', lineHeight: 1.6 }}>
+                {pd.service_menu_access}
+              </div>
+            </div>
+          )}
+
+          <Card title="TV Picture Mode">
+            <div className="text-sm"><strong>{pd.picture_mode || '—'}</strong></div>
+            {pd.wb_menu_path    && <div className="text-sm muted mt-2">White Balance: <span className="accent">{pd.wb_menu_path}</span></div>}
+            {pd.gamma_menu_path && <div className="text-sm muted">Gamma: <span className="accent">{pd.gamma_menu_path}</span></div>}
+            {pd.gamma_note      && <div className="text-sm muted mt-2">{pd.gamma_note}</div>}
+          </Card>
+
+          <div className="two-col">
+            {(pd.reset_settings || []).length > 0 && (
+              <Card title="Reset to Defaults Before Calibrating">
+                <ul className="checklist">
+                  {pd.reset_settings.map((item, i) => (
+                    <li key={i}>
+                      <span className="checklist-label">{item.setting}</span>
+                      <span className="checklist-value">→ {item.value}</span>
+                    </li>
+                  ))}
+                </ul>
+              </Card>
+            )}
+            {(pd.disable_settings || []).length > 0 && (
+              <Card title="Disable Before Calibrating">
+                <ul className="checklist">
+                  {pd.disable_settings.map((item, i) => (
+                    <li key={i}>
+                      <span className="checklist-label">{item.setting}</span>
+                      <span className="checklist-value">→ {item.value}</span>
+                    </li>
+                  ))}
+                </ul>
+              </Card>
+            )}
+          </div>
+
+          {(pd.configure_settings || []).length > 0 && (
+            <Card title="Configure">
+              <ul className="checklist">
+                {pd.configure_settings.map((item, i) => (
+                  <li key={i}>
+                    <span className="checklist-label">{item.setting}</span>
+                    <span className="checklist-value">→ {item.value}</span>
+                  </li>
+                ))}
+              </ul>
+            </Card>
+          )}
+        </CollapsibleSection>
+      )}
+
+      {/* Section 4: AI Assistant — collapsed by default */}
+      <CollapsibleSection title="AI Assistant" storageKey="prepare-ai" defaultOpen={false}>
+        <Card>
+          <div className="text-sm muted" style={{ marginBottom: 16 }}>
+            Connect an OpenAI-compatible LLM (e.g. Ollama, LiteLLM) to get real-time coaching
+            after each ZRO import. If unconfigured the rest of the workflow is unaffected.
+          </div>
+          <label style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 16, cursor: 'pointer', userSelect: 'none' }}>
+            <input
+              type="checkbox"
+              checked={llmEnabled}
+              onChange={e => handleLlmToggle(e.target.checked)}
+              style={{ width: 16, height: 16, accentColor: 'var(--accent)', cursor: 'pointer' }}
+            />
+            <span style={{ fontSize: '0.875rem', fontWeight: 500 }}>Enable AI Assistant</span>
+          </label>
+          {llmEnabled && (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
+                <label style={{ fontSize: '0.78rem', fontWeight: 600, color: 'var(--muted)', textTransform: 'uppercase', letterSpacing: '0.06em' }}>
+                  Endpoint URL
+                </label>
+                <input
+                  type="url"
+                  value={llmEndpoint}
+                  onChange={e => setLlmEndpoint(e.target.value)}
+                  onBlur={e => handleLlmEndpointBlur(e.target.value)}
+                  placeholder="http://localhost:11434/v1"
+                  autoComplete="off"
+                  spellCheck={false}
+                  style={{ background: 'var(--surface2)', border: '1px solid var(--border2)', borderRadius: 'var(--radius)', color: 'var(--text)', fontSize: '0.84rem', padding: '7px 10px', width: '100%', maxWidth: 480, outline: 'none', fontFamily: 'inherit' }}
+                />
+              </div>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
+                <label style={{ fontSize: '0.78rem', fontWeight: 600, color: 'var(--muted)', textTransform: 'uppercase', letterSpacing: '0.06em' }}>
+                  Model name
+                </label>
+                <input
+                  type="text"
+                  value={llmModel}
+                  onChange={e => setLlmModel(e.target.value)}
+                  onBlur={e => handleLlmModelBlur(e.target.value)}
+                  placeholder="llama3"
+                  autoComplete="off"
+                  spellCheck={false}
+                  style={{ background: 'var(--surface2)', border: '1px solid var(--border2)', borderRadius: 'var(--radius)', color: 'var(--text)', fontSize: '0.84rem', padding: '7px 10px', width: '100%', maxWidth: 480, outline: 'none', fontFamily: 'inherit' }}
+                />
+              </div>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
+                <label style={{ fontSize: '0.78rem', fontWeight: 600, color: 'var(--muted)', textTransform: 'uppercase', letterSpacing: '0.06em' }}>
+                  API key{' '}
+                  <span style={{ fontSize: '0.72rem', fontWeight: 400, textTransform: 'none', letterSpacing: 0, color: 'var(--border2)' }}>
+                    (optional — never shown)
+                  </span>
+                </label>
+                <input
+                  type="password"
+                  value={llmApiKey}
+                  onChange={e => setLlmApiKey(e.target.value)}
+                  onBlur={e => handleLlmApiKeyBlur(e.target.value)}
+                  placeholder="sk-…"
+                  autoComplete="new-password"
+                  style={{ background: 'var(--surface2)', border: '1px solid var(--border2)', borderRadius: 'var(--radius)', color: 'var(--text)', fontSize: '0.84rem', padding: '7px 10px', width: '100%', maxWidth: 480, outline: 'none', fontFamily: 'inherit' }}
+                />
+              </div>
+              <div className="btn-group" style={{ marginTop: 2 }}>
+                <Button small onClick={handleTestConnection}>Test Connection</Button>
+                {llmTestStatus === 'testing'    && <span style={{ fontSize: '0.8rem', fontWeight: 600, padding: '5px 10px', borderRadius: 'var(--radius)', color: 'var(--muted)', background: 'var(--surface2)', border: '1px solid var(--border)' }}>Testing…</span>}
+                {llmTestStatus === 'ok'         && <span style={{ fontSize: '0.8rem', fontWeight: 600, padding: '5px 10px', borderRadius: 'var(--radius)', color: 'var(--green)', background: 'var(--green-dim)', border: '1px solid #22c98759' }}>✓ Reachable</span>}
+                {llmTestStatus === 'unreachable'&& <span style={{ fontSize: '0.8rem', fontWeight: 600, padding: '5px 10px', borderRadius: 'var(--radius)', color: 'var(--red)',   background: 'var(--red-dim)',   border: '1px solid #e74c3c4d' }}>✗ Unreachable</span>}
+                {llmTestStatus === 'error'      && <span style={{ fontSize: '0.8rem', fontWeight: 600, padding: '5px 10px', borderRadius: 'var(--radius)', color: 'var(--red)',   background: 'var(--red-dim)',   border: '1px solid #e74c3c4d' }}>✗ Error</span>}
+              </div>
+            </div>
+          )}
+        </Card>
+      </CollapsibleSection>
 
       <div className="btn-group">
         <Button onClick={onPrev}>← Back</Button>

--- a/frontend/src/pages/Report.jsx
+++ b/frontend/src/pages/Report.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { Card, StatCard } from '../components/Card';
 import { Button } from '../components/Button';
 import { MeasurementTable } from '../components/MeasurementTable';
+import { Tooltip } from '../components/Tooltip';
 import { DeChart } from '../charts/DeChart';
 import { GammaChart } from '../charts/GammaChart';
 import { api } from '../api/client';
@@ -57,9 +58,9 @@ export function Report({ session, onPrev }) {
       {report && (
         <>
           <div className="four-col" style={{ marginBottom: 16 }}>
-            <StatCard value={pre.avg_de != null ? pre.avg_de.toFixed(2) : '—'} label="Pre-Cal Avg ΔE" color="red" />
-            <StatCard value={post.avg_de != null ? post.avg_de.toFixed(2) : '—'} label="Post-Cal Avg ΔE" color="green" />
-            <StatCard value={fmtNits(report.peak_luminance)} label="Peak Luminance" color="accent" />
+            <StatCard value={pre.avg_de != null ? pre.avg_de.toFixed(2) : '—'} label="Pre-Cal Avg ΔE" color="red" tooltip="Average Delta E before calibration. ΔE < 2 is invisible to most viewers." />
+            <StatCard value={post.avg_de != null ? post.avg_de.toFixed(2) : '—'} label="Post-Cal Avg ΔE" color="green" tooltip="Average Delta E after calibration. ΔE < 1 is excellent." />
+            <StatCard value={fmtNits(report.peak_luminance)} label="Peak Luminance" color="accent" tooltip="Maximum brightness measured in cd/m² (nits). HDR10 content typically targets 1000 nits." />
             <StatCard
               value={report.improvement_pct != null ? report.improvement_pct.toFixed(1) + '%' : '—'}
               label="Improvement"

--- a/server.py
+++ b/server.py
@@ -142,6 +142,10 @@ class GrayscaleRampReq(BaseModel):
     ramp_steps: int
 
 
+class JumpToStepReq(BaseModel):
+    step_index: int
+
+
 class DogegenConfigReq(BaseModel):
     path: Optional[str] = None
     resolve_host: Optional[str] = None
@@ -593,6 +597,11 @@ def next_step(sid: str):
 @app.post("/api/session/{sid}/prev")
 def prev_step(sid: str):
     return _session_view(store.prev_step(sid))
+
+
+@app.post("/api/session/{sid}/jump")
+def jump_to_step(sid: str, req: JumpToStepReq):
+    return _session_view(store.jump_to_step(sid, req.step_index))
 
 
 @app.post("/api/session/{sid}/llm/configure")


### PR DESCRIPTION
## Summary

Implements three medium-effort UX issues in one pass:

- **#35 — Clickable completed progress-bar steps**: Done step tabs now act as instant back-navigation. Clicking any ✓ tab jumps directly to that step (no more clicking ← Back repeatedly). Backend guards that only already-completed steps can be jumped to.
- **#41 — Inline ⓘ tooltips**: A reusable `Tooltip` component shows a dark popover on hover/focus. Applied to ΔE, CCT, and γ column headers in `MeasurementTable`; Pre/Post Avg ΔE and Peak Luminance in `Report` StatCards; and Grayscale Ramp, Signal Range, and Patch Code Scale titles on the Prepare page.
- **#44 — Collapsible Prepare sections**: The 11-card Prepare wall is reorganised into four accordion sections — **Hardware** (open), **Measurement Settings** (collapsed, summary line e.g. `21-step · Full Range · 10-bit`), **TV Setup Checklist** (collapsed, auto-expands when a service-menu warning is present), **AI Assistant** (collapsed). Section open/closed state persists to `localStorage` so power users don't re-expand on every visit.

## Changes

| File | What changed |
|---|---|
| `calibrator/session.py` | `jump_to_step()` — validates target < current index, sets step |
| `server.py` | `POST /api/session/{sid}/jump` endpoint + `JumpToStepReq` model |
| `api/client.js` | `jumpToStep(sid, step_index)` |
| `hooks/useSession.js` | `jumpToStep()` async function, exported |
| `App.jsx` | `ProgressBar` wires `onJump`; done tabs get click handler + CSS class |
| `index.css` | `.step-tab-clickable` hover, `CollapsibleSection` styles, `Tooltip` styles |
| `Tooltip.jsx` *(new)* | ⓘ trigger + CSS-positioned popover, keyboard-accessible |
| `CollapsibleSection.jsx` *(new)* | Chevron toggle, `localStorage` persistence, optional summary line |
| `Card.jsx` | `StatCard` accepts optional `tooltip` prop |
| `MeasurementTable.jsx` | Tooltip on CCT, ΔE, γ headers |
| `Report.jsx` | Tooltip on Pre/Post ΔE and Peak Luminance stat cards |
| `Prepare.jsx` | Wrapped in 4 `CollapsibleSection`s; tooltips on Ramp/Range/Scale titles |

## Test plan

- [ ] Click a ✓ done step tab — app jumps directly to that step without clearing measurements
- [ ] Attempt to jump to the current or a future step via dev console — expect 400 from `/jump`
- [ ] Hover the ⓘ badge next to ΔE, CCT, γ in any measurement table — tooltip appears above
- [ ] Tab to ⓘ with keyboard — tooltip appears on focus, disappears on blur
- [ ] Open Prepare page — Hardware section is open, the other three are collapsed
- [ ] Collapse Hardware, reload — localStorage preserves collapsed state
- [ ] With a profile that has `service_menu_access`, open Prepare — TV Setup Checklist auto-expands
- [ ] Measurement Settings summary shows correct values (e.g. "21-step · Full Range · 10-bit")

🤖 Generated with [Claude Code](https://claude.com/claude-code)