### PR TITLE
fix: null checks for zero values in MeasurementTable; number types in DogegenCard

### DIFF
--- a/frontend/src/components/DogegenCard.jsx
+++ b/frontend/src/components/DogegenCard.jsx
@@ -122,7 +122,7 @@ export function DogegenCard({ dogegenStatus, session, onSaveConfig, onStart, onS
               min={1}
               max={100}
               value={windowPct}
-              onChange={e => setWindowPct(e.target.value)}
+              onChange={e => setWindowPct(Number(e.target.value))}
               style={{ width: 120 }}
             />
             <span className="text-sm muted">Window %</span>
@@ -130,7 +130,7 @@ export function DogegenCard({ dogegenStatus, session, onSaveConfig, onStart, onS
               type="number"
               min={1}
               value={maxcll}
-              onChange={e => setMaxcll(e.target.value)}
+              onChange={e => setMaxcll(Number(e.target.value))}
               style={{ width: 140, marginLeft: 8 }}
             />
             <span className="text-sm muted">MaxCLL</span>

--- a/frontend/src/components/MeasurementTable.jsx
+++ b/frontend/src/components/MeasurementTable.jsx
@@ -84,10 +84,10 @@ export function MeasurementTable({ measurements, includeGamma }) {
           <tr key={i}>
             <td>{m.label || ''}</td>
             <td>{fmtDateTime(m.timestamp)}</td>
-            <td>{m.Y ? m.Y.toFixed(1) : '—'}</td>
-            <td>{m.x ? m.x.toFixed(4) : '—'}</td>
-            <td>{m.y ? m.y.toFixed(4) : '—'}</td>
-            <td>{m.cct ? Math.round(m.cct) + 'K' : '—'}</td>
+            <td>{m.Y != null ? m.Y.toFixed(1) : '—'}</td>
+            <td>{m.x != null ? m.x.toFixed(4) : '—'}</td>
+            <td>{m.y != null ? m.y.toFixed(4) : '—'}</td>
+            <td>{m.cct != null ? Math.round(m.cct) + 'K' : '—'}</td>
             <td dangerouslySetInnerHTML={{ __html: fmtDe(m.delta_e) }} />
             {includeGamma && <td>{m.effective_gamma != null ? m.effective_gamma.toFixed(3) : '—'}</td>}
           </tr>


### PR DESCRIPTION
## Summary
- **MeasurementTable** (#53): falsy checks (`m.Y ? ...`) caused valid zero values (black patch Y=0, x=0, y=0) to display as `—`. Replaced with `!= null` checks so zeros render correctly as `0.0` / `0.0000`.
- **DogegenCard** (#58): `onChange` handlers on `windowPct` and `maxcll` inputs assigned `e.target.value` (string) directly to state, diverging from the number type set at initialisation. Wrapped with `Number()` to maintain type consistency.

Closes #53
Closes #58

## Test plan
- [ ] Import a ZRO CSV containing a black patch (Y=0, x=0, y=0) — verify the MeasurementTable row shows `0.0`, `0.0000`, `0.0000` instead of `—`
- [ ] Open DogegenCard settings, edit Window % and MaxCLL — verify values remain numbers (confirm save payload has numeric types)

🤖 Generated with [Claude Code](https://claude.com/claude-code)