### PR TITLE
fix: 5 backlog bugs — polling leak, LLM reset, stale URL, CCT, peak-Y fallback

### DIFF
--- a/calcore/analysis.py
+++ b/calcore/analysis.py
@@ -37,10 +37,7 @@ def analyze(patches: List[Patch], cfg: AnalysisConfig) -> Summary:
         measured_peak_y = max(gray_measured_y)
         measured_black_y = min(gray_measured_y)
     else:
-        measured_peak_y = max(
-            p.meas_yxy[0] if p.meas_yxy is not None else p.meas_xyz[1]
-            for p in patches
-        )
+        measured_peak_y = None
         measured_black_y = 0.0
 
     grayscale_rows: List[Dict[str, Any]] = []

--- a/calcore/models.py
+++ b/calcore/models.py
@@ -154,7 +154,9 @@ class Measurement:
         return (self.x, self.y)
 
     @property
-    def cct(self) -> float:
+    def cct(self) -> Optional[float]:
+        if self.Y <= 0 or (self.x == 0.0 and self.y == 0.0):
+            return None
         n = (self.x - 0.3320) / (0.1858 - self.y) if self.y != 0.1858 else 0
         return 449 * n**3 + 3525 * n**2 + 6823.3 * n + 5520.33
 

--- a/calcore/targets.py
+++ b/calcore/targets.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Tuple
+from typing import Optional, Tuple
 
 from .colour import D65_xy, xyY_to_xyz
 from .eotf import bt1886_eotf, gamma_eotf, pq_eotf
@@ -12,7 +12,7 @@ def target_xyz_for_patch(
     patch: Patch,
     code_max: int,
     cfg: AnalysisConfig,
-    measured_peak_y: float,
+    measured_peak_y: Optional[float],
     measured_black_y: float,
 ) -> Tuple[float, float, float]:
     target_rgb = (

--- a/calibrator/models.py
+++ b/calibrator/models.py
@@ -75,7 +75,7 @@ class CalibrationReport:
                         self.target.peak_luminance_nits * (stim_pct / 100) ** self.target.gamma
                         if self.target.gamma > 0 else m.Y,
                     )
-                    writer.writerow([phase, stim_pct, m.x, m.y, m.Y, round(m.cct, 0), round(de, 2)])
+                    writer.writerow([phase, stim_pct, m.x, m.y, m.Y, round(m.cct, 0) if m.cct is not None else '', round(de, 2)])
 
     def save_html(self, filepath: str):
         improvement = None

--- a/calibrator/session.py
+++ b/calibrator/session.py
@@ -677,7 +677,7 @@ def m_to_dict(
     return {
         **data,
         "stimulus_pct": stim_pct,
-        "cct": None if invalid else round(m.cct, 0),
+        "cct": round(m.cct, 0) if m.cct is not None else None,
         "delta_e": None if de is None else round(de, 2),
         "delta_xy": None if dxy is None else round(dxy, 4),
         "effective_gamma": eff_gamma,

--- a/frontend/src/components/BridgeCard.jsx
+++ b/frontend/src/components/BridgeCard.jsx
@@ -1,9 +1,11 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Button } from './Button';
 
 export function BridgeCard({ bridgeStatus, bridgeUrl, session, dogegenStatus, onSaveUrl, onMeasure }) {
   const [url, setUrl] = useState(bridgeUrl || '');
   const [showSettings, setShowSettings] = useState(!bridgeUrl);
+
+  useEffect(() => { setUrl(bridgeUrl || ''); }, [bridgeUrl]);
   const [busy, setBusy] = useState(false);
   const [msg, setMsg] = useState('');
 

--- a/frontend/src/hooks/useSession.js
+++ b/frontend/src/hooks/useSession.js
@@ -96,17 +96,18 @@ export function useSession() {
 
   // Bridge polling
   useEffect(() => {
-    if (!bridgeUrl) return;
+    if (!bridgeUrl || !session?.id) return;
     refreshBridgeStatus(bridgeUrl);
     const t = setInterval(() => refreshBridgeStatus(bridgeUrl), 8000);
     return () => clearInterval(t);
-  }, [bridgeUrl, refreshBridgeStatus]);
+  }, [bridgeUrl, refreshBridgeStatus, session?.id]);
 
   useEffect(() => {
+    if (!session?.id) return;
     refreshDogegenStatus();
     const t = setInterval(refreshDogegenStatus, 8000);
     return () => clearInterval(t);
-  }, [refreshDogegenStatus]);
+  }, [refreshDogegenStatus, session?.id]);
 
   useEffect(() => {
     if (!dogegenStatus?.running || dogegenStatus?.ready) return;

--- a/frontend/src/pages/Prepare.jsx
+++ b/frontend/src/pages/Prepare.jsx
@@ -43,7 +43,7 @@ export function Prepare({ session, dogegenStatus, onConfirmPrepared, onPrev, onS
     setLlmEnabled(!!(cfg.endpoint && cfg.model));
     setLlmEndpoint(cfg.endpoint || '');
     setLlmModel(cfg.model || '');
-  }, [session.llm_config]);
+  }, [session.llm_config?.endpoint, session.llm_config?.model]);
 
   const availableRamps = selectedGenerator === 'lightspace_connect'
     ? rampOptions.filter(o => !o.requires_paid || selectedTier === 'paid')


### PR DESCRIPTION
## Summary

Fixes five open bugs from the backlog in a single pass. All changes are surgical — no refactoring beyond what each issue requires.

### #54 — BridgeCard stale URL after parent update
`BridgeCard` initialised its `url` state from the `bridgeUrl` prop but never re-synced. Added a `useEffect` to mirror the prop so the settings input reflects the saved value on re-mount.

### #56 — `analyze()` using color patch luminance as peak-Y fallback
When no grayscale patches were present, `measured_peak_y` was set to `max(Y)` across all patches including saturated primaries (green ≈ highest Y), corrupting the reference for any downstream summary. Now sets `measured_peak_y = None`; color-patch ΔE calculations in `target_xyz_for_patch` don't use this value, so behaviour is unchanged for CMS-only imports while the `meta` field is now honest. Updated `target_xyz_for_patch` signature to `Optional[float]`.

### #57 — `deleteSession` leaves bridge/dogegen polling running
The bridge and dogegen `useEffect` intervals had no dependency on `session?.id`, so they kept firing after `deleteSession()` cleared the session. Added `session?.id` as a dependency and guard so both intervals are torn down when the session is cleared.

### #59 — `Measurement.cct` returns bogus value for black patch
The CCT formula produced ~3700–5520 K for a zero-luminance patch (`Y=0, x=0, y=0`), which is meaningless and misleading in the table. Now returns `None` when `Y <= 0` or chromaticity is at the origin. Fixed the one call site in `calibrator/models.py` (`round(m.cct, 0)`) that lacked a null guard.

### #61 — Prepare.jsx LLM fields reset mid-input on every SSE event
The `useEffect` that synced LLM config depended on `session.llm_config` (object reference), which is replaced on every SSE update. Changed dependency to the stable primitives `session.llm_config?.endpoint` and `session.llm_config?.model` so the effect only fires when values actually change.

## Test plan
- [ ] Save a bridge URL, navigate away, return — settings input shows saved URL
- [ ] Import a CMS-only ZRO CSV (no grayscale patches) — no exception, `measured_peak_y` is null in summary meta
- [ ] Delete a session — verify no further `/api/bridge/status` or `/api/dogegen/status` polling in Network tab
- [ ] Black patch row in MeasurementTable shows `—` for CCT (not a K value)
- [ ] While typing in LLM endpoint field during active measurement session, field does not reset between keystrokes

Closes #54
Closes #56
Closes #57
Closes #59
Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)