### PR TITLE
feat: LLM engine overhaul — structured output, phase gates, TV profile schema, hardware settings (#95-#99)

### DIFF
--- a/calcore/__init__.py
+++ b/calcore/__init__.py
@@ -13,7 +13,7 @@ from .colour import (
     xyz_to_lab,
 )
 from .csv_import import parse_measurement_csv
-from .llm import call_llm
+from .llm import AdjustmentPlan, call_llm, parse_adjustment_plan
 from .models import (
     AnalysisConfig,
     CalMode,
@@ -26,8 +26,9 @@ from .models import (
     SDR_TARGET,
     SessionState,
     Summary,
+    TVSettings,
 )
-from .phase import determine_phase
+from .phase import check_cms_regression, determine_phase
 from .spaces import (
     BT2020_PRIMARIES,
     BT2020_RGB_TO_XYZ,
@@ -41,6 +42,7 @@ from .spaces import (
 )
 
 __all__ = [
+    "AdjustmentPlan",
     "AnalysisConfig",
     "BT2020_PRIMARIES",
     "BT2020_RGB_TO_XYZ",
@@ -60,14 +62,17 @@ __all__ = [
     "SDR_TARGET",
     "SessionState",
     "Summary",
+    "TVSettings",
     "XYZ_to_lab",
     "analyze",
     "call_llm",
+    "check_cms_regression",
     "ciede2000",
     "delta_e_cie76",
     "detect_matrix",
     "detect_primaries",
     "determine_phase",
+    "parse_adjustment_plan",
     "parse_measurement_csv",
     "rgb_to_xyz",
     "xyY_to_XYZ",

--- a/calcore/analysis.py
+++ b/calcore/analysis.py
@@ -161,4 +161,5 @@ def analyze(patches: List[Patch], cfg: AnalysisConfig) -> Summary:
             "target_space": cfg.target_space,
             "code_max": cfg.code_max,
         },
+        measured_patch_count=len(grayscale),
     )

--- a/calcore/llm.py
+++ b/calcore/llm.py
@@ -6,7 +6,7 @@ import urllib.request
 from dataclasses import asdict, dataclass
 from typing import Any, Dict, List, Optional
 
-from .models import AnalysisConfig, LLMConfig, Summary
+from .models import AnalysisConfig, LLMConfig, Summary, TVSettings
 
 
 def _top_offenders(summary: Summary) -> Dict[str, Any]:
@@ -44,12 +44,68 @@ def _top_offenders(summary: Summary) -> Dict[str, Any]:
     return result
 
 
+@dataclass
+class AdjustmentPlan:
+    """Structured LLM output: a list of hardware adjustments + next-step directive."""
+    adjustments: List[Dict[str, Any]]  # list of adjustment dicts per schema below
+    next_step: str                      # "rerun_grayscale" | "proceed_cms" | "rerun_wb" | "verify"
+    confidence: float                   # 0.0–1.0
+
+    # Adjustment dict schema (each item):
+    # {
+    #   "menu":    str         — TV menu name
+    #   "setting": str         — setting name
+    #   "from":    int|float   — current value (if known)
+    #   "to":      int|float   — target value
+    #   "scope":   "global" | "local"
+    #   "reason":  str         — 1-2 sentences, physics-based
+    # }
+
+
+def parse_adjustment_plan(text: str) -> Optional[AdjustmentPlan]:
+    """Parse a JSON LLM response into an AdjustmentPlan.
+
+    Strips markdown code fences if present (defensive, same pattern as
+    query_next_patch_strategy).  Returns None if the text cannot be parsed or
+    required fields are missing.
+    """
+    content = text.strip()
+    if content.startswith("```"):
+        parts = content.split("```")
+        content = parts[1] if len(parts) > 1 else content
+        if content.startswith("json"):
+            content = content[4:]
+        content = content.strip()
+    try:
+        obj = json.loads(content)
+    except (json.JSONDecodeError, ValueError):
+        return None
+
+    adjustments = obj.get("adjustments")
+    next_step = obj.get("next_step")
+    confidence = obj.get("confidence")
+
+    if not isinstance(adjustments, list) or not next_step:
+        return None
+
+    try:
+        return AdjustmentPlan(
+            adjustments=adjustments,
+            next_step=str(next_step),
+            confidence=float(confidence) if confidence is not None else 0.5,
+        )
+    except (TypeError, ValueError):
+        return None
+
+
 def build_llm_prompt(
     summary: Summary,
     cfg: AnalysisConfig,
     phase: str,
     guidance_context: Optional[str] = None,
     history_block: Optional[str] = None,
+    tv_settings: Optional[TVSettings] = None,
+    tv_schema: Optional[Dict[str, Any]] = None,
 ) -> str:
     # Exclude raw per-patch rows from the LLM payload — they waste tokens and
     # tempt the model to do per-patch math it can't reliably perform.
@@ -63,7 +119,7 @@ def build_llm_prompt(
     if top:
         summary_dict["top_offenders"] = top
 
-    payload = {
+    payload: Dict[str, Any] = {
         "phase": phase,
         "mode": cfg.mode,
         "eotf": cfg.eotf,
@@ -71,16 +127,42 @@ def build_llm_prompt(
         "summary": summary_dict,
     }
 
-    parts: List[str] = [
-        "You are a TV calibration co-pilot. Use the provided summary only. "
-        "Do not do new math. Do not invent missing data. "
-        "Return exactly one calibration step in this format:\n\n"
-        "> **Step [Phase.Step]:** [Action title]\n"
-        "> **Do this:** [Specific instruction]\n"
-        "> **Why:** [1-2 sentences]\n"
-        "> **Send me:** [What to send back]\n\n"
-        "If the data is insufficient, say exactly what is missing and stop.",
-    ]
+    # Inject current TV hardware slider values when supplied (#96)
+    if tv_settings is not None:
+        ts_dict = {k: v for k, v in asdict(tv_settings).items() if v is not None}
+        if ts_dict:
+            payload["current_tv_settings"] = ts_dict
+
+    # Inject TV model settings schema (ranges, menu paths) when available (#99)
+    if tv_schema:
+        payload["tv_settings_schema"] = tv_schema
+
+    # Structured JSON output schema instructions
+    schema_instructions = (
+        "Respond with ONLY a valid JSON object matching this exact schema "
+        "(no markdown, no prose outside the JSON):\n"
+        "{\n"
+        '  "adjustments": [\n'
+        '    {\n'
+        '      "menu": "<TV menu name>",\n'
+        '      "setting": "<setting name>",\n'
+        '      "from": <current value or null>,\n'
+        '      "to": <target value>,\n'
+        '      "scope": "global" | "local",\n'
+        '      "reason": "<1-2 sentences, physics-based>"\n'
+        '    }\n'
+        '  ],\n'
+        '  "next_step": "rerun_grayscale" | "proceed_cms" | "rerun_wb" | "verify",\n'
+        '  "confidence": <0.0-1.0>\n'
+        "}\n\n"
+        '"scope" distinguishes Global errors (2-point Gain/Offset) from Local errors '
+        "(multi-point / EOTF adjustment).\n"
+        "If the data is insufficient to produce adjustments, return an empty "
+        '"adjustments" array with "next_step": "rerun_grayscale" and '
+        '"confidence": 0.0.'
+    )
+
+    parts: List[str] = [schema_instructions]
 
     if history_block:
         parts.append(f"\nDISPLAY HISTORY (prior sessions for this TV):\n{history_block}")
@@ -112,6 +194,13 @@ def resolve_endpoint(endpoint: str) -> str:
     return endpoint
 
 
+_SYSTEM_PROMPT = (
+    "You are an expert Display Calibration Engine. "
+    "Identify the highest-dE errors and produce precise hardware adjustment deltas. "
+    "Respond only with valid JSON. No prose, no markdown, no explanations outside the JSON schema."
+)
+
+
 def call_llm(
     summary: Summary,
     cfg: AnalysisConfig,
@@ -119,20 +208,45 @@ def call_llm(
     llm: LLMConfig,
     guidance_context: Optional[str] = None,
     history_block: Optional[str] = None,
+    tv_settings: Optional[TVSettings] = None,
+    tv_schema: Optional[Dict[str, Any]] = None,
 ) -> Optional[str]:
-    """Call an OpenAI-compatible chat/completions endpoint (e.g. LiteLLM proxy)."""
+    """Call an OpenAI-compatible chat/completions endpoint (e.g. LiteLLM proxy).
+
+    Returns the raw JSON string from the model (to be parsed by
+    parse_adjustment_plan), or a deferred-message string when the sweep is
+    incomplete, or None if the LLM is not configured.
+    """
     if not llm.endpoint or not llm.model:
         return None
 
+    # Gate: defer analysis on partial sweeps (#97)
+    if not summary.is_sweep_complete:
+        measured = summary.measured_patch_count
+        expected = summary.expected_patch_count
+        expected_str = str(expected) if expected is not None else "?"
+        return (
+            f"Partial sweep received ({measured}/{expected_str} patches) "
+            f"— awaiting full {phase} sweep before providing adjustments."
+        )
+
     url = resolve_endpoint(llm.endpoint)
-    prompt = build_llm_prompt(summary, cfg, phase, guidance_context=guidance_context, history_block=history_block)
+    prompt = build_llm_prompt(
+        summary,
+        cfg,
+        phase,
+        guidance_context=guidance_context,
+        history_block=history_block,
+        tv_settings=tv_settings,
+        tv_schema=tv_schema,
+    )
     body = {
         "model": llm.model,
         "messages": [
-            {"role": "system", "content": "You are a strict calibration assistant."},
+            {"role": "system", "content": _SYSTEM_PROMPT},
             {"role": "user", "content": prompt},
         ],
-        "temperature": llm.temperature,
+        "temperature": 0.0,
     }
 
     data = json.dumps(body).encode("utf-8")

--- a/calcore/models.py
+++ b/calcore/models.py
@@ -68,6 +68,29 @@ class Summary:
     grayscale_rows: List[Dict[str, Any]]
     color_rows: List[Dict[str, Any]]
     meta: Dict[str, Any]
+    # Sweep completeness tracking — set by analyze() and checked by call_llm()
+    measured_patch_count: int = 0
+    expected_patch_count: Optional[int] = None
+
+    @property
+    def is_sweep_complete(self) -> bool:
+        """True when enough patches are present to support LLM analysis.
+
+        If ``expected_patch_count`` is set by the caller, the measured count
+        must meet or exceed it.  Otherwise a heuristic of ≥5 grayscale steps
+        is used so single-patch imports are silently deferred.
+        """
+        if self.expected_patch_count is not None:
+            return self.measured_patch_count >= self.expected_patch_count
+        return self.measured_patch_count >= 5
+
+
+@dataclass
+class TVSettings:
+    """Current TV hardware slider values supplied by the user for LLM context."""
+    two_point_wb: Optional[Dict[str, int]] = None    # e.g. {"R_gain": 0, "B_gain": -3}
+    multipoint_wb: Optional[Dict[str, Dict]] = None  # keyed by stimulus %
+    cms_sliders: Optional[Dict[str, Dict]] = None    # keyed by primary colour
 
 
 @dataclass
@@ -77,6 +100,7 @@ class SessionState:
     last_report_hash: str = ""
     config: AnalysisConfig = field(default_factory=AnalysisConfig)
     llm: LLMConfig = field(default_factory=LLMConfig)
+    grayscale_at_cms_entry: Optional[float] = None  # stored when CMS phase begins
 
 
 class CalMode(Enum):

--- a/calcore/phase.py
+++ b/calcore/phase.py
@@ -1,17 +1,32 @@
 from __future__ import annotations
 
+from typing import Optional
+
 from .models import Summary
+
+# Grayscale quality thresholds for CMS phase unlock.
+# Tightened per spec: avg < 0.5 dE, max < 1.0 dE.
+_GRAY_AVG_THRESHOLD = 0.5
+_GRAY_MAX_THRESHOLD = 1.0
+
+# If CMS adjustments shift grayscale dE by more than this, flag a WB re-run.
+_CMS_REGRESSION_THRESHOLD = 0.3
 
 
 def determine_phase(summary: Summary, prev_phase: str) -> str:
+    """Determine the next calibration phase based on current measurements.
+
+    Uses tightened grayscale thresholds (avg < 0.5, max < 1.0) to gate CMS
+    unlock per the sequential-dependency spec.
+    """
     # Heuristic phase progression.
     if prev_phase == "baseline":
         return "wb"
 
     gray_ok = (
         summary.grayscale_avg_de is not None
-        and summary.grayscale_avg_de <= 2.0
-        and (summary.grayscale_max_de or 999) <= 3.0
+        and summary.grayscale_avg_de < _GRAY_AVG_THRESHOLD
+        and (summary.grayscale_max_de or 999) < _GRAY_MAX_THRESHOLD
     )
     gamma_ok = True
     if summary.gamma_midtones is not None:
@@ -39,3 +54,30 @@ def determine_phase(summary: Summary, prev_phase: str) -> str:
         return "cms"
 
     return prev_phase
+
+
+def check_cms_regression(
+    summary: Summary,
+    baseline_de: float,
+    threshold: float = _CMS_REGRESSION_THRESHOLD,
+) -> Optional[str]:
+    """Return a warning string if CMS adjustments have regressed grayscale dE.
+
+    Call this after each CMS sweep, passing the grayscale_avg_de that was
+    recorded when CMS phase began.  Returns None when the shift is acceptable.
+
+    Args:
+        summary: Current measurement summary.
+        baseline_de: Grayscale avg dE at the moment CMS phase started.
+        threshold: Maximum tolerated increase in avg dE (default 0.3).
+    """
+    if summary.grayscale_avg_de is None:
+        return None
+    delta = summary.grayscale_avg_de - baseline_de
+    if delta > threshold:
+        return (
+            f"CMS adjustment shifted Grayscale dE by +{delta:.2f} "
+            f"(baseline {baseline_de:.2f} → current {summary.grayscale_avg_de:.2f}) "
+            f"— re-run White Balance"
+        )
+    return None

--- a/calibrator/__init__.py
+++ b/calibrator/__init__.py
@@ -17,6 +17,7 @@ from calcore import (
     Measurement,
     P3D65_PRIMARIES as P3_PRIMARIES,
     SDR_TARGET,
+    TVSettings,
     XYZ_to_lab,
     ciede2000,
     delta_e_cie76,
@@ -24,7 +25,7 @@ from calcore import (
     xyY_to_lab,
 )
 from .models import CalibrationReport
-from .profiles import TVProfile, TV_PROFILES, DEFAULT_TV_PROFILE
+from .profiles import TVProfile, TV_PROFILES, DEFAULT_TV_PROFILE, get_tv_profile
 from .runtime import REQUIRED_PACKAGES, console, ensure_packages
 from .guidance import (
     cms_control_plan,
@@ -69,7 +70,8 @@ __all__ = [
     "ciede2000", "delta_e_cie76", "delta_e_ciede2000_xyY", "xyY_to_XYZ", "XYZ_to_lab", "xyY_to_lab",
     "delta_xy", "gamma_from_luminance", "rating_emoji", "direction_hint",
     "stimulus_pct_from_code_value",
-    "TVProfile", "TV_PROFILES", "DEFAULT_TV_PROFILE",
+    "TVProfile", "TV_PROFILES", "DEFAULT_TV_PROFILE", "get_tv_profile",
+    "TVSettings",
     "wb_hints", "wb_control_plan", "wb_recommendations",
     "gamma_recommendations", "u8g_gamma_control_plan", "preset_gamma_control_plan",
     "luminance_control_plan",

--- a/calibrator/profiles.py
+++ b/calibrator/profiles.py
@@ -7,7 +7,7 @@ registering it in TV_PROFILES.
 """
 
 from dataclasses import dataclass, field
-from typing import Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from calcore.models import CalMode
 
@@ -63,6 +63,10 @@ class TVProfile:
     # Optional hidden / service menu instructions
     SERVICE_MENU_ACCESS: str = ""
     SERVICE_MENU_CONTROLS: List[Tuple[str, str]] = field(default_factory=list)
+
+    # Machine-readable settings schema for LLM injection (#99).
+    # Maps setting key → dict with type, path, options/range, and dependency info.
+    llm_schema: Dict[str, Any] = field(default_factory=dict)
 
 
 def _build_u8g_profile() -> TVProfile:
@@ -151,6 +155,109 @@ def _build_u8g_profile() -> TVProfile:
             ("Sharpness",                              "0  (no edge enhancement — sharpening can corrupt near-white patch readings)"),
         ],
         supported_gamuts=["bt709", "p3d65", "bt2020"],
+        llm_schema={
+            "model": "Hisense U8G",
+            "variants": ["55U8G", "65U8G", "75U8G"],
+            "nomenclature": {
+                "backlight": {
+                    "term": "Backlight Level",
+                    "function": "Overall panel illumination (nits). Sets peak white output. Does NOT affect black crush.",
+                    "path": "Settings > Picture > Backlight > Backlight Level",
+                },
+                "black_level": {
+                    "term": "Brightness",
+                    "function": "Black level control. Sets the point where shadow detail clips. Calibration: set so near-black test patterns are just visible.",
+                    "path": "Settings > Picture > Brightness",
+                },
+            },
+            "settings": {
+                "gamma": {
+                    "path": "Settings > Picture > Calibration settings > Gamma",
+                    "type": "enum",
+                    "options": [2.0, 2.2, 2.4],
+                    "increment": 0.2,
+                    "default": 2.2,
+                    "calibration_target": 2.4,
+                    "note": "Only these three values available as presets.",
+                },
+                "local_dimming": {
+                    "path": "Settings > Picture > Backlight > Dynamic Backlight Control",
+                    "type": "enum",
+                    "options": ["Off", "Low", "Medium", "High"],
+                    "zones": 360,
+                    "calibration_note": "Set High for HDR measurement; Off only as troubleshooting cross-check.",
+                },
+                "color_space": {
+                    "path": "Settings > Picture > Advanced Settings > Color Space",
+                    "type": "enum",
+                    "options": ["Auto", "BT.709", "Rec.2020"],
+                },
+                "color_temperature": {
+                    "path": "Settings > Picture > Advanced Settings > Color Temperature",
+                    "type": "enum",
+                    "options": ["Warm", "Cool"],
+                    "calibration_target": "Warm",
+                },
+                "white_balance_2pt": {
+                    "path": "Settings > Picture > Calibration settings > White Balance > 2 Point",
+                    "type": "slider",
+                    "channels": {
+                        "R_gain": {"label": "R-Gain", "affects": "red highlights (80-100% gray)"},
+                        "G_gain": {"label": "G-Gain", "affects": "green highlights (80-100% gray)"},
+                        "B_gain": {"label": "B-Gain", "affects": "blue highlights (80-100% gray)"},
+                        "R_offset": {"label": "R-Offset", "affects": "red shadows (20-30% gray)"},
+                        "G_offset": {"label": "G-Offset", "affects": "green shadows (20-30% gray)"},
+                        "B_offset": {"label": "B-Offset", "affects": "blue shadows (20-30% gray)"},
+                    },
+                    "neutral_value": 0,
+                    "note": "Start with 2-point. Leave 20-point untouched until 2-point is already close.",
+                },
+                "white_balance_20pt": {
+                    "path": "Settings > Picture > Calibration settings > White Balance > 20 Point",
+                    "type": "multipoint",
+                    "step_pct_options": [5, 10],
+                    "neutral_value": 0,
+                    "note": "Used for fine grayscale tracking after 2-point is close.",
+                },
+                "cms": {
+                    "path": "Settings > Picture > Calibration settings > Color Tuner",
+                    "type": "cms",
+                    "colors": ["Red", "Green", "Blue", "Cyan", "Magenta", "Yellow"],
+                    "params": {
+                        "Hue": "Shifts relative colour angle.",
+                        "Saturation": "Adjusts purity / vibrancy.",
+                        "Brightness": "Controls luminance of that specific colour.",
+                    },
+                    "neutral_value": 0,
+                    "note": "Zero all CMS values before loading a 3D LUT (ColourSpace, Calman).",
+                },
+                "contrast": {
+                    "path": "Settings > Picture > Contrast",
+                    "type": "slider",
+                    "calibration_default": 90,
+                    "note": "Controls peak white levels. Back down if 100% whites clip.",
+                },
+                "brightness": {
+                    "path": "Settings > Picture > Brightness",
+                    "type": "slider",
+                    "calibration_default": 50,
+                    "note": "Black level control — NOT luminance. Set so 5% near-black is just visible.",
+                },
+                "active_contrast": {
+                    "path": "Settings > Picture > Advanced Settings > Active Contrast",
+                    "type": "toggle",
+                    "calibration_value": "Off",
+                    "note": "Auto local contrast — disable during calibration.",
+                },
+                "hdmi_dynamic_range": {
+                    "path": "Settings > Picture > Advanced Settings > HDMI Dynamic Range",
+                    "type": "enum",
+                    "options": ["Auto", "Full"],
+                    "dependency": "Only available when HDMI input is active.",
+                    "calibration_note": "Set Auto (or Full if PC source).",
+                },
+            },
+        },
     )
 
 
@@ -493,3 +600,11 @@ TV_PROFILES: Dict[str, TVProfile] = {
 }
 
 DEFAULT_TV_PROFILE = "u8g"
+
+
+def get_tv_profile(model_name: str) -> Optional[TVProfile]:
+    """Return the TVProfile for the given model key, or None if not found.
+
+    Accepts the short_name key used in TV_PROFILES (e.g. "u8g", "tcl7105x").
+    """
+    return TV_PROFILES.get(model_name)

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -41,6 +41,7 @@ import { PostGrayscale } from './pages/PostGrayscale';
 import { Report }        from './pages/Report';
 import { ConfirmModal }  from './components/ConfirmModal';
 import { LlmInsightCard } from './components/LlmInsightCard';
+import { TvSettingsInput } from './components/TvSettingsInput';
 import { LogsPanel }     from './components/LogsPanel';
 
 function QualityDot({ gate }) {
@@ -94,7 +95,7 @@ function scrollToCard(id) {
 export default function App() {
   const sess = useSession();
   const { session, profiles, watchStatus, watchDefaultPath, bridgeStatus, bridgeUrl, dogegenStatus, adbStatus, loading,
-          llmInsight, llmStreaming, llmError, dismissLlmInsight } = sess;
+          llmInsight, llmStreaming, llmError, dismissLlmInsight, saveTvSettings } = sess;
   const [showStartOver, setShowStartOver] = useState(false);
 
   function handleStartOver() {
@@ -207,6 +208,9 @@ export default function App() {
 
       {/* Main content */}
       <main className="main">
+        {session && saveTvSettings && (
+          <TvSettingsInput onSave={saveTvSettings} />
+        )}
         <LlmInsightCard
           insight={llmInsight}
           streaming={llmStreaming}

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -92,6 +92,7 @@ export const api = {
   // LLM
   configureLlm:  (sid, body)  => api.post(`/api/session/${sid}/llm/configure`, body),
   getLlmStatus:  (sid)        => api.get(`/api/session/${sid}/llm/status`),
+  saveTvSettings: (sid, body) => api.post(`/api/session/${sid}/tv-settings`, body),
 
   // Report
   getReport:     (sid)        => api.get(`/api/session/${sid}/report`),

--- a/frontend/src/components/LlmInsightCard.jsx
+++ b/frontend/src/components/LlmInsightCard.jsx
@@ -2,13 +2,105 @@
  * LlmInsightCard — displays the latest AI assistant insight received via SSE.
  *
  * Props:
- *   insight    — { text: string, phase: string, timestamp: string } | null
+ *   insight    — { text: string, plan: AdjustmentPlan|null, phase: string, timestamp: string } | null
  *   streaming  — bool, true while the LLM is generating
  *   error      — string | null
  *   onDismiss  — () => void
+ *
+ * AdjustmentPlan shape (from calcore/llm.py):
+ *   { adjustments: [{menu, setting, from, to, scope, reason}], next_step, confidence }
  */
+
+const NEXT_STEP_LABEL = {
+  rerun_grayscale: 'Re-run Grayscale',
+  proceed_cms:     'Proceed to CMS',
+  rerun_wb:        'Re-run White Balance',
+  verify:          'Verify / Done',
+};
+
+const SCOPE_BADGE = {
+  global: { label: 'Global', color: 'var(--accent)' },
+  local:  { label: 'Local',  color: 'var(--yellow, #f0a500)' },
+};
+
+function AdjustmentRow({ adj }) {
+  const scope = SCOPE_BADGE[adj.scope] || { label: adj.scope || '—', color: 'var(--muted)' };
+  const fromStr = adj.from != null ? String(adj.from) : '?';
+  const toStr   = adj.to   != null ? String(adj.to)   : '?';
+  return (
+    <div style={{ padding: '8px 0', borderBottom: '1px solid var(--border-subtle, rgba(255,255,255,0.06))' }}>
+      <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, flexWrap: 'wrap' }}>
+        <span style={{ fontWeight: 600, fontSize: '0.83rem', color: 'var(--text)' }}>
+          {adj.setting}
+        </span>
+        <span style={{ fontSize: '0.75rem', color: 'var(--muted)' }}>
+          {adj.menu}
+        </span>
+        <span style={{
+          marginLeft: 'auto',
+          fontSize: '0.72rem',
+          fontWeight: 700,
+          color: scope.color,
+          textTransform: 'uppercase',
+          letterSpacing: '0.06em',
+        }}>
+          {scope.label}
+        </span>
+      </div>
+      <div style={{ fontSize: '0.82rem', color: 'var(--accent)', marginTop: 2 }}>
+        {fromStr} → {toStr}
+      </div>
+      {adj.reason && (
+        <div style={{ fontSize: '0.79rem', color: 'var(--muted)', marginTop: 3, lineHeight: 1.5 }}>
+          {adj.reason}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function AdjustmentPlanView({ plan }) {
+  const nextLabel = NEXT_STEP_LABEL[plan.next_step] || plan.next_step;
+  const confidencePct = Math.round((plan.confidence ?? 0) * 100);
+  return (
+    <div style={{ padding: '10px 14px' }}>
+      {plan.adjustments.length === 0 ? (
+        <div style={{ fontSize: '0.82rem', color: 'var(--muted)', fontStyle: 'italic' }}>
+          No adjustments needed — data insufficient or sweep complete.
+        </div>
+      ) : (
+        <>
+          <div style={{ fontSize: '0.72rem', fontWeight: 700, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--muted)', marginBottom: 6 }}>
+            Required Adjustments
+          </div>
+          {plan.adjustments.map((adj, i) => (
+            <AdjustmentRow key={i} adj={adj} />
+          ))}
+        </>
+      )}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginTop: 10 }}>
+        <div style={{
+          flex: 1,
+          background: 'var(--surface3, rgba(255,255,255,0.05))',
+          borderRadius: 6,
+          padding: '5px 10px',
+          fontSize: '0.8rem',
+        }}>
+          <span style={{ color: 'var(--muted)', marginRight: 6 }}>Next Step:</span>
+          <span style={{ fontWeight: 600, color: 'var(--text)' }}>{nextLabel}</span>
+        </div>
+        <div style={{ fontSize: '0.75rem', color: 'var(--muted)', whiteSpace: 'nowrap' }}>
+          Confidence {confidencePct}%
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export function LlmInsightCard({ insight, streaming, error, onDismiss }) {
   if (!streaming && !insight && !error) return null;
+
+  const hasPlan = insight?.plan && Array.isArray(insight.plan.adjustments);
 
   return (
     <div style={{
@@ -28,7 +120,7 @@ export function LlmInsightCard({ insight, streaming, error, onDismiss }) {
         borderBottom: `1px solid ${error ? 'rgba(231,76,60,0.2)' : 'rgba(0,180,216,0.2)'}`,
       }}>
         <span style={{ fontSize: '0.72rem', fontWeight: 700, letterSpacing: '0.1em', textTransform: 'uppercase', color: error ? 'var(--red)' : 'var(--accent)', flexGrow: 1 }}>
-          {error ? 'AI Assistant — Error' : 'AI Assistant'}
+          {error ? 'AI Assistant — Error' : hasPlan ? 'Adjustment Plan' : 'AI Assistant'}
           {insight?.phase && !error && (
             <span style={{ marginLeft: 8, fontWeight: 400, color: 'var(--muted)', textTransform: 'none', letterSpacing: 0 }}>
               · {insight.phase}
@@ -63,7 +155,10 @@ export function LlmInsightCard({ insight, streaming, error, onDismiss }) {
           {error}
         </div>
       )}
-      {insight?.text && (
+      {hasPlan && (
+        <AdjustmentPlanView plan={insight.plan} />
+      )}
+      {!hasPlan && insight?.text && (
         <div style={{ padding: '12px 14px', fontSize: '0.84rem', lineHeight: 1.65, whiteSpace: 'pre-wrap', color: 'var(--text)' }}>
           {insight.text}
         </div>

--- a/frontend/src/components/TvSettingsInput.jsx
+++ b/frontend/src/components/TvSettingsInput.jsx
@@ -1,0 +1,124 @@
+/**
+ * TvSettingsInput — collapsible JSON paste field for current TV hardware slider values.
+ *
+ * Allows the user to paste their current WB/CMS slider values so the LLM can
+ * compute specific "Change from X to Y" deltas rather than reasoning in a vacuum.
+ *
+ * Props:
+ *   onSave — async (payload) => void  — called with the parsed TVSettings object
+ */
+import { useState } from 'react';
+
+const PLACEHOLDER = JSON.stringify(
+  {
+    two_point_wb: { R_gain: 0, G_gain: 0, B_gain: -3, R_offset: 0, G_offset: 0, B_offset: 2 },
+    cms_sliders: {
+      Red:     { Hue: 0, Saturation: 0, Brightness: 0 },
+      Green:   { Hue: 0, Saturation: 0, Brightness: 0 },
+      Blue:    { Hue: 0, Saturation: 0, Brightness: 0 },
+    },
+  },
+  null,
+  2,
+);
+
+export function TvSettingsInput({ onSave }) {
+  const [open, setOpen] = useState(false);
+  const [text, setText] = useState('');
+  const [status, setStatus] = useState(null); // 'saved' | 'error' | null
+  const [errorMsg, setErrorMsg] = useState('');
+
+  async function handleSave() {
+    setStatus(null);
+    setErrorMsg('');
+    let parsed;
+    try {
+      parsed = JSON.parse(text.trim() || '{}');
+    } catch (e) {
+      setStatus('error');
+      setErrorMsg('Invalid JSON: ' + e.message);
+      return;
+    }
+    try {
+      await onSave(parsed);
+      setStatus('saved');
+      setTimeout(() => setStatus(null), 3000);
+    } catch (e) {
+      setStatus('error');
+      setErrorMsg(e.message || 'Save failed');
+    }
+  }
+
+  return (
+    <div style={{ margin: '0 0 10px 0' }}>
+      <button
+        onClick={() => setOpen(o => !o)}
+        style={{
+          background: 'none',
+          border: 'none',
+          color: 'var(--muted)',
+          cursor: 'pointer',
+          fontSize: '0.75rem',
+          padding: '2px 0',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 5,
+          fontFamily: 'inherit',
+        }}
+      >
+        <span style={{ fontSize: '0.65rem' }}>{open ? '▾' : '▸'}</span>
+        Current TV Settings (for LLM context)
+      </button>
+
+      {open && (
+        <div style={{
+          marginTop: 6,
+          background: 'var(--surface2)',
+          border: '1px solid var(--border-subtle, rgba(255,255,255,0.08))',
+          borderRadius: 'var(--radius-md, 6px)',
+          padding: '10px 12px',
+        }}>
+          <div style={{ fontSize: '0.75rem', color: 'var(--muted)', marginBottom: 6, lineHeight: 1.5 }}>
+            Paste your current WB / CMS slider values as JSON. The LLM will use these
+            to compute specific "from → to" adjustment deltas.
+          </div>
+          <textarea
+            value={text}
+            onChange={e => setText(e.target.value)}
+            placeholder={PLACEHOLDER}
+            rows={10}
+            spellCheck={false}
+            style={{
+              width: '100%',
+              fontFamily: 'monospace',
+              fontSize: '0.76rem',
+              background: 'var(--surface3, rgba(0,0,0,0.2))',
+              color: 'var(--text)',
+              border: `1px solid ${status === 'error' ? 'var(--red)' : 'var(--border-subtle, rgba(255,255,255,0.1))'}`,
+              borderRadius: 4,
+              padding: '6px 8px',
+              resize: 'vertical',
+              boxSizing: 'border-box',
+              outline: 'none',
+            }}
+          />
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginTop: 6 }}>
+            <button
+              onClick={handleSave}
+              className="btn btn-primary"
+              style={{ fontSize: '0.78rem', padding: '4px 14px' }}
+            >
+              Save Settings
+            </button>
+            {status === 'saved' && (
+              <span style={{ fontSize: '0.75rem', color: 'var(--green)' }}>Saved</span>
+            )}
+            {status === 'error' && (
+              <span style={{ fontSize: '0.75rem', color: 'var(--red)' }}>{errorMsg}</span>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/hooks/useSession.js
+++ b/frontend/src/hooks/useSession.js
@@ -366,6 +366,11 @@ export function useSession() {
     return api.getLlmStatus(session.id);
   }
 
+  async function saveTvSettings(payload) {
+    if (!session?.id) return;
+    return api.saveTvSettings(session.id, payload);
+  }
+
   function dismissLlmInsight() {
     setLlmInsight(null);
     setLlmError(null);
@@ -378,7 +383,7 @@ export function useSession() {
     saveBridgeUrl, triggerMeasure, refreshBridgeStatus,
     saveDogegenConfig, startDogegen, stopDogegen, refreshDogegenStatus,
     adbDeploy, adbApply, adbReset, adbSetPicture, adbGetPicture, refreshAdbStatus,
-    configureLlm, getLlmStatus,
+    configureLlm, getLlmStatus, saveTvSettings,
     llmInsight, llmStreaming, llmError, dismissLlmInsight,
     reload,
   };

--- a/server.py
+++ b/server.py
@@ -36,14 +36,15 @@ from calcore.gamut import (
 from calcore.llm import (
     build_history_block as _build_history_block,
     call_llm as _call_llm,
+    parse_adjustment_plan as _parse_adjustment_plan,
     probe_llm as _probe_llm,
     query_gamut_advice as _query_gamut_advice,
     query_next_patch_strategy as _query_next_patch_strategy,
     query_remediation as _query_remediation,
 )
-from calcore.models import AnalysisConfig, LLMConfig, Patch
+from calcore.models import AnalysisConfig, LLMConfig, Patch, TVSettings
 from calcore.phase import determine_phase as _determine_phase
-from calibrator import TV_PROFILES
+from calibrator import TV_PROFILES, get_tv_profile as _get_tv_profile
 from calibrator.history import (
     history_summary as _history_summary,
     load_baseline as _load_baseline,
@@ -311,6 +312,13 @@ class _AdbPictureGetReq(BaseModel):
     device: Optional[str] = None
 
 
+class TvSettingsReq(BaseModel):
+    """Current TV hardware slider values for LLM context (#96)."""
+    two_point_wb: Optional[Dict[str, int]] = None
+    multipoint_wb: Optional[Dict[str, Any]] = None
+    cms_sliders: Optional[Dict[str, Any]] = None
+
+
 class _ZroBridgeConfigBody(BaseModel):
     url: str
 
@@ -576,6 +584,7 @@ def _run_llm_background(
     llm_cfg: LLMConfig,
     tv_key: str = "",
     session_step_history: Optional[List[Dict[str, Any]]] = None,
+    tv_settings: Optional[TVSettings] = None,
 ) -> None:
     logger.info("LLM run started  sid=%s phase=%s endpoint=%s model=%s",
                 sid, phase, llm_cfg.endpoint, llm_cfg.model)
@@ -597,19 +606,38 @@ def _run_llm_background(
             except Exception:
                 pass  # history is advisory; never block the main LLM call
 
+        # Inject TV settings schema when the TV model is known (#99)
+        tv_schema: Optional[Dict[str, Any]] = None
+        if tv_key:
+            profile = _get_tv_profile(tv_key)
+            if profile and profile.llm_schema:
+                tv_schema = profile.llm_schema
+
         result = _call_llm(
             summary,
             cfg,
             phase,
             llm_cfg,
             history_block=history_block,
+            tv_settings=tv_settings,
+            tv_schema=tv_schema,
         )
         logger.info("LLM run complete sid=%s phase=%s chars=%d", sid, phase, len(result or ""))
+
+        # Attempt to parse structured AdjustmentPlan from the JSON response (#95)
+        plan_data: Optional[Dict[str, Any]] = None
+        if result:
+            plan = _parse_adjustment_plan(result)
+            if plan is not None:
+                from dataclasses import asdict as _asdict
+                plan_data = _asdict(plan)
+
         _llm_broadcast(sid, {
             "event": "llm_insight",
             "data": {
                 "phase": phase,
                 "text": result,
+                "plan": plan_data,
                 "timestamp": datetime.utcnow().isoformat() + "Z",
             },
         })
@@ -675,12 +703,23 @@ def _maybe_trigger_llm(sid: str, session: Dict[str, Any]) -> None:
     has_key = bool(llm_cfg_dict.get("api_key"))
     logger.info("LLM trigger  sid=%s step=%s patches=%d has_api_key=%s",
                 sid, session.get("step", "baseline"), len(patches), has_key)
+    # Reconstruct TVSettings from session if the user supplied slider values (#96)
+    tv_settings: Optional[TVSettings] = None
+    raw_tv_settings = session.get("tv_settings")
+    if raw_tv_settings:
+        tv_settings = TVSettings(
+            two_point_wb=raw_tv_settings.get("two_point_wb"),
+            multipoint_wb=raw_tv_settings.get("multipoint_wb"),
+            cms_sliders=raw_tv_settings.get("cms_sliders"),
+        )
+
     threading.Thread(
         target=_run_llm_background,
         args=(sid, patches, cfg, session.get("step", "baseline"), llm_cfg),
         kwargs={
             "tv_key": session.get("tv_key", ""),
             "session_step_history": session.get("llm_step_history", []),
+            "tv_settings": tv_settings,
         },
         daemon=True,
     ).start()
@@ -872,6 +911,19 @@ def configure_llm(sid: str, req: LlmConfigureReq):
         "configured": configured,
         "model": llm_cfg.get("model", ""),
     }
+
+
+@app.post("/api/session/{sid}/tv-settings")
+def set_tv_settings(sid: str, req: TvSettingsReq):
+    """Store current TV hardware slider values in the session for LLM context (#96)."""
+    session = store.get(sid)
+    session["tv_settings"] = {
+        "two_point_wb": req.two_point_wb,
+        "multipoint_wb": req.multipoint_wb,
+        "cms_sliders": req.cms_sliders,
+    }
+    _save_session(sid)
+    return {"stored": True}
 
 
 @app.get("/api/session/{sid}/llm/status")

--- a/tests/test_calcore/test_calcore.py
+++ b/tests/test_calcore/test_calcore.py
@@ -1,3 +1,4 @@
+import json
 import tempfile
 import textwrap
 import unittest
@@ -6,7 +7,8 @@ from unittest import mock
 
 import cli
 from calcore import AnalysisConfig, Patch, SessionState, Summary, analyze, determine_phase, parse_measurement_csv
-from calcore.llm import _resolve_endpoint
+from calcore.llm import _resolve_endpoint, parse_adjustment_plan, build_llm_prompt
+from calcore.phase import check_cms_regression
 
 
 class ParseMeasurementCsvTests(unittest.TestCase):
@@ -127,9 +129,10 @@ class AnalyzeTests(unittest.TestCase):
 
 class DeterminePhaseTests(unittest.TestCase):
     def make_summary(self, **overrides):
+        # Default grayscale values pass the tightened threshold (avg < 0.5, max < 1.0)
         base = dict(
-            grayscale_avg_de=1.0,
-            grayscale_max_de=2.0,
+            grayscale_avg_de=0.4,
+            grayscale_max_de=0.8,
             grayscale_over_3=0,
             gamma_midtones=2.2,
             pq_err_midtones=None,
@@ -158,6 +161,189 @@ class DeterminePhaseTests(unittest.TestCase):
     def test_wb_stays_mpwb_when_grayscale_needs_more_work(self):
         summary = self.make_summary(grayscale_avg_de=2.5, grayscale_max_de=3.5)
         self.assertEqual(determine_phase(summary, "wb"), "mpwb")
+
+    # Tightened threshold boundary tests (#98)
+    def test_wb_advances_to_cms_at_tightened_threshold(self):
+        # avg=0.4 (< 0.5) and max=0.8 (< 1.0) → should unlock CMS
+        summary = self.make_summary(grayscale_avg_de=0.4, grayscale_max_de=0.8)
+        self.assertEqual(determine_phase(summary, "wb"), "cms")
+
+    def test_wb_stays_mpwb_just_above_avg_threshold(self):
+        # avg=0.6 (>= 0.5) → should remain mpwb even if max is fine
+        summary = self.make_summary(grayscale_avg_de=0.6, grayscale_max_de=0.8)
+        self.assertEqual(determine_phase(summary, "wb"), "mpwb")
+
+    def test_wb_stays_mpwb_just_above_max_threshold(self):
+        # avg passes but max=1.1 (>= 1.0) → should remain mpwb
+        summary = self.make_summary(grayscale_avg_de=0.4, grayscale_max_de=1.1)
+        self.assertEqual(determine_phase(summary, "wb"), "mpwb")
+
+
+class CheckCmsRegressionTests(unittest.TestCase):
+    def make_summary(self, grayscale_avg_de):
+        return Summary(
+            grayscale_avg_de=grayscale_avg_de,
+            grayscale_max_de=0.5,
+            grayscale_over_3=0,
+            gamma_midtones=2.2,
+            pq_err_midtones=None,
+            color_75_avg_de=None,
+            color_75_max_de=None,
+            color_75_chroma_avg=None,
+            color_100_avg_de=None,
+            color_100_max_de=None,
+            color_100_chroma_avg=None,
+            grayscale_rows=[],
+            color_rows=[],
+            meta={},
+        )
+
+    def test_no_regression_returns_none(self):
+        # baseline 0.3, current 0.4 — delta 0.1 < threshold 0.3
+        summary = self.make_summary(grayscale_avg_de=0.4)
+        self.assertIsNone(check_cms_regression(summary, baseline_de=0.3))
+
+    def test_regression_above_threshold_returns_warning(self):
+        # baseline 0.3, current 0.7 — delta 0.4 > threshold 0.3
+        summary = self.make_summary(grayscale_avg_de=0.7)
+        result = check_cms_regression(summary, baseline_de=0.3)
+        self.assertIsNotNone(result)
+        self.assertIn("re-run White Balance", result)
+
+    def test_none_grayscale_de_returns_none(self):
+        summary = self.make_summary(grayscale_avg_de=None)
+        self.assertIsNone(check_cms_regression(summary, baseline_de=0.3))
+
+
+class SweepGateTests(unittest.TestCase):
+    """Tests for the partial-sweep LLM gate (#97)."""
+
+    def make_summary(self, measured_patch_count=0, expected_patch_count=None):
+        return Summary(
+            grayscale_avg_de=0.4,
+            grayscale_max_de=0.8,
+            grayscale_over_3=0,
+            gamma_midtones=2.2,
+            pq_err_midtones=None,
+            color_75_avg_de=None,
+            color_75_max_de=None,
+            color_75_chroma_avg=None,
+            color_100_avg_de=None,
+            color_100_max_de=None,
+            color_100_chroma_avg=None,
+            grayscale_rows=[],
+            color_rows=[],
+            meta={},
+            measured_patch_count=measured_patch_count,
+            expected_patch_count=expected_patch_count,
+        )
+
+    def test_partial_sweep_is_incomplete(self):
+        summary = self.make_summary(measured_patch_count=3)
+        self.assertFalse(summary.is_sweep_complete)
+
+    def test_full_sweep_is_complete(self):
+        summary = self.make_summary(measured_patch_count=10)
+        self.assertTrue(summary.is_sweep_complete)
+
+    def test_expected_count_gates_completion(self):
+        summary = self.make_summary(measured_patch_count=8, expected_patch_count=21)
+        self.assertFalse(summary.is_sweep_complete)
+
+    def test_expected_count_unlocks_when_met(self):
+        summary = self.make_summary(measured_patch_count=21, expected_patch_count=21)
+        self.assertTrue(summary.is_sweep_complete)
+
+
+class ParseAdjustmentPlanTests(unittest.TestCase):
+    """Tests for parse_adjustment_plan (#95)."""
+
+    VALID_JSON = json.dumps({
+        "adjustments": [
+            {
+                "menu": "White Balance",
+                "setting": "B-Gain",
+                "from": 0,
+                "to": -3,
+                "scope": "global",
+                "reason": "Blue push at 80% lifting xy above D65 locus.",
+            }
+        ],
+        "next_step": "rerun_grayscale",
+        "confidence": 0.85,
+    })
+
+    def test_parses_valid_json(self):
+        plan = parse_adjustment_plan(self.VALID_JSON)
+        self.assertIsNotNone(plan)
+        self.assertEqual(len(plan.adjustments), 1)
+        self.assertEqual(plan.adjustments[0]["setting"], "B-Gain")
+        self.assertEqual(plan.next_step, "rerun_grayscale")
+        self.assertAlmostEqual(plan.confidence, 0.85)
+
+    def test_strips_markdown_fences(self):
+        fenced = f"```json\n{self.VALID_JSON}\n```"
+        plan = parse_adjustment_plan(fenced)
+        self.assertIsNotNone(plan)
+        self.assertEqual(plan.next_step, "rerun_grayscale")
+
+    def test_returns_none_for_invalid_json(self):
+        self.assertIsNone(parse_adjustment_plan("not json at all"))
+
+    def test_returns_none_when_adjustments_missing(self):
+        bad = json.dumps({"next_step": "verify", "confidence": 1.0})
+        self.assertIsNone(parse_adjustment_plan(bad))
+
+    def test_empty_adjustments_list_is_valid(self):
+        empty = json.dumps({"adjustments": [], "next_step": "rerun_grayscale", "confidence": 0.0})
+        plan = parse_adjustment_plan(empty)
+        self.assertIsNotNone(plan)
+        self.assertEqual(plan.adjustments, [])
+
+
+class BuildLlmPromptTests(unittest.TestCase):
+    """Tests for build_llm_prompt changes (#95, #96, #99)."""
+
+    def make_summary(self):
+        return Summary(
+            grayscale_avg_de=0.4,
+            grayscale_max_de=0.8,
+            grayscale_over_3=0,
+            gamma_midtones=2.2,
+            pq_err_midtones=None,
+            color_75_avg_de=None,
+            color_75_max_de=None,
+            color_75_chroma_avg=None,
+            color_100_avg_de=None,
+            color_100_max_de=None,
+            color_100_chroma_avg=None,
+            grayscale_rows=[],
+            color_rows=[],
+            meta={},
+            measured_patch_count=10,
+        )
+
+    def test_prompt_requests_json_output(self):
+        cfg = AnalysisConfig(mode="sdr", eotf="gamma22", target_space="bt709")
+        prompt = build_llm_prompt(self.make_summary(), cfg, "wb")
+        self.assertIn('"adjustments"', prompt)
+        self.assertIn('"next_step"', prompt)
+        self.assertIn('"confidence"', prompt)
+
+    def test_tv_settings_injected_when_provided(self):
+        from calcore.models import TVSettings
+        cfg = AnalysisConfig(mode="sdr", eotf="gamma22", target_space="bt709")
+        settings = TVSettings(two_point_wb={"R_gain": 0, "B_gain": -3})
+        prompt = build_llm_prompt(self.make_summary(), cfg, "wb", tv_settings=settings)
+        self.assertIn("current_tv_settings", prompt)
+        self.assertIn("B_gain", prompt)
+
+    def test_tv_schema_injected_when_provided(self):
+        cfg = AnalysisConfig(mode="sdr", eotf="gamma22", target_space="bt709")
+        schema = {"model": "Hisense U8G", "settings": {"gamma": {"options": [2.0, 2.2, 2.4]}}}
+        prompt = build_llm_prompt(self.make_summary(), cfg, "wb", tv_schema=schema)
+        self.assertIn("tv_settings_schema", prompt)
+        self.assertIn("Hisense U8G", prompt)
 
 
 class ResolveEndpointTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

Implements all 5 open enhancement issues in dependency order:

- **#98 — Phase gate tightening + CMS regression detection**
  - `calcore/phase.py`: CMS unlock threshold tightened to avg dE < 0.5 / max dE < 1.0 (was 2.0/3.0)
  - New `check_cms_regression(summary, baseline_de)` function — returns warning string when CMS adjustments shift grayscale dE > 0.3
  - `calcore/models.py`: `grayscale_at_cms_entry` field added to `SessionState`

- **#97 — Full-sweep state gate**
  - `Summary` gains `measured_patch_count`, `expected_patch_count`, and `is_sweep_complete` property
  - `analyze()` populates `measured_patch_count` from grayscale patch count
  - `call_llm()` returns a deferred message (no HTTP call) when `is_sweep_complete` is False

- **#95 — LLM persona + structured JSON output**
  - System prompt updated to Display Calibration Engine persona
  - `build_llm_prompt` now requests structured JSON (`AdjustmentPlan` schema) instead of freeform markdown
  - New `AdjustmentPlan` dataclass and `parse_adjustment_plan()` parser (strips markdown fences)
  - Temperature locked to 0.0 for deterministic output
  - `LlmInsightCard` renders a structured adjustments table + Next Step badge when a valid plan is returned; falls back to raw text for deferred/error responses

- **#99 — Hisense U8G LLM settings schema**
  - `TVProfile` gains `llm_schema: Dict[str, Any]` field
  - U8G profile populated with full machine-readable settings map (gamma options [2.0, 2.2, 2.4], WB 2-point channels, CMS colors/params, menu paths, dependencies, nomenclature)
  - `get_tv_profile(model_name)` utility added to `calibrator/profiles.py` and re-exported
  - Server injects the schema into `build_llm_prompt` when TV model is known

- **#96 — TV hardware settings in LLM context**
  - New `TVSettings` dataclass in `calcore/models.py`
  - `POST /api/session/{sid}/tv-settings` endpoint stores current slider values in session
  - `_maybe_trigger_llm` reconstructs `TVSettings` and passes to background thread
  - `build_llm_prompt` injects `current_tv_settings` into the payload when provided
  - `TvSettingsInput` collapsible component in frontend for JSON paste of current WB/CMS slider values
  - `saveTvSettings` wired through `useSession` → `api.client` → server

## Test plan

- [ ] `tests/test_calcore/test_calcore.py` — 29 tests all pass (465 total suite passes, 0 failures)
- [ ] New `DeterminePhaseTests` boundary cases: avg=0.4→cms, avg=0.6→mpwb, max=1.1→mpwb
- [ ] New `CheckCmsRegressionTests`: no-regression→None, delta>0.3→warning, None avg→None
- [ ] New `SweepGateTests`: partial (<5)→incomplete, full (≥5)→complete, explicit expected count
- [ ] New `ParseAdjustmentPlanTests`: valid JSON, markdown fences, invalid JSON, missing fields, empty adjustments
- [ ] New `BuildLlmPromptTests`: JSON schema present, tv_settings injected, tv_schema injected
- [ ] `tests/test_tv_profiles.py` — 51 tests pass (llm_schema field is optional/default empty, doesn't break existing profiles)

🤖 Generated with [Claude Code](https://claude.com/claude-code)