### PR TITLE
fix: preserve all imported CSV grayscale data across timestamp gaps

### DIFF
--- a/calibrator/session.py
+++ b/calibrator/session.py
@@ -774,39 +774,62 @@ def latest_grayscale_pass(
     max_count: int = 51,
     signal_range: str = "auto",
     code_scale: str = "8bit",
+    detect_sessions: bool = True,
 ) -> List[Measurement]:
+    """Extract the latest contiguous grayscale pass from a list of measurements.
+
+    Parameters
+    ----------
+    measurements :
+        Raw grayscale Measurement objects from the session.
+    max_count :
+        Maximum number of measurements to collect (default 51).
+    signal_range, code_scale :
+        Used to decode stimulus percentage from RGB code values.
+    detect_sessions :
+        When True (default), use timestamp gaps to detect session breaks.
+        Set to False for freshly imported CSV data where the entire batch
+        should be treated as a single coherent pass.
+    """
     if not measurements:
         return []
-    latest_reversed: List[Measurement] = []
-    prev_dt: Optional[datetime] = None
-    for measurement in reversed(measurements):
-        ts = measurement.timestamp
-        if not ts:
-            if latest_reversed:
+
+    if detect_sessions:
+        # Walk backwards through measurements, stopping at session gaps
+        latest_reversed: List[Measurement] = []
+        prev_dt: Optional[datetime] = None
+        for measurement in reversed(measurements):
+            ts = measurement.timestamp
+            if not ts:
+                if latest_reversed:
+                    break
+                continue
+            try:
+                current_dt = datetime.fromisoformat(ts)
+            except ValueError:
+                if latest_reversed:
+                    break
+                continue
+            if prev_dt is not None:
+                gap = (prev_dt - current_dt).total_seconds()
+                if gap > ZRO_SESSION_BREAK_SECONDS:
+                    break
+            latest_reversed.append(measurement)
+            prev_dt = current_dt
+            if len(latest_reversed) == max_count:
                 break
-            continue
-        try:
-            current_dt = datetime.fromisoformat(ts)
-        except ValueError:
-            if latest_reversed:
-                break
-            continue
-        if prev_dt is not None:
-            gap = (prev_dt - current_dt).total_seconds()
-            if gap > ZRO_SESSION_BREAK_SECONDS:
-                break
-        latest_reversed.append(measurement)
-        prev_dt = current_dt
-        if len(latest_reversed) == max_count:
-            break
-    latest = list(reversed(latest_reversed))
+        latest = list(reversed(latest_reversed))
+    else:
+        # Use all measurements — assume they form a single coherent pass
+        # (appropriate for freshly imported CSV data)
+        latest = list(measurements)
+
     decode_range = "full10" if signal_range == "full" and code_scale == "10bit" else signal_range
     return sorted(
         latest,
-        key=lambda m: (
-            stimulus_pct_from_code_value(m.stimulus_rgb[0], decode_range) if m.stimulus_rgb else float("inf"),
-            m.timestamp or "",
-        ),
+        key=lambda m: stimulus_pct_from_code_value(m.stimulus_rgb[0], decode_range)
+        if m.stimulus_rgb
+        else float("inf"),
     )
 
 

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -1127,6 +1127,59 @@ class TestGrayscalePassHelpers:
         assert [m.timestamp for m in latest] == ["2026-03-15T16:00:09", "2026-03-15T16:00:06"]
         assert [m.label for m in latest] == ["Black (0%)", "10% Gray"]
 
+    def test_latest_grayscale_pass_detect_sessions_false_ignores_gaps(self):
+        """With detect_sessions=False (fresh CSV import), all measurements are kept
+        even when there are large timestamp gaps between them."""
+        measurements = [
+            Measurement(x=0.3127, y=0.3290, Y=1.0, X=1.0, Z=1.0,
+                        timestamp="2026-03-15T15:00:00", label="Black (0%)",
+                        stimulus_rgb=(16, 16, 16)),
+            Measurement(x=0.3127, y=0.3290, Y=10.0, X=1.0, Z=1.0,
+                        timestamp="2026-03-15T15:02:00", label="25% Gray",
+                        stimulus_rgb=(77, 77, 77)),
+            # User took a 3-minute break — normally this would split the pass
+            # (but with detect_sessions=True this is just 1 session because
+            # the 2-min gap between black->25% is also within SESSION_BREAK_SECONDS)
+            Measurement(x=0.3127, y=0.3290, Y=30.0, X=1.0, Z=1.0,
+                        timestamp="2026-03-15T15:05:00", label="50% Gray",
+                        stimulus_rgb=(128, 128, 128)),
+            Measurement(x=0.3127, y=0.3290, Y=85.0, X=1.0, Z=1.0,
+                        timestamp="2026-03-15T15:06:00", label="White (100%)",
+                        stimulus_rgb=(235, 235, 235)),
+        ]
+        # With detect_sessions=False (imported CSV), all measurements are kept
+        latest_imported = server_module._latest_grayscale_pass(
+            measurements, max_count=10, detect_sessions=False)
+        assert len(latest_imported) == 4
+        assert [m.label for m in latest_imported] == [
+            "Black (0%)", "25% Gray", "50% Gray", "White (100%)"
+        ]
+
+    def test_latest_grayscale_pass_detect_sessions_false_sorts_by_stimulus(self):
+        """Imported CSV data is sorted purely by stimulus percentage, not by
+        timestamp which could cause incorrect ordering with mixed-import data."""
+        # Measurements in reverse order (like a file read backwards)
+        measurements = [
+            Measurement(x=0.3127, y=0.3290, Y=85.0, X=1.0, Z=1.0,
+                        timestamp="2026-03-15T15:20:00", label="White (100%)",
+                        stimulus_rgb=(235, 235, 235)),
+            Measurement(x=0.3127, y=0.3290, Y=30.0, X=1.0, Z=1.0,
+                        timestamp="2026-03-15T15:19:00", label="50% Gray",
+                        stimulus_rgb=(128, 128, 128)),
+            Measurement(x=0.3127, y=0.3290, Y=10.0, X=1.0, Z=1.0,
+                        timestamp="2026-03-15T15:18:00", label="25% Gray",
+                        stimulus_rgb=(77, 77, 77)),
+            Measurement(x=0.3127, y=0.3290, Y=1.0, X=1.0, Z=1.0,
+                        timestamp="2026-03-15T15:17:00", label="Black (0%)",
+                        stimulus_rgb=(16, 16, 16)),
+        ]
+        latest = server_module._latest_grayscale_pass(
+            measurements, max_count=10, detect_sessions=False)
+        # Sorted by stimulus percentage ascending
+        assert [m.label for m in latest] == [
+            "Black (0%)", "25% Gray", "50% Gray", "White (100%)"
+        ]
+
 
 # ── Report ────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Add detect_sessions parameter to _latest_grayscale_pass() so that imported CSV data keeps all measurements regardless of time gaps, instead of incorrectly splitting them into separate sessions.

Remove secondary timestamp sort since measurements are already sorted by stimulus percentage.

Updates server.py to use detect_sessions=True where session-break detection is still desired for real-time capture displays.

Adds tests for the new behavior.

Closes #88