### PR TITLE
Fix issues #134-#136: LocalStorage quota handling, magic numbers, and server startup validation

### DIFF
--- a/frontend/src/components/CollapsibleSection.jsx
+++ b/frontend/src/components/CollapsibleSection.jsx
@@ -1,5 +1,17 @@
 import { useState, useEffect } from 'react';
 
+function trySetLocalStorage(key, value) {
+  try {
+    localStorage.setItem(key, value);
+  } catch (err) {
+    if (err.name === 'QuotaExceededError' || err.code === 22) {
+      console.warn(`LocalStorage quota exceeded for key: ${key}`);
+    } else {
+      console.warn(`LocalStorage write failed for key: ${key}`, err);
+    }
+  }
+}
+
 export function CollapsibleSection({ title, storageKey, defaultOpen = false, summary, children }) {
   const [open, setOpen] = useState(() => {
     if (storageKey) {
@@ -10,7 +22,7 @@ export function CollapsibleSection({ title, storageKey, defaultOpen = false, sum
   });
 
   useEffect(() => {
-    if (storageKey) localStorage.setItem(`section:${storageKey}`, open);
+    if (storageKey) trySetLocalStorage(`section:${storageKey}`, open);
   }, [open, storageKey]);
 
   return (

--- a/frontend/src/hooks/useSession.js
+++ b/frontend/src/hooks/useSession.js
@@ -1,6 +1,28 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { api } from '../api/client';
 
+const SSE_RETRY_DELAY_MS = 1000;
+const SSE_RETRY_MAX_DELAY_MS = 30000;
+const LLM_SSE_RETRY_DELAY_MS = 2000;
+const WATCH_POLL_INTERVAL_MS = 5000;
+const BRIDGE_POLL_INTERVAL_MS = 8000;
+const DOGEGEN_POLL_INTERVAL_MS = 8000;
+const DOGEGEN_READY_RETRY_MS = 500;
+const DOGEGEN_STARTUP_TIMEOUT_MS = 5000;
+const DOGEGEN_POLL_INTERVAL_MS_MIN = 250;
+
+function trySetLocalStorage(key, value) {
+  try {
+    localStorage.setItem(key, value);
+  } catch (err) {
+    if (err.name === 'QuotaExceededError' || err.code === 22) {
+      console.warn(`LocalStorage quota exceeded for key: ${key}`);
+    } else {
+      console.warn(`LocalStorage write failed for key: ${key}`, err);
+    }
+  }
+}
+
 export function useSession() {
   const [session, setSession] = useState(null);
   const [profiles, setProfiles] = useState([]);
@@ -31,7 +53,7 @@ export function useSession() {
 
   function startLlmSSE(sid) {
     stopLlmSSE();
-    let retryDelay = 2000;
+    let retryDelay = LLM_SSE_RETRY_DELAY_MS;
 
     function connect() {
       console.log('[LLM] connecting to stream', sid);
@@ -65,7 +87,7 @@ export function useSession() {
         console.warn('[LLM] SSE connection error — retrying in', retryDelay, 'ms', err);
         es.close();
         llmEsRetryRef.current = setTimeout(() => {
-          retryDelay = Math.min(retryDelay * 2, 30000);
+          retryDelay = Math.min(retryDelay * 2, SSE_RETRY_MAX_DELAY_MS);
           connect();
         }, retryDelay);
       };
@@ -79,7 +101,7 @@ export function useSession() {
     clearTimeout(sseRetryRef.current);
     sseRef.current?.close();
 
-    let retryDelay = 1000;
+    let retryDelay = SSE_RETRY_DELAY_MS;
 
     function connect() {
       const es = new EventSource(`/events/${sid}`);
@@ -92,7 +114,7 @@ export function useSession() {
       es.onerror = () => {
         es.close();
         sseRetryRef.current = setTimeout(() => {
-          retryDelay = Math.min(retryDelay * 2, 30000);
+          retryDelay = Math.min(retryDelay * 2, SSE_RETRY_MAX_DELAY_MS);
           connect();
         }, retryDelay);
       };
@@ -144,7 +166,7 @@ export function useSession() {
   // Polling for watch status when SSE not available
   useEffect(() => {
     clearInterval(watchPollRef.current);
-    watchPollRef.current = setInterval(refreshWatchStatus, 5000);
+    watchPollRef.current = setInterval(refreshWatchStatus, WATCH_POLL_INTERVAL_MS);
     refreshWatchStatus();
     return () => clearInterval(watchPollRef.current);
   }, [refreshWatchStatus]);
@@ -153,7 +175,7 @@ export function useSession() {
   useEffect(() => {
     if (!bridgeUrl || !session?.id) return;
     refreshBridgeStatus(bridgeUrl);
-    const t = setInterval(() => refreshBridgeStatus(bridgeUrl), 8000);
+      const t = setInterval(() => refreshBridgeStatus(bridgeUrl), BRIDGE_POLL_INTERVAL_MS);
     return () => clearInterval(t);
   }, [bridgeUrl, refreshBridgeStatus, session?.id]);
 
@@ -172,13 +194,13 @@ export function useSession() {
   useEffect(() => {
     if (!session?.id) return;
     refreshDogegenStatus();
-    const t = setInterval(refreshDogegenStatus, 8000);
+    const t = setInterval(refreshDogegenStatus, DOGEGEN_POLL_INTERVAL_MS);
     return () => clearInterval(t);
   }, [refreshDogegenStatus, session?.id]);
 
   useEffect(() => {
     if (!dogegenStatus?.running || dogegenStatus?.ready) return;
-    const t = setTimeout(() => refreshDogegenStatus(), 500);
+    const t = setTimeout(() => refreshDogegenStatus(), DOGEGEN_READY_RETRY_MS);
     return () => clearTimeout(t);
   }, [dogegenStatus?.running, dogegenStatus?.ready, refreshDogegenStatus]);
 
@@ -279,7 +301,7 @@ export function useSession() {
   }
 
   async function saveBridgeUrl(url) {
-    localStorage.setItem('bridgeUrl', url);
+    trySetLocalStorage('bridgeUrl', url);
     setBridgeUrl(url);
     await api.saveBridgeUrl(url);
     await refreshBridgeStatus(url);
@@ -297,9 +319,9 @@ export function useSession() {
 
     if (status?.ready) return status;
 
-    const deadline = Date.now() + 5000;
+    const deadline = Date.now() + DOGEGEN_STARTUP_TIMEOUT_MS;
     while (Date.now() < deadline) {
-      await new Promise(resolve => setTimeout(resolve, 250));
+      await new Promise(resolve => setTimeout(resolve, DOGEGEN_POLL_INTERVAL_MS_MIN));
       status = await api.getDogegenStatus();
       setDogegenStatus(status);
       if (status?.ready) return status;

--- a/server.py
+++ b/server.py
@@ -155,9 +155,43 @@ logging.getLogger().addHandler(_log_buffer)
 logging.getLogger().setLevel(logging.DEBUG)
 
 
+def _validate_startup_config() -> List[str]:
+    """Validate required config paths and settings at startup. Returns list of warnings."""
+    warnings: List[str] = []
+
+    if not SESSION_STORE_DIR.exists():
+        try:
+            SESSION_STORE_DIR.mkdir(parents=True, exist_ok=True)
+        except Exception as exc:
+            warnings.append(
+                f"Cannot create session store directory {SESSION_STORE_DIR}: {exc}"
+            )
+
+    if not os.access(SESSION_STORE_DIR, os.W_OK):
+        warnings.append(f"Session store directory {SESSION_STORE_DIR} is not writable")
+
+    if _PREFS_PATH.exists() and not os.access(_PREFS_PATH, os.W_OK):
+        warnings.append(f"Prefs file {_PREFS_PATH} exists but is not writable")
+
+    dogegen_path = os.getenv("DOGEGEN_PATH", "").strip()
+    if dogegen_path and not Path(dogegen_path).exists():
+        warnings.append(f"DOGEGEN_PATH points to non-existent file: {dogegen_path}")
+
+    return warnings
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     _load_prefs()
+    startup_warnings = _validate_startup_config()
+    for w in startup_warnings:
+        logger.warning(f"Startup validation: {w}")
+    if startup_warnings:
+        logger.info(
+            f"Server started with {len(startup_warnings)} configuration warning(s)"
+        )
+    else:
+        logger.info("Server started with all validations passing")
     yield
 
 


### PR DESCRIPTION
## Summary
- Issue #134: Add trySetLocalStorage helper to catch QuotaExceededError when writing to LocalStorage in useSession.js and CollapsibleSection.jsx
- Issue #135: Replace magic numbers with named constants in useSession.js (SSE retry delays, poll intervals, dogegen timeouts)
- Issue #136: Add _validate_startup_config() to validate session store directory, prefs file, and DOGEGEN_PATH on server startup

## Changes
- frontend/src/hooks/useSession.js: Added 9 named constants for timeout/poll values, added trySetLocalStorage helper
- frontend/src/components/CollapsibleSection.jsx: Added trySetLocalStorage helper for quota handling
- server.py: Added startup validation function that checks directory existence, write permissions, and config path validity