### PR TITLE
feat: Dogegen SDR support, corrected startup args, and preferences persistence

### DIFF
--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -85,6 +85,10 @@ export const api = {
   adbGetPicture: (control, device) =>
     api.post('/api/adb/picture/get', { control, device }),
 
+  // Prefs
+  getPrefs:      ()           => api.get('/api/prefs'),
+  savePrefs:     (body)       => api.post('/api/prefs', body),
+
   // LLM
   configureLlm:  (sid, body)  => api.post(`/api/session/${sid}/llm/configure`, body),
   getLlmStatus:  (sid)        => api.get(`/api/session/${sid}/llm/status`),

--- a/frontend/src/hooks/useSession.js
+++ b/frontend/src/hooks/useSession.js
@@ -45,23 +45,18 @@ export function useSession() {
 
   // Initial load
   useEffect(() => {
-    Promise.all([api.getSession(), api.getProfiles()])
-      .then(([sess, profs]) => {
+    Promise.all([api.getSession(), api.getProfiles(), api.getPrefs()])
+      .then(([sess, profs, prefs]) => {
         setSession(sess);
         setProfiles(profs);
         if (sess?.id) startSSE(sess.id);
+        const url = prefs?.bridge_url || 'http://localhost:7070';
+        setBridgeUrl(url);
+        api.saveBridgeUrl(url).catch(() => { /* best-effort sync */ });
+        setWatchDefaultPath(prefs?.watch_folder || '');
       })
-      .catch(() => { /* session load failure is non-fatal */ })
+      .catch(() => { /* load failure is non-fatal */ })
       .finally(() => setLoading(false));
-
-    // Load persisted bridge URL (default to localhost where the bridge normally runs)
-    const saved = localStorage.getItem('bridgeUrl') || 'http://localhost:7070';
-    setBridgeUrl(saved);
-    api.saveBridgeUrl(saved).catch(() => { /* best-effort persistence */ });
-
-    // Load persisted watch path
-    const savedWatch = localStorage.getItem('watchPath') || '';
-    setWatchDefaultPath(savedWatch);
 
     return () => {
       clearTimeout(sseRetryRef.current);
@@ -166,6 +161,7 @@ export function useSession() {
   async function setSignalRange(range) {
     if (!session?.id) return;
     setSession(await api.setSignalRange(session.id, range));
+    api.savePrefs({ signal_range: range }).catch(() => {});
   }
 
   async function setGrayscaleRamp(rampSteps) {
@@ -176,11 +172,13 @@ export function useSession() {
   async function setCodeScale(codeScale) {
     if (!session?.id) return;
     setSession(await api.setCodeScale(session.id, codeScale));
+    api.savePrefs({ code_scale: codeScale }).catch(() => {});
   }
 
   async function setPatternGenerator(generator) {
     if (!session?.id) return;
     setSession(await api.setPatternGenerator(session.id, generator));
+    api.savePrefs({ pattern_generator: generator }).catch(() => {});
   }
 
   async function setLightspaceTier(tier, rampSteps) {
@@ -197,8 +195,8 @@ export function useSession() {
 
   async function startWatch(path) {
     if (!session?.id) return;
-    localStorage.setItem('watchPath', path);
     setWatchDefaultPath(path);
+    api.savePrefs({ watch_folder: path }).catch(() => {});
     const status = await api.startWatch(session.id, path);
     setWatchStatus(status);
   }

--- a/server.py
+++ b/server.py
@@ -324,8 +324,8 @@ def _dogegen_command_for_session(session: Dict[str, Any], exe_path: str) -> List
         cmd.append(resolve_arg)
         return cmd
     if mode == "SDR":
-        resolve_arg = f"resolve_sdr {resolve_host}" if resolve_host else "resolve_sdr"
-        return [exe_path, resolve_arg]
+        host = resolve_host or "127.0.0.1"
+        return [exe_path, f"maxcll {maxcll}", f"resolve_sdr {host}"]
     return [exe_path]
 
 

--- a/server.py
+++ b/server.py
@@ -94,6 +94,11 @@ logger = logging.getLogger(__name__)
 
 app = FastAPI(title="ZRO Calibration Helper")
 
+
+@app.on_event("startup")
+def _startup() -> None:
+    _load_prefs()
+
 SESSION_STORE_DIR = Path(__file__).parent / ".sessions"
 SESSION_TTL = timedelta(days=7)
 _watched_session_id: Optional[str] = None
@@ -122,6 +127,54 @@ store = SessionStore(
 store.load_sessions()
 
 _sessions = store.sessions
+
+# ---------------------------------------------------------------------------
+# Preferences — persisted to .prefs.json, loaded on startup
+# ---------------------------------------------------------------------------
+_PREFS_PATH = Path(__file__).parent / ".prefs.json"
+_prefs: Dict[str, Any] = {
+    "dogegen": {},
+    "bridge_url": "",
+    "watch_folder": "",
+    "llm": {"endpoint": "", "model": ""},
+    "session_defaults": {
+        "signal_range": "full",
+        "code_scale": "8bit",
+        "pattern_generator": "dogegen",
+    },
+}
+
+
+def _load_prefs() -> None:
+    """Read .prefs.json and apply to live globals. Env vars set initial values;
+    saved prefs overwrite them so the user's last UI choice always wins."""
+    global _zro_bridge_url
+    if not _PREFS_PATH.exists():
+        return
+    try:
+        saved = json.loads(_PREFS_PATH.read_text(encoding="utf-8"))
+    except Exception:
+        return
+    for key in ("dogegen", "bridge_url", "watch_folder", "llm", "session_defaults"):
+        if key in saved:
+            _prefs[key] = saved[key]
+    for field in ("path", "resolve_host", "window_pct", "maxcll"):
+        if field in _prefs.get("dogegen", {}):
+            _dogegen_config[field] = _prefs["dogegen"][field]
+    if _prefs.get("bridge_url"):
+        _zro_bridge_url = _prefs["bridge_url"]
+
+
+def _save_prefs() -> None:
+    """Snapshot current globals into _prefs and write atomically."""
+    _prefs["dogegen"] = dict(_dogegen_config)
+    _prefs["bridge_url"] = _zro_bridge_url
+    try:
+        tmp = _PREFS_PATH.with_suffix(".tmp")
+        tmp.write_text(json.dumps(_prefs, indent=2), encoding="utf-8")
+        tmp.replace(_PREFS_PATH)
+    except Exception:
+        pass  # best-effort — never crash on a prefs write failure
 _save_session = store.save_session
 
 
@@ -169,6 +222,15 @@ class DogegenConfigReq(BaseModel):
     resolve_host: Optional[str] = None
     window_pct: Optional[int] = None
     maxcll: Optional[int] = None
+
+
+class PrefsReq(BaseModel):
+    signal_range: Optional[str] = None
+    code_scale: Optional[str] = None
+    pattern_generator: Optional[str] = None
+    llm_endpoint: Optional[str] = None
+    llm_model: Optional[str] = None
+    watch_folder: Optional[str] = None
 
 
 class _AdbCmsSetReq(BaseModel):
@@ -563,6 +625,32 @@ def list_profiles():
 @app.post("/api/session")
 def create_session(req: CreateSessionReq):
     session = store.create_session(req.tv_key, req.sdr_peak_nits)
+    sid = session["id"]
+    sd = _prefs.get("session_defaults", {})
+    if sd.get("signal_range"):
+        try:
+            session = store.set_signal_range(sid, sd["signal_range"])
+        except Exception:
+            pass
+    if sd.get("code_scale"):
+        try:
+            session = store.set_code_scale(sid, sd["code_scale"])
+        except Exception:
+            pass
+    if sd.get("pattern_generator"):
+        try:
+            session = store.set_pattern_generator(sid, sd["pattern_generator"])
+        except Exception:
+            pass
+    llm = _prefs.get("llm", {})
+    if llm.get("endpoint") or llm.get("model"):
+        llm_cfg = session.setdefault("llm_config", {})
+        if llm.get("endpoint") and not llm_cfg.get("endpoint"):
+            llm_cfg["endpoint"] = llm["endpoint"]
+        if llm.get("model") and not llm_cfg.get("model"):
+            llm_cfg["model"] = llm["model"]
+        store.save_session(sid)
+        session = store.get(sid)
     return {
         **_session_view(session),
         "modes": MODE_OPTIONS,
@@ -636,6 +724,7 @@ def dogegen_config(req: DogegenConfigReq):
         if req.maxcll <= 0:
             raise HTTPException(400, "maxcll must be greater than 0")
         _dogegen_config["maxcll"] = int(req.maxcll)
+    _save_prefs()
     return {"ok": True, **_dogegen_status_payload()}
 
 
@@ -713,7 +802,12 @@ def configure_llm(sid: str, req: LlmConfigureReq):
             reachable = False
     
     _save_session(sid)
-    
+    if llm_cfg.get("endpoint"):
+        _prefs["llm"]["endpoint"] = llm_cfg["endpoint"]
+    if llm_cfg.get("model"):
+        _prefs["llm"]["model"] = llm_cfg["model"]
+    _save_prefs()
+
     return {
         "configured": configured,
         "reachable": reachable,
@@ -1098,7 +1192,36 @@ def zro_bridge_status():
 def zro_bridge_config(body: _ZroBridgeConfigBody):
     global _zro_bridge_url
     _zro_bridge_url = body.url.rstrip("/")
+    _save_prefs()
     return {"ok": True, "url": _zro_bridge_url}
+
+
+@app.get("/api/prefs")
+def get_prefs():
+    return _prefs
+
+
+@app.post("/api/prefs")
+def save_prefs_endpoint(req: PrefsReq):
+    sd = _prefs["session_defaults"]
+    if req.signal_range is not None:
+        if req.signal_range not in ("full", "limited"):
+            raise HTTPException(400, "signal_range must be 'full' or 'limited'")
+        sd["signal_range"] = req.signal_range
+    if req.code_scale is not None:
+        if req.code_scale not in ("8bit", "10bit"):
+            raise HTTPException(400, "code_scale must be '8bit' or '10bit'")
+        sd["code_scale"] = req.code_scale
+    if req.pattern_generator is not None:
+        sd["pattern_generator"] = req.pattern_generator
+    if req.llm_endpoint is not None:
+        _prefs["llm"]["endpoint"] = req.llm_endpoint.strip()
+    if req.llm_model is not None:
+        _prefs["llm"]["model"] = req.llm_model.strip()
+    if req.watch_folder is not None:
+        _prefs["watch_folder"] = req.watch_folder.strip()
+    _save_prefs()
+    return {"ok": True, **_prefs}
 
 
 @app.post("/api/zro/trigger")

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -11,8 +11,7 @@ from server import app, _sessions
 
 # ── Fixtures ──────────────────────────────────────────────────────────────────
 
-@pytest.fixture(autouse=True)
-def clear_sessions():
+def _reset_globals():
     _sessions.clear()
     server_module._watched_session_id = None
     server_module._dogegen_proc = None
@@ -25,15 +24,25 @@ def clear_sessions():
         "window_pct": 10,
         "maxcll": 1000,
     }
+    server_module._prefs = {
+        "dogegen": {},
+        "bridge_url": "",
+        "watch_folder": "",
+        "llm": {"endpoint": "", "model": ""},
+        "session_defaults": {
+            "signal_range": "full",
+            "code_scale": "8bit",
+            "pattern_generator": "dogegen",
+        },
+    }
     server_module._llm_queues.clear()
+
+
+@pytest.fixture(autouse=True)
+def clear_sessions():
+    _reset_globals()
     yield
-    _sessions.clear()
-    server_module._watched_session_id = None
-    server_module._dogegen_proc = None
-    server_module._dogegen_started_at = None
-    server_module._dogegen_launch_cmd = []
-    server_module._llm_queues.clear()
-    server_module._dogegen_last_error = None
+    _reset_globals()
 
 
 @pytest.fixture

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -448,16 +448,16 @@ class TestDogegenAutomation:
 
         assert resp.status_code == 200
         assert captured["cmd"][0] == str(exe)
-        assert "resolve_sdr" in captured["cmd"]
+        assert "maxcll 1000" in captured["cmd"]
+        assert "resolve_sdr 127.0.0.1" in captured["cmd"]
         assert not any("resolve_hdr" in a for a in captured["cmd"])
-        assert not any(a.startswith("resolve_sdr ") for a in captured["cmd"]), "SDR must not pin window size"
 
     def test_dogegen_start_for_sdr_with_resolve_host_includes_host(self, client, session_id, monkeypatch, tmp_path):
         exe = tmp_path / "Dogegen.exe"
         exe.write_text("")
         client.post(f"/api/session/{session_id}/mode", json={"mode": "SDR"})
         client.post(f"/api/session/{session_id}/pattern-generator", json={"pattern_generator": "dogegen"})
-        client.post("/api/dogegen/config", json={"path": str(exe), "resolve_host": "192.168.1.50"})
+        client.post("/api/dogegen/config", json={"path": str(exe), "resolve_host": "192.168.1.50", "maxcll": 160})
 
         captured = {}
         monkeypatch.setattr(server_module.subprocess, "Popen",
@@ -465,6 +465,7 @@ class TestDogegenAutomation:
 
         client.post(f"/api/session/{session_id}/dogegen/start")
 
+        assert "maxcll 160" in captured["cmd"]
         assert "resolve_sdr 192.168.1.50" in captured["cmd"]
 
     def test_dogegen_status_turns_ready_after_warmup(self, client, session_id, monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

Three related changes built during this session:

**Dogegen SDR mode fix**
- Dogegen was launching with no arguments for SDR sessions, so it never connected to ColourSpace as a TPG and no patches were displayed
- Added `resolve_sdr` startup command (+ optional host); window size omitted so ColourSpace controls patch size
- Updated `workflow_setup` for both SDR and HDR10: app now handles launch/mode automatically, added fullscreen step, named the Resolve connection path in ColourSpace

**Corrected SDR startup arguments**
- SDR command now matches Dogegen's expected format: `dogegen.exe "maxcll N" "resolve_sdr host"`
- Added `maxcll` to SDR launch (same config field as HDR10)
- Defaults host to `127.0.0.1` when `resolve_host` is not configured

**Preferences persistence**
- Adds `.prefs.json` that survives server restarts and seeds new sessions with last-used settings
- Auto-saved: Dogegen config, ZRO Bridge URL, watch folder path, LLM endpoint/model, signal range, code scale, pattern generator
- New `GET /api/prefs` and `POST /api/prefs` endpoints
- Frontend loads prefs on startup instead of localStorage for bridge URL and watch folder
- API key intentionally excluded from persistence

## Test plan

- [ ] Start SDR session → Dogegen launches with `maxcll N "resolve_sdr 127.0.0.1"`, ColourSpace connects via Resolve, patches display
- [ ] Start HDR10 session → existing behaviour unchanged
- [ ] Change signal range, code scale, pattern generator → restart server → new session inherits those values
- [ ] Configure Dogegen path → restart server → path is pre-filled
- [ ] `pytest tests/test_server_api.py` — 101 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)