### PR TITLE
feat: trigger LLM after watch-folder imports and add server logs panel

### DIFF
--- a/calibrator/file_watcher.py
+++ b/calibrator/file_watcher.py
@@ -240,6 +240,7 @@ class _ZROHandler(FileSystemEventHandler):
         measurement_deserializer: Optional[Callable[[Dict], object]] = None,
         grayscale_level_count: int = 11,
         watched_file: Optional[str] = None,
+        post_import_hook: Optional[Callable[[Dict], None]] = None,
     ) -> None:
         super().__init__()
         self._session_getter = session_getter
@@ -247,6 +248,7 @@ class _ZROHandler(FileSystemEventHandler):
         self._measurement_deserializer = measurement_deserializer
         self._grayscale_level_count = grayscale_level_count
         self._watched_file = os.path.abspath(watched_file) if watched_file else None
+        self._post_import_hook = post_import_hook
 
         # path → timer
         self._timers: Dict[str, threading.Timer] = {}
@@ -547,6 +549,12 @@ class _ZROHandler(FileSystemEventHandler):
         _broadcast_event(event_payload)
         logger.info("Auto-imported %s (%d rows, %d buckets)", src_path, result.total_rows, len(counts))
 
+        if self._post_import_hook is not None:
+            try:
+                self._post_import_hook(session)
+            except Exception as exc:
+                logger.warning("post_import_hook raised: %s", exc)
+
 
 def _broadcast_event(payload: Dict) -> None:
     """Send an import event to every active SSE subscriber."""
@@ -591,6 +599,7 @@ def start_watching(
     session_saver: Callable[[], None],
     measurement_deserializer: Optional[Callable[[Dict], object]] = None,
     grayscale_level_count: int = 11,
+    post_import_hook: Optional[Callable[[Dict], None]] = None,
 ) -> None:
     """
     Start watching *path* for new or modified ``.csv`` files.
@@ -637,6 +646,7 @@ def start_watching(
         measurement_deserializer=measurement_deserializer,
         grayscale_level_count=grayscale_level_count,
         watched_file=watched_file,
+        post_import_hook=post_import_hook,
     )
     observer = Observer()
     observer.schedule(handler, watch_dir, recursive=False)

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -41,6 +41,7 @@ import { PostGrayscale } from './pages/PostGrayscale';
 import { Report }        from './pages/Report';
 import { ConfirmModal }  from './components/ConfirmModal';
 import { LlmInsightCard } from './components/LlmInsightCard';
+import { LogsPanel }     from './components/LogsPanel';
 
 function QualityDot({ gate }) {
   if (!gate) return null;
@@ -152,7 +153,7 @@ export default function App() {
   const dogegenConfigured = dogegenStatus?.configured;
 
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
+    <div style={{ display: 'flex', flexDirection: 'column', minHeight: '100vh', paddingBottom: 28 }}>
       {showStartOver && (
         <ConfirmModal
           title="Discard this calibration session?"
@@ -216,6 +217,7 @@ export default function App() {
           {renderStep()}
         </StepErrorBoundary>
       </main>
+      <LogsPanel />
     </div>
   );
 }

--- a/frontend/src/components/LogsPanel.jsx
+++ b/frontend/src/components/LogsPanel.jsx
@@ -1,0 +1,96 @@
+import { useState, useEffect, useRef } from 'react';
+
+const LEVEL_COLOR = {
+  DEBUG:    'var(--muted)',
+  INFO:     'var(--text)',
+  WARNING:  '#e6a817',
+  ERROR:    'var(--red)',
+  CRITICAL: 'var(--red)',
+};
+
+function levelOf(line) {
+  if (/\bCRITICAL\b/.test(line)) return 'CRITICAL';
+  if (/\bERROR\b/.test(line))    return 'ERROR';
+  if (/\bWARNING\b/.test(line))  return 'WARNING';
+  if (/\bDEBUG\b/.test(line))    return 'DEBUG';
+  return 'INFO';
+}
+
+export function LogsPanel() {
+  const [open, setOpen] = useState(false);
+  const [lines, setLines] = useState([]);
+  const [connected, setConnected] = useState(false);
+  const esRef = useRef(null);
+  const bottomRef = useRef(null);
+  const MAX_LINES = 300;
+
+  useEffect(() => {
+    const es = new EventSource('/api/logs/stream');
+    esRef.current = es;
+    es.onopen = () => setConnected(true);
+    es.onmessage = e => {
+      try {
+        const line = JSON.parse(e.data);
+        setLines(prev => {
+          const next = [...prev, line];
+          return next.length > MAX_LINES ? next.slice(next.length - MAX_LINES) : next;
+        });
+      } catch { /* ignore */ }
+    };
+    es.onerror = () => setConnected(false);
+    return () => es.close();
+  }, []);
+
+  // Auto-scroll when panel is open
+  useEffect(() => {
+    if (open) bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [lines, open]);
+
+  const errorCount = lines.filter(l => /\b(ERROR|CRITICAL)\b/.test(l)).length;
+
+  return (
+    <div style={{
+      position: 'fixed', bottom: 0, left: 0, right: 0, zIndex: 1000,
+      fontFamily: 'monospace', fontSize: '0.75rem',
+      background: 'var(--surface)', borderTop: '1px solid var(--border)',
+      boxShadow: open ? '0 -4px 24px rgba(0,0,0,0.4)' : 'none',
+    }}>
+      {/* Toggle bar */}
+      <div
+        onClick={() => setOpen(o => !o)}
+        style={{
+          display: 'flex', alignItems: 'center', gap: 10, padding: '4px 14px',
+          cursor: 'pointer', userSelect: 'none',
+          background: 'var(--surface2)',
+        }}
+      >
+        <span style={{ color: connected ? 'var(--green)' : 'var(--muted)', fontSize: '0.65rem' }}>●</span>
+        <span style={{ color: 'var(--muted)', fontWeight: 600, letterSpacing: '0.05em' }}>SERVER LOGS</span>
+        {errorCount > 0 && (
+          <span style={{ background: 'var(--red)', color: '#fff', borderRadius: 3, padding: '0 5px', fontSize: '0.65rem' }}>
+            {errorCount} error{errorCount !== 1 ? 's' : ''}
+          </span>
+        )}
+        <span style={{ marginLeft: 'auto', color: 'var(--muted)', fontSize: '0.65rem' }}>
+          {open ? '▼' : '▲'}
+        </span>
+      </div>
+
+      {/* Log lines */}
+      {open && (
+        <div style={{ height: 220, overflowY: 'auto', padding: '6px 14px' }}>
+          {lines.length === 0 ? (
+            <div style={{ color: 'var(--muted)', padding: '20px 0', textAlign: 'center' }}>No log lines yet.</div>
+          ) : (
+            lines.map((line, i) => (
+              <div key={i} style={{ color: LEVEL_COLOR[levelOf(line)], whiteSpace: 'pre-wrap', wordBreak: 'break-all', lineHeight: 1.5 }}>
+                {line}
+              </div>
+            ))
+          )}
+          <div ref={bottomRef} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/server.py
+++ b/server.py
@@ -9,6 +9,7 @@ Run with:
 
 from __future__ import annotations
 
+import collections
 import json
 import logging
 import os
@@ -92,6 +93,58 @@ from calibrator.session import (
 import calibrator.adb_control as _adb
 
 logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# In-memory log buffer — streams recent log records to the frontend
+# ---------------------------------------------------------------------------
+
+class _LogBuffer(logging.Handler):
+    """Circular buffer of recent log records with SSE subscriber support."""
+
+    MAX_LINES = 500
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._lines: collections.deque = collections.deque(maxlen=self.MAX_LINES)
+        self._subscribers: List[queue.Queue] = []
+        self._sub_lock = threading.Lock()
+        self.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(name)s — %(message)s", "%H:%M:%S"))
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            line = self.format(record)
+        except Exception:
+            return
+        self._lines.append(line)
+        with self._sub_lock:
+            subs = list(self._subscribers)
+        for q in subs:
+            try:
+                q.put_nowait(line)
+            except queue.Full:
+                pass
+
+    def snapshot(self) -> List[str]:
+        return list(self._lines)
+
+    def subscribe(self) -> queue.Queue:
+        q: queue.Queue = queue.Queue(maxsize=200)
+        with self._sub_lock:
+            self._subscribers.append(q)
+        return q
+
+    def unsubscribe(self, q: queue.Queue) -> None:
+        with self._sub_lock:
+            try:
+                self._subscribers.remove(q)
+            except ValueError:
+                pass
+
+
+_log_buffer = _LogBuffer()
+_log_buffer.setLevel(logging.DEBUG)
+logging.getLogger().addHandler(_log_buffer)
+logging.getLogger().setLevel(logging.DEBUG)
 
 app = FastAPI(title="ZRO Calibration Helper")
 
@@ -1272,6 +1325,7 @@ def watch_config(body: _WatchConfigBody):
             lambda: _save_session(sid),
             measurement_deserializer=_deserialize_measurement,
             grayscale_level_count=len(_grayscale_levels_for_ramp(session.get("grayscale_ramp_steps", 11))),
+            post_import_hook=lambda sess: _maybe_trigger_llm(sid, sess),
         )
     except ValueError as exc:
         raise HTTPException(400, str(exc)) from exc
@@ -1340,6 +1394,35 @@ def session_events(sid: str):
                     yield ": keep-alive\n\n"
         finally:
             _fw_unsubscribe(ev_queue)
+
+    return StreamingResponse(
+        _generator(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )
+
+
+@app.get("/api/logs/stream")
+def logs_stream():
+    q = _log_buffer.subscribe()
+
+    def _generator():
+        try:
+            # Send the recent buffer first so the panel populates immediately
+            for line in _log_buffer.snapshot():
+                yield f"data: {json.dumps(line)}\n\n"
+            while True:
+                try:
+                    line = q.get(timeout=20.0)
+                    yield f"data: {json.dumps(line)}\n\n"
+                except queue.Empty:
+                    yield ": keep-alive\n\n"
+        finally:
+            _log_buffer.unsubscribe(q)
 
     return StreamingResponse(
         _generator(),


### PR DESCRIPTION
## Summary

- **LLM fix**: Watch-folder CSV imports now trigger LLM analysis. Root cause was `_maybe_trigger_llm` was only wired to the manual HTTP upload endpoints, not the file watcher path. Fixed by adding a `post_import_hook` callback to `file_watcher.start_watching()` — server passes `lambda sess: _maybe_trigger_llm(sid, sess)` so every auto-import fires the same LLM pipeline as a manual upload.
- **Logs panel**: Fixed-position collapsible panel at the bottom of the page subscribes to a new `/api/logs/stream` SSE endpoint. Shows last 500 server log lines, colour-coded by level (warning = amber, error = red), with an error count badge and auto-scroll.

## Test plan

- [ ] Start watch folder, drop a ZRO CSV — confirm `LLM trigger sid=...` appears in the logs panel and an insight card appears
- [ ] Logs panel toggle (▲/▼ bar) opens/closes the log view
- [ ] Errors/warnings show in colour; error badge count increments
- [ ] All 448 existing tests pass (`python3 -m pytest tests/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)