### PR TITLE
fix: add diagnostic logging to LLM trigger

### DIFF
--- a/server.py
+++ b/server.py
@@ -593,7 +593,10 @@ def _run_llm_background(
 def _maybe_trigger_llm(sid: str, session: Dict[str, Any]) -> None:
     """Fire a background LLM analysis if the session has LLM configured and measurements."""
     llm_cfg_dict = session.get("llm_config", {})
-    if not (llm_cfg_dict.get("endpoint") and llm_cfg_dict.get("model")):
+    endpoint = llm_cfg_dict.get("endpoint", "")
+    model = llm_cfg_dict.get("model", "")
+    if not (endpoint and model):
+        logger.info("LLM skip  sid=%s reason=not_configured endpoint=%r model=%r", sid, endpoint, model)
         return
 
     all_measurements = (
@@ -604,6 +607,7 @@ def _maybe_trigger_llm(sid: str, session: Dict[str, Any]) -> None:
         + session.get("post_measurements", [])
     )
     if not all_measurements:
+        logger.info("LLM skip  sid=%s reason=no_measurements", sid)
         return
 
     patches = [_measurement_to_patch(m) for m in all_measurements]
@@ -615,6 +619,9 @@ def _maybe_trigger_llm(sid: str, session: Dict[str, Any]) -> None:
         temperature=float(llm_cfg_dict.get("temperature", 0.2)),
         timeout=float(llm_cfg_dict.get("timeout", 30.0)),
     )
+    has_key = bool(llm_cfg_dict.get("api_key"))
+    logger.info("LLM trigger  sid=%s step=%s patches=%d has_api_key=%s",
+                sid, session.get("step", "baseline"), len(patches), has_key)
     threading.Thread(
         target=_run_llm_background,
         args=(sid, patches, cfg, session.get("step", "baseline"), llm_cfg),


### PR DESCRIPTION
## Summary

`_maybe_trigger_llm` had two silent early-returns with no log output, making it impossible to tell from server logs why the LLM never fired after a CSV import.

**New log lines:**
```
LLM skip   sid=… reason=not_configured endpoint='' model=''
LLM skip   sid=… reason=no_measurements
LLM trigger sid=… step=white_balance patches=21 has_api_key=True
```

The `has_api_key` flag is particularly useful — the API key is intentionally not persisted to disk, so after a server restart it will show `has_api_key=False`, explaining why authenticated endpoints fail even when endpoint and model are correctly configured.

## Test plan

- [ ] Import CSV with LLM not configured → see `LLM skip reason=not_configured`
- [ ] Import CSV with LLM configured but no measurements → see `LLM skip reason=no_measurements`  
- [ ] Import CSV with LLM configured → see `LLM trigger … has_api_key=True/False`
- [ ] Restart server, re-import → `has_api_key=False` confirms key was lost

🤖 Generated with [Claude Code](https://claude.com/claude-code)