### PR TITLE
feat: add logging to LLM pipeline

### DIFF
--- a/frontend/src/hooks/useSession.js
+++ b/frontend/src/hooks/useSession.js
@@ -34,27 +34,35 @@ export function useSession() {
     let retryDelay = 2000;
 
     function connect() {
+      console.log('[LLM] connecting to stream', sid);
       const es = new EventSource(`/api/session/${sid}/llm/stream`);
-      es.addEventListener('llm_start', () => {
+      es.addEventListener('llm_start', e => {
+        console.log('[LLM] started', JSON.parse(e.data));
         setLlmStreaming(true);
         setLlmError(null);
       });
       es.addEventListener('llm_insight', e => {
         try {
           const data = JSON.parse(e.data);
+          console.log('[LLM] insight received', data.phase, data.text?.slice(0, 80));
           setLlmInsight(data);
-        } catch { /* malformed */ }
+        } catch (err) {
+          console.warn('[LLM] malformed insight payload', e.data, err);
+        }
         setLlmStreaming(false);
       });
-      es.addEventListener('patch_strategy', () => {
-        // patch_strategy arrives alongside llm_insight; streaming is done
+      es.addEventListener('patch_strategy', e => {
+        console.log('[LLM] patch_strategy received', JSON.parse(e.data));
         setLlmStreaming(false);
       });
       es.addEventListener('llm_error', e => {
-        try { setLlmError(JSON.parse(e.data)); } catch { setLlmError(String(e.data)); }
+        const msg = (() => { try { return JSON.parse(e.data); } catch { return String(e.data); } })();
+        console.error('[LLM] error received', msg);
+        setLlmError(msg);
         setLlmStreaming(false);
       });
-      es.onerror = () => {
+      es.onerror = err => {
+        console.warn('[LLM] SSE connection error — retrying in', retryDelay, 'ms', err);
         es.close();
         llmEsRetryRef.current = setTimeout(() => {
           retryDelay = Math.min(retryDelay * 2, 30000);

--- a/server.py
+++ b/server.py
@@ -524,6 +524,8 @@ def _run_llm_background(
     tv_key: str = "",
     session_step_history: Optional[List[Dict[str, Any]]] = None,
 ) -> None:
+    logger.info("LLM run started  sid=%s phase=%s endpoint=%s model=%s",
+                sid, phase, llm_cfg.endpoint, llm_cfg.model)
     _llm_broadcast(sid, {
         "event": "llm_start",
         "data": {"phase": phase, "timestamp": datetime.utcnow().isoformat() + "Z"},
@@ -549,6 +551,7 @@ def _run_llm_background(
             llm_cfg,
             history_block=history_block,
         )
+        logger.info("LLM run complete sid=%s phase=%s chars=%d", sid, phase, len(result or ""))
         _llm_broadcast(sid, {
             "event": "llm_insight",
             "data": {
@@ -583,6 +586,7 @@ def _run_llm_background(
                     },
                 })
     except Exception as exc:
+        logger.error("LLM run failed  sid=%s phase=%s error=%s", sid, phase, exc, exc_info=True)
         _llm_broadcast(sid, {"event": "llm_error", "data": str(exc)})
 
 


### PR DESCRIPTION
## Summary

Adds visibility into the LLM pipeline to diagnose silent failures.

- **Server**: `logger.info` at start and completion (with char count), `logger.error` with full traceback on failure — visible in uvicorn/server stdout
- **Frontend**: `console.log('[LLM] ...')` on every SSE event (start, insight, patch_strategy, error) and on SSE connection errors — filter by `[LLM]` in browser DevTools console

## Test plan

- [ ] Import CSV with LLM configured → server stdout shows `LLM run started` then `LLM run complete`
- [ ] Browser DevTools → Console → filter `[LLM]` → see start/insight events
- [ ] With bad endpoint → server shows `LLM run failed` with traceback, browser console shows `[LLM] error received`

🤖 Generated with [Claude Code](https://claude.com/claude-code)