### PR TITLE
fix: correct WB guidance when xy is on-target but ΔE is high

### DIFF
--- a/calibrator/guidance.py
+++ b/calibrator/guidance.py
@@ -219,7 +219,12 @@ def wb_control_candidates(m: Measurement, hints: Dict[str, Any], tv: TVProfile) 
     return sorted(merged.values(), key=lambda i: (i["label"] != "primary", -i["score"], i["control"]))
 
 
-def wb_control_plan(m: Measurement, hints: Dict[str, Any], tv: TVProfile) -> List[Dict[str, Any]]:
+def wb_control_plan(
+    m: Measurement,
+    hints: Dict[str, Any],
+    tv: TVProfile,
+    de: Optional[float] = None,
+) -> List[Dict[str, Any]]:
     ranked = wb_control_candidates(m, hints, tv)
     controls: List[Dict[str, Any]] = []
     for idx, item in enumerate(ranked[:2], start=1):
@@ -236,6 +241,16 @@ def wb_control_plan(m: Measurement, hints: Dict[str, Any], tv: TVProfile) -> Lis
     if not controls:
         measurement_type = wb_measurement_type(m)
         suffix_label = "Gain" if measurement_type == "gain" else "Offset"
+        # Chromaticity is on target but ΔE may still be high due to luminance error.
+        if de is not None and de > 3.0:
+            reason = (
+                f"Chromaticity on target — no RGB {suffix_label.lower()} adjustment needed. "
+                f"ΔE {de:.1f} is elevated due to luminance error at this stimulus level, "
+                f"not a color cast. This will be addressed during gamma calibration; "
+                f"do not adjust RGB {suffix_label.lower()} controls for it."
+            )
+        else:
+            reason = "This reading is already within tolerance."
         controls.append(
             {
                 "control": f"{suffix_label} controls",
@@ -243,7 +258,7 @@ def wb_control_plan(m: Measurement, hints: Dict[str, Any], tv: TVProfile) -> Lis
                 "amount": 0,
                 "priority": "primary",
                 "summary": f"Leave {suffix_label} as-is",
-                "reason": "This reading is already within tolerance.",
+                "reason": reason,
             }
         )
     return controls[:3]
@@ -253,6 +268,7 @@ def wb_recommendations(
     m: Measurement,
     hints: Dict[str, Any],
     tv: Optional[TVProfile] = None,
+    de: Optional[float] = None,
 ) -> List[str]:
     recs: List[str] = []
     is_gain = "80%" in m.label or "Gain" in m.label
@@ -275,7 +291,13 @@ def wb_recommendations(
             recs.append(hints["y"]["action"])
 
     if hints["overall"] == "excellent":
-        recs.append("White balance is within tolerance. Re-measure the other gray point and move on.")
+        if de is not None and de > 3.0:
+            recs.append(
+                f"Chromaticity on target. ΔE {de:.1f} is elevated due to luminance error — "
+                "not a color cast. Address during gamma calibration."
+            )
+        else:
+            recs.append("White balance is within tolerance. Re-measure the other gray point and move on.")
     elif hints["overall"] == "close":
         recs.append("Make only one-click changes, then re-measure the same patch.")
     else:

--- a/calibrator/session.py
+++ b/calibrator/session.py
@@ -953,6 +953,7 @@ def session_view(s: Dict[str, Any]) -> Dict[str, Any]:
         latest_gain = latest_wb["gain"]
         latest_offset = latest_wb["offset"]
         current_hints = wb_hints(wb[-1], target.white_point_xy) if wb and target else None
+        last_wb_de = m_to_dict(wb[-1], target, signal_range, code_scale)["delta_e"] if wb and target else None
         view["wb_data"] = {
             "menu_path": tv.WB_MENU_PATH,
             "controls": [{"control": k, "desc": v} for k, v in tv.WB_2POINT.items()],
@@ -965,8 +966,8 @@ def session_view(s: Dict[str, Any]) -> Dict[str, Any]:
             "has_offset_measurement": latest_offset is not None,
             "ready_to_continue": latest_gain is not None and latest_offset is not None,
             "hints": current_hints,
-            "recommendations": wb_recommendations(wb[-1], current_hints, tv) if wb and target and current_hints else [],
-            "control_plan": wb_control_plan(wb[-1], current_hints, tv) if wb and target and current_hints else [],
+            "recommendations": wb_recommendations(wb[-1], current_hints, tv, de=last_wb_de) if wb and target and current_hints else [],
+            "control_plan": wb_control_plan(wb[-1], current_hints, tv, de=last_wb_de) if wb and target and current_hints else [],
             "target_xy": list(target.white_point_xy) if target else [0.3127, 0.3290],
         }
         view["zro_instructions"] = zro_step_instructions(signal_range, s.get("pattern_generator", "lightspace_connect"), code_scale)["white_balance"]


### PR DESCRIPTION
## Summary

The white balance guidance only checked chromaticity (±0.003 x,y deviation from D65) to decide whether to recommend an adjustment. A 30% gray offset measurement with perfect chromaticity but high ΔE (e.g. 4.66) was returning "Leave Offset as-is — this reading is already within tolerance" — which is misleading.

A high ΔE with on-target xy means the **luminance** at that stimulus level is wrong, not the color. This is a gamma issue, not a WB issue — adjusting RGB offset controls would create a color cast.

**Changes:**
- `wb_control_plan` and `wb_recommendations` now accept an optional `de` parameter
- When ΔE > 3.0 and xy is on target, the "leave as is" reason is replaced with: "Chromaticity on target — no RGB offset adjustment needed. ΔE N.N is elevated due to luminance error at this stimulus level, not a color cast. This will be addressed during gamma calibration."
- `session.py` computes `m_to_dict` for the latest WB measurement and passes `delta_e` to both functions

## Test plan

- [ ] Measure 30% gray with on-target xy but high ΔE → guidance says luminance error, not color cast
- [ ] Measure 30% gray with both xy off AND high ΔE → normal RGB adjustment candidates shown (de only affects the "leave as is" fallback)
- [ ] Measure 30% gray with good xy and low ΔE → "within tolerance" as before
- [ ] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)