### PR TITLE
Fix issues #131-#133: Error boundaries, test coverage for LLM edge cases and session deserialization

### DIFF
--- a/frontend/src/components/AdbErrorBoundary.jsx
+++ b/frontend/src/components/AdbErrorBoundary.jsx
@@ -1,0 +1,38 @@
+import { Component } from 'react';
+
+export class AdbErrorBoundary extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { error: null };
+  }
+
+  static getDerivedStateFromError(error) {
+    return { error };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    console.error('ADB control error:', error, errorInfo);
+  }
+
+  render() {
+    if (this.state.error) {
+      return (
+        <div style={{ padding: 16, border: '1px solid var(--red)', borderRadius: 6, background: 'var(--surface2)' }}>
+          <div style={{ color: 'var(--red)', fontWeight: 600, marginBottom: 8 }}>
+            ADB Control Error
+          </div>
+          <div style={{ color: 'var(--muted)', fontSize: '0.85rem', marginBottom: 12 }}>
+            {this.state.error.message}
+          </div>
+          <button
+            className="btn"
+            onClick={() => this.setState({ error: null })}
+          >
+            Retry
+          </button>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/frontend/src/pages/ColorTuner.jsx
+++ b/frontend/src/pages/ColorTuner.jsx
@@ -7,6 +7,7 @@ import { BridgeCard } from '../components/BridgeCard';
 import { ZroInstructions } from '../components/ZroInstructions';
 import { fmtDe, dirIcon } from '../utils/fmt';
 import { QualityGate } from '../components/QualityGate';
+import { AdbErrorBoundary } from '../components/AdbErrorBoundary';
 
 function AdbStatusPanel({ adbStatus, onDeploy, onRefresh }) {
   if (!adbStatus) {
@@ -121,15 +122,17 @@ export function ColorTuner({ session, watchStatus, watchDefaultPath, bridgeStatu
         </Card>
       )}
 
-      <Card title="Programmatic Control (ADB)">
-        <AdbStatusPanel adbStatus={adbStatus} onDeploy={onAdbDeploy} onRefresh={onRefreshAdb} />
-        <div style={{ marginTop: 10 }}>
-          <Button small disabled={!ready} onClick={onAdbReset}>
-            Reset All CMS to 0
-          </Button>
-          <span className="muted text-sm" style={{ marginLeft: 8 }}>Calls setColorTunerReset() on the TV</span>
-        </div>
-      </Card>
+      <AdbErrorBoundary>
+        <Card title="Programmatic Control (ADB)">
+          <AdbStatusPanel adbStatus={adbStatus} onDeploy={onAdbDeploy} onRefresh={onRefreshAdb} />
+          <div style={{ marginTop: 10 }}>
+            <Button small disabled={!ready} onClick={onAdbReset}>
+              Reset All CMS to 0
+            </Button>
+            <span className="muted text-sm" style={{ marginLeft: 8 }}>Calls setColorTunerReset() on the TV</span>
+          </div>
+        </Card>
+      </AdbErrorBoundary>
 
       <Card title="ZRO Bridge" id="bridge-card">
         <BridgeCard bridgeStatus={bridgeStatus} bridgeUrl={bridgeUrl} session={session} dogegenStatus={dogegenStatus} onSaveUrl={onSaveBridgeUrl} onMeasure={onMeasure} />

--- a/frontend/src/pages/Luminance.jsx
+++ b/frontend/src/pages/Luminance.jsx
@@ -8,6 +8,7 @@ import { BridgeCard } from '../components/BridgeCard';
 import { ZroInstructions } from '../components/ZroInstructions';
 import { fmtDateTime, fmtNits } from '../utils/fmt';
 import { QualityGate } from '../components/QualityGate';
+import { AdbErrorBoundary } from '../components/AdbErrorBoundary';
 
 const PICTURE_CONTROLS = [
   { key: 'Brightness', label: 'Brightness', hint: 'black level' },
@@ -123,13 +124,15 @@ export function Luminance({ session, watchStatus, watchDefaultPath, bridgeStatus
       <ActionPlan plan={plan} title="Backlight Control Plan" />
 
       {onAdbSetPicture && (
-        <AdbPictureControls
-          adbStatus={adbStatus}
-          onAdbSetPicture={onAdbSetPicture}
-          onAdbGetPicture={onAdbGetPicture}
-          onDeploy={onAdbDeploy}
-          onRefresh={onRefreshAdb}
-        />
+        <AdbErrorBoundary>
+          <AdbPictureControls
+            adbStatus={adbStatus}
+            onAdbSetPicture={onAdbSetPicture}
+            onAdbGetPicture={onAdbGetPicture}
+            onDeploy={onAdbDeploy}
+            onRefresh={onRefreshAdb}
+          />
+        </AdbErrorBoundary>
       )}
 
       <Card title="ZRO Bridge" id="bridge-card">

--- a/tests/test_calcore/test_calcore.py
+++ b/tests/test_calcore/test_calcore.py
@@ -6,7 +6,15 @@ from pathlib import Path
 from unittest import mock
 
 import cli
-from calcore import AnalysisConfig, Patch, SessionState, Summary, analyze, determine_phase, parse_measurement_csv
+from calcore import (
+    AnalysisConfig,
+    Patch,
+    SessionState,
+    Summary,
+    analyze,
+    determine_phase,
+    parse_measurement_csv,
+)
 from calcore.llm import _resolve_endpoint, parse_adjustment_plan, build_llm_prompt
 from calcore.phase import check_cms_regression
 
@@ -258,20 +266,22 @@ class SweepGateTests(unittest.TestCase):
 class ParseAdjustmentPlanTests(unittest.TestCase):
     """Tests for parse_adjustment_plan (#95)."""
 
-    VALID_JSON = json.dumps({
-        "adjustments": [
-            {
-                "menu": "White Balance",
-                "setting": "B-Gain",
-                "from": 0,
-                "to": -3,
-                "scope": "global",
-                "reason": "Blue push at 80% lifting xy above D65 locus.",
-            }
-        ],
-        "next_step": "rerun_grayscale",
-        "confidence": 0.85,
-    })
+    VALID_JSON = json.dumps(
+        {
+            "adjustments": [
+                {
+                    "menu": "White Balance",
+                    "setting": "B-Gain",
+                    "from": 0,
+                    "to": -3,
+                    "scope": "global",
+                    "reason": "Blue push at 80% lifting xy above D65 locus.",
+                }
+            ],
+            "next_step": "rerun_grayscale",
+            "confidence": 0.85,
+        }
+    )
 
     def test_parses_valid_json(self):
         plan = parse_adjustment_plan(self.VALID_JSON)
@@ -295,7 +305,9 @@ class ParseAdjustmentPlanTests(unittest.TestCase):
         self.assertIsNone(parse_adjustment_plan(bad))
 
     def test_empty_adjustments_list_is_valid(self):
-        empty = json.dumps({"adjustments": [], "next_step": "rerun_grayscale", "confidence": 0.0})
+        empty = json.dumps(
+            {"adjustments": [], "next_step": "rerun_grayscale", "confidence": 0.0}
+        )
         plan = parse_adjustment_plan(empty)
         self.assertIsNotNone(plan)
         self.assertEqual(plan.adjustments, [])
@@ -332,6 +344,7 @@ class BuildLlmPromptTests(unittest.TestCase):
 
     def test_tv_settings_injected_when_provided(self):
         from calcore.models import TVSettings
+
         cfg = AnalysisConfig(mode="sdr", eotf="gamma22", target_space="bt709")
         settings = TVSettings(two_point_wb={"R_gain": 0, "B_gain": -3})
         prompt = build_llm_prompt(self.make_summary(), cfg, "wb", tv_settings=settings)
@@ -340,7 +353,10 @@ class BuildLlmPromptTests(unittest.TestCase):
 
     def test_tv_schema_injected_when_provided(self):
         cfg = AnalysisConfig(mode="sdr", eotf="gamma22", target_space="bt709")
-        schema = {"model": "Hisense U8G", "settings": {"gamma": {"options": [2.0, 2.2, 2.4]}}}
+        schema = {
+            "model": "Hisense U8G",
+            "settings": {"gamma": {"options": [2.0, 2.2, 2.4]}},
+        }
         prompt = build_llm_prompt(self.make_summary(), cfg, "wb", tv_schema=schema)
         self.assertIn("tv_settings_schema", prompt)
         self.assertIn("Hisense U8G", prompt)
@@ -368,18 +384,91 @@ class WatchTests(unittest.TestCase):
         csv_path = Path("/tmp/measurements.csv")
         state_path = Path("/tmp/state.json")
 
-        with mock.patch("cli.run_once", side_effect=RuntimeError("boom")), mock.patch(
-            "cli.save_state"
-        ) as save_state_mock, mock.patch(
-            "cli.time.sleep", side_effect=KeyboardInterrupt
-        ), mock.patch(
-            "pathlib.Path.stat", return_value=mock.Mock(st_mtime=123.0)
+        with (
+            mock.patch("cli.run_once", side_effect=RuntimeError("boom")),
+            mock.patch("cli.save_state") as save_state_mock,
+            mock.patch("cli.time.sleep", side_effect=KeyboardInterrupt),
+            mock.patch("pathlib.Path.stat", return_value=mock.Mock(st_mtime=123.0)),
         ):
             with self.assertRaises(KeyboardInterrupt):
                 cli.watch(csv_path, state_path, state, interval=0)
 
         self.assertEqual(state.last_mtime, 0.0)
         save_state_mock.assert_not_called()
+
+
+class LlmResponseEdgeCasesTests(unittest.TestCase):
+    """Tests for LLM response edge cases (#132)."""
+
+    def test_parse_adjustment_plan_missing_adjustments_key(self):
+        data = json.dumps({"next_step": "verify", "confidence": 1.0})
+        result = parse_adjustment_plan(data)
+        self.assertIsNone(result)
+
+    def test_parse_adjustment_plan_missing_next_step(self):
+        data = json.dumps({"adjustments": [], "confidence": 0.5})
+        result = parse_adjustment_plan(data)
+        self.assertIsNone(result)
+
+    def test_parse_adjustment_plan_missing_confidence(self):
+        data = json.dumps({"adjustments": [], "next_step": "verify"})
+        result = parse_adjustment_plan(data)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.confidence, 0.5)
+
+    def test_parse_adjustment_plan_empty_string(self):
+        result = parse_adjustment_plan("")
+        self.assertIsNone(result)
+
+    def test_parse_adjustment_plan_whitespace_only(self):
+        result = parse_adjustment_plan("   \n\t  ")
+        self.assertIsNone(result)
+
+    def test_parse_adjustment_plan_null_in_response(self):
+        data = json.dumps(
+            {"adjustments": [], "next_step": "verify", "confidence": None}
+        )
+        result = parse_adjustment_plan(data)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.confidence, 0.5)
+
+    def test_parse_adjustment_plan_adjustments_not_list(self):
+        data = json.dumps(
+            {"adjustments": "not a list", "next_step": "verify", "confidence": 0.5}
+        )
+        result = parse_adjustment_plan(data)
+        self.assertIsNone(result)
+
+    def test_parse_adjustment_plan_adjustments_dict(self):
+        data = json.dumps(
+            {"adjustments": {"key": "value"}, "next_step": "verify", "confidence": 0.5}
+        )
+        result = parse_adjustment_plan(data)
+        self.assertIsNone(result)
+
+    def test_parse_adjustment_plan_adjustment_missing_fields(self):
+        data = json.dumps(
+            {
+                "adjustments": [{"menu": "White Balance"}],
+                "next_step": "verify",
+                "confidence": 0.5,
+            }
+        )
+        result = parse_adjustment_plan(data)
+        self.assertIsNotNone(result)
+        self.assertEqual(len(result.adjustments), 1)
+        self.assertEqual(result.adjustments[0].get("menu"), "White Balance")
+
+    def test_parse_adjustment_plan_valid_json_string(self):
+        invalid = '{"adjustments": [], "next_step": "verify", "confidence": 0.5}'
+        result = parse_adjustment_plan(invalid)
+        self.assertIsNotNone(result)
+
+    def test_parse_adjustment_plan_confidence_out_of_range(self):
+        data = json.dumps({"adjustments": [], "next_step": "verify", "confidence": 1.5})
+        result = parse_adjustment_plan(data)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.confidence, 1.5)
 
 
 if __name__ == "__main__":

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,0 +1,178 @@
+"""Tests for calibrator/session.py deserialization functions."""
+
+import pytest
+from calibrator.session import deserialize_session, deserialize_measurement
+
+
+class TestDeserializeMeasurement:
+    def test_valid_measurement(self):
+        data = {
+            "label": "White (100%)",
+            "stimulus_rgb": [1.0, 1.0, 1.0],
+            "X": 100.0,
+            "Y": 100.0,
+            "Z": 100.0,
+            "x": 0.3127,
+            "y": 0.3290,
+        }
+        m = deserialize_measurement(data)
+        assert m.label == "White (100%)"
+        assert m.stimulus_rgb == (1.0, 1.0, 1.0)
+        assert m.X == 100.0
+        assert m.Y == 100.0
+        assert m.Z == 100.0
+
+    def test_missing_all_fields_returns_defaults(self):
+        data = {}
+        m = deserialize_measurement(data)
+        assert m.label == ""
+        assert m.X == 0.0
+        assert m.Y == 0.0
+        assert m.Z == 0.0
+        assert m.stimulus_rgb == (255, 255, 255)
+
+    def test_partial_fields(self):
+        data = {"label": "Red", "stimulus_rgb": [1.0, 0.0, 0.0]}
+        m = deserialize_measurement(data)
+        assert m.label == "Red"
+        assert m.stimulus_rgb == (1.0, 0.0, 0.0)
+        assert m.X == 0.0
+        assert m.Y == 0.0
+        assert m.Z == 0.0
+
+
+class TestDeserializeSession:
+    def test_valid_session(self):
+        data = {
+            "id": "test-123",
+            "tv_key": "u8g",
+            "tv_name": "Hisense U8G",
+            "step": "baseline",
+            "mode": "SDR",
+            "sdr_peak_nits": 1000.0,
+            "pre_measurements": [],
+            "wb_measurements": [],
+            "gamma_measurements": [],
+            "cms_measurements": [],
+            "post_measurements": [],
+            "lum_measurements": [],
+        }
+        sess = deserialize_session(data)
+        assert sess["id"] == "test-123"
+        assert sess["tv_key"] == "u8g"
+        assert sess["mode"] == "SDR"
+        assert sess["sdr_peak_nits"] == 1000.0
+
+    def test_corrupted_json_missing_id(self):
+        data = {
+            "tv_key": "u8g",
+            "tv_name": "Hisense U8G",
+            "step": "baseline",
+        }
+        with pytest.raises(KeyError):
+            deserialize_session(data)
+
+    def test_corrupted_json_missing_tv_key(self):
+        data = {
+            "id": "test-123",
+            "tv_name": "Hisense U8G",
+            "step": "baseline",
+        }
+        with pytest.raises(KeyError):
+            deserialize_session(data)
+
+    def test_corrupted_json_missing_step(self):
+        data = {
+            "id": "test-123",
+            "tv_key": "u8g",
+            "tv_name": "Hisense U8G",
+        }
+        with pytest.raises(KeyError):
+            deserialize_session(data)
+
+    def test_invalid_mode_type(self):
+        data = {
+            "id": "test-123",
+            "tv_key": "u8g",
+            "tv_name": "Hisense U8G",
+            "step": "baseline",
+            "mode": 12345,
+            "sdr_peak_nits": 1000.0,
+            "pre_measurements": [],
+            "wb_measurements": [],
+            "gamma_measurements": [],
+            "cms_measurements": [],
+            "post_measurements": [],
+            "lum_measurements": [],
+        }
+        sess = deserialize_session(data)
+        assert sess["mode"] == 12345
+
+    def test_invalid_measurements_not_list(self):
+        data = {
+            "id": "test-123",
+            "tv_key": "u8g",
+            "tv_name": "Hisense U8G",
+            "step": "baseline",
+            "mode": "SDR",
+            "sdr_peak_nits": 1000.0,
+            "pre_measurements": "not a list",
+            "wb_measurements": [],
+            "gamma_measurements": [],
+            "cms_measurements": [],
+            "post_measurements": [],
+            "lum_measurements": [],
+        }
+        with pytest.raises(ValueError):
+            deserialize_session(data)
+
+    def test_corrupted_measurement_in_list_uses_defaults(self):
+        data = {
+            "id": "test-123",
+            "tv_key": "u8g",
+            "tv_name": "Hisense U8G",
+            "step": "baseline",
+            "mode": "SDR",
+            "sdr_peak_nits": 1000.0,
+            "pre_measurements": [{"label": "invalid", "stimulus_rgb": [1.0, 1.0, 1.0]}],
+            "wb_measurements": [],
+            "gamma_measurements": [],
+            "cms_measurements": [],
+            "post_measurements": [],
+            "lum_measurements": [],
+        }
+        sess = deserialize_session(data)
+        assert len(sess["pre_measurements"]) == 1
+        m = sess["pre_measurements"][0]
+        assert m.label == "invalid"
+        assert m.X == 0.0
+        assert m.Y == 0.0
+
+    def test_empty_list_measurements(self):
+        data = {
+            "id": "test-123",
+            "tv_key": "u8g",
+            "tv_name": "Hisense U8G",
+            "step": "baseline",
+            "mode": "SDR",
+            "pre_measurements": [],
+            "wb_measurements": [],
+            "gamma_measurements": [],
+            "cms_measurements": [],
+            "post_measurements": [],
+            "lum_measurements": [],
+        }
+        sess = deserialize_session(data)
+        assert sess["pre_measurements"] == []
+        assert sess["wb_measurements"] == []
+
+    def test_missing_measurements_keys(self):
+        data = {
+            "id": "test-123",
+            "tv_key": "u8g",
+            "tv_name": "Hisense U8G",
+            "step": "baseline",
+        }
+        sess = deserialize_session(data)
+        assert sess["pre_measurements"] == []
+        assert sess["wb_measurements"] == []


### PR DESCRIPTION
## Summary
- Issue #131: Add AdbErrorBoundary component to wrap ADB controls in Luminance.jsx and ColorTuner.jsx to catch and display errors gracefully
- Issue #132: Add test coverage for LLM parse_adjustment_plan edge cases (empty choices, missing fields, null values, confidence out of range)
- Issue #133: Add test coverage for session deserialize_session and deserialize_measurement edge cases (corrupted JSON, missing required fields, invalid measurement types)

## Changes
- frontend/src/components/AdbErrorBoundary.jsx: New error boundary component
- frontend/src/pages/Luminance.jsx: Wrap AdbPictureControls with AdbErrorBoundary
- frontend/src/pages/ColorTuner.jsx: Wrap ADB control Card with AdbErrorBoundary
- tests/test_session.py: New test file for session deserialization edge cases
- tests/test_calcore/test_calcore.py: Add LlmResponseEdgeCasesTests class