### PR TITLE
Fix issues #122-#127: SSE validation, CORS, file size limits, polling errors, loading state, Windows OSError

### DIFF
--- a/calibrator/file_watcher.py
+++ b/calibrator/file_watcher.py
@@ -334,15 +334,29 @@ class _ZROHandler(FileSystemEventHandler):
         # ── mtime dedup ───────────────────────────────────────────────────
         try:
             mtime = os.path.getmtime(src_path)
-        except OSError:
-            # File vanished; ignore.
+        except OSError as exc:
+            if isinstance(exc, PermissionError):
+                msg = f"Permission denied accessing {src_path}, may be locked by another process"
+                logger.info(msg)
+                with _lock:
+                    _watcher_error = msg
+                    _last_attempt = {
+                        "timestamp": datetime.now(timezone.utc).isoformat(),
+                        "file": os.path.basename(src_path),
+                        "path": os.path.abspath(src_path),
+                        "status": "locked",
+                        "detail": str(exc),
+                    }
+                self._schedule_timer(src_path, LOCKED_FILE_RETRY_SECONDS)
+                return
+            logger.warning("OSError accessing mtime for %s: %s", src_path, exc)
             with _lock:
                 _last_attempt = {
                     "timestamp": datetime.now(timezone.utc).isoformat(),
                     "file": os.path.basename(src_path),
                     "path": os.path.abspath(src_path),
-                    "status": "missing",
-                    "detail": "File disappeared before it could be imported.",
+                    "status": "error",
+                    "detail": str(exc),
                 }
             return
 

--- a/frontend/src/hooks/useSession.js
+++ b/frontend/src/hooks/useSession.js
@@ -59,13 +59,26 @@ export function useSession() {
       console.log('[LLM] connecting to stream', sid);
       const es = new EventSource(`/api/session/${sid}/llm/stream`);
       es.addEventListener('llm_start', e => {
-        console.log('[LLM] started', JSON.parse(e.data));
-        setLlmStreaming(true);
-        setLlmError(null);
+        try {
+          const data = JSON.parse(e.data);
+          if (!data.phase) {
+            console.warn('[LLM] malformed llm_start payload - missing phase', data);
+            return;
+          }
+          console.log('[LLM] started', data.phase);
+          setLlmStreaming(true);
+          setLlmError(null);
+        } catch (err) {
+          console.warn('[LLM] malformed llm_start payload', e.data, err);
+        }
       });
       es.addEventListener('llm_insight', e => {
         try {
           const data = JSON.parse(e.data);
+          if (!data.phase || !data.text) {
+            console.warn('[LLM] malformed insight payload - missing phase or text', data);
+            return;
+          }
           console.log('[LLM] insight received', data.phase, data.text?.slice(0, 80));
           setLlmInsight(data);
         } catch (err) {
@@ -147,20 +160,20 @@ export function useSession() {
     };
   }, []);
   const refreshWatchStatus = useCallback(async () => {
-    try { setWatchStatus(await api.getWatchStatus()); } catch { /* poll failure is non-fatal */ }
+    try { setWatchStatus(await api.getWatchStatus()); } catch (err) { console.warn('watch status poll error:', err); }
   }, []);
 
   const refreshBridgeStatus = useCallback(async (url = bridgeUrl) => {
     if (!url) return;
-    try { setBridgeStatus(await api.getBridgeStatus(url)); } catch { setBridgeStatus(null); }
+    try { setBridgeStatus(await api.getBridgeStatus(url)); } catch (err) { console.warn('bridge status poll error:', err); setBridgeStatus(null); }
   }, [bridgeUrl]);
 
   const refreshAdbStatus = useCallback(async () => {
-    try { setAdbStatus(await api.getAdbStatus()); } catch { setAdbStatus(null); }
+    try { setAdbStatus(await api.getAdbStatus()); } catch (err) { console.warn('ADB status poll error:', err); setAdbStatus(null); }
   }, []);
 
   const refreshDogegenStatus = useCallback(async () => {
-    try { setDogegenStatus(await api.getDogegenStatus()); } catch { setDogegenStatus(null); }
+    try { setDogegenStatus(await api.getDogegenStatus()); } catch (err) { console.warn('dogegen status poll error:', err); setDogegenStatus(null); }
   }, []);
 
   // Polling for watch status when SSE not available

--- a/frontend/src/pages/Prepare.jsx
+++ b/frontend/src/pages/Prepare.jsx
@@ -22,6 +22,7 @@ export function Prepare({ session, dogegenStatus, onConfirmPrepared, onPrev, onS
   const [selectedSignalRange, setSelectedSignalRange] = useState(currentSignalRange);
   const [selectedCodeScale,   setSelectedCodeScale]   = useState(currentCodeScale);
   const [selectedGenerator,   setSelectedGenerator]   = useState(currentGenerator);
+  const [settingsLoading, setSettingsLoading] = useState(false);
 
   // AI Assistant state
   const llmCfg = session.llm_config || {};
@@ -92,26 +93,45 @@ export function Prepare({ session, dogegenStatus, onConfirmPrepared, onPrev, onS
 
   async function handleLlmToggle(enabled) {
     setLlmEnabled(enabled);
-    if (!enabled) {
-      setLlmEndpoint('');
-      setLlmModel('');
-      setLlmTestStatus(null);
-      if (onConfigureLlm) await onConfigureLlm({ endpoint: '', model: '' });
+    setSettingsLoading(true);
+    try {
+      if (!enabled) {
+        setLlmEndpoint('');
+        setLlmModel('');
+        setLlmTestStatus(null);
+        if (onConfigureLlm) await onConfigureLlm({ endpoint: '', model: '' });
+      }
+    } finally {
+      setSettingsLoading(false);
     }
   }
 
   async function handleLlmEndpointBlur(value) {
-    if (onConfigureLlm) await onConfigureLlm({ endpoint: value.trim() });
+    setSettingsLoading(true);
+    try {
+      if (onConfigureLlm) await onConfigureLlm({ endpoint: value.trim() });
+    } finally {
+      setSettingsLoading(false);
+    }
   }
 
   async function handleLlmModelBlur(value) {
-    if (onConfigureLlm) await onConfigureLlm({ model: value.trim() });
+    setSettingsLoading(true);
+    try {
+      if (onConfigureLlm) await onConfigureLlm({ model: value.trim() });
+    } finally {
+      setSettingsLoading(false);
+    }
   }
 
   async function handleLlmApiKeyBlur(value) {
-    if (value && onConfigureLlm) {
+    if (!value || !onConfigureLlm) return;
+    setSettingsLoading(true);
+    try {
       await onConfigureLlm({ api_key: value });
       setLlmApiKey('');
+    } finally {
+      setSettingsLoading(false);
     }
   }
 
@@ -421,6 +441,7 @@ export function Prepare({ session, dogegenStatus, onConfirmPrepared, onPrev, onS
                   placeholder="http://localhost:11434/v1"
                   autoComplete="off"
                   spellCheck={false}
+                  disabled={settingsLoading}
                   style={{ background: 'var(--surface2)', border: '1px solid var(--border2)', borderRadius: 'var(--radius)', color: 'var(--text)', fontSize: '0.84rem', padding: '7px 10px', width: '100%', maxWidth: 480, outline: 'none', fontFamily: 'inherit' }}
                 />
               </div>
@@ -436,6 +457,7 @@ export function Prepare({ session, dogegenStatus, onConfirmPrepared, onPrev, onS
                   placeholder="llama3"
                   autoComplete="off"
                   spellCheck={false}
+                  disabled={settingsLoading}
                   style={{ background: 'var(--surface2)', border: '1px solid var(--border2)', borderRadius: 'var(--radius)', color: 'var(--text)', fontSize: '0.84rem', padding: '7px 10px', width: '100%', maxWidth: 480, outline: 'none', fontFamily: 'inherit' }}
                 />
               </div>
@@ -453,6 +475,7 @@ export function Prepare({ session, dogegenStatus, onConfirmPrepared, onPrev, onS
                   onBlur={e => handleLlmApiKeyBlur(e.target.value)}
                   placeholder="sk-…"
                   autoComplete="new-password"
+                  disabled={settingsLoading}
                   style={{ background: 'var(--surface2)', border: '1px solid var(--border2)', borderRadius: 'var(--radius)', color: 'var(--text)', fontSize: '0.84rem', padding: '7px 10px', width: '100%', maxWidth: 480, outline: 'none', fontFamily: 'inherit' }}
                 />
               </div>

--- a/server.py
+++ b/server.py
@@ -25,6 +25,9 @@ import httpx
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, File, HTTPException, UploadFile
+from fastapi.middleware.cors import CORSMiddleware
+
+MAX_UPLOAD_SIZE_BYTES = 10 * 1024 * 1024  # 10MB limit for CSV uploads
 from fastapi.responses import FileResponse, HTMLResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
@@ -196,6 +199,14 @@ async def lifespan(app: FastAPI):
 
 
 app = FastAPI(title="ZRO Calibration Helper", lifespan=lifespan)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 
 SESSION_STORE_DIR = Path(__file__).parent / ".sessions"
@@ -1240,6 +1251,12 @@ async def import_zro_csv(sid: str, file: UploadFile = File(...)):
         contents = await file.read()
     except Exception as exc:
         raise HTTPException(400, f"Could not read uploaded file: {exc}") from exc
+
+    if len(contents) > MAX_UPLOAD_SIZE_BYTES:
+        raise HTTPException(
+            413, f"File too large: {len(contents)} bytes (max {MAX_UPLOAD_SIZE_BYTES})"
+        )
+
     session, import_meta = store.import_zro_bytes(sid, file.filename, contents)
     _maybe_trigger_llm(sid, session)
     return {"session": _session_view(session), "import_summary": import_meta}
@@ -1251,6 +1268,12 @@ async def import_generic_csv(sid: str, file: UploadFile = File(...)):
         contents = await file.read()
     except Exception as exc:
         raise HTTPException(400, f"Could not read uploaded file: {exc}") from exc
+
+    if len(contents) > MAX_UPLOAD_SIZE_BYTES:
+        raise HTTPException(
+            413, f"File too large: {len(contents)} bytes (max {MAX_UPLOAD_SIZE_BYTES})"
+        )
+
     session, import_meta = store.import_generic_bytes(sid, file.filename, contents)
     _maybe_trigger_llm(sid, session)
     return {"session": _session_view(session), "import_summary": import_meta}


### PR DESCRIPTION
## Summary
- **Issue #122**: Log polling errors with `console.warn` in `useSession.js` instead of silently swallowing them
- **Issue #123**: Add `CORSMiddleware` to FastAPI `server.py` (allow all origins; this is a local LAN tool)
- **Issue #124**: Enforce 10MB `MAX_UPLOAD_SIZE_BYTES` limit on `/import/zro` and `/import/generic` endpoints — returns HTTP 413 on oversized uploads
- **Issue #125**: Add `settingsLoading` boolean to `Prepare.jsx`; all LLM config blur handlers set it while awaiting, and inputs are `disabled` during the request to prevent race conditions
- **Issue #126**: Validate `llm_start` and `llm_insight` SSE payloads in `useSession.js` — guard against missing `phase`/`text` fields before applying state, and wrap `llm_start` in try/catch
- **Issue #127**: In `file_watcher.py`, distinguish `PermissionError` (schedule retry after `LOCKED_FILE_RETRY_SECONDS`) vs other `OSError` (log warning + record error status) when checking mtime

## Files changed
- `server.py`: CORSMiddleware + 10MB upload limit
- `calibrator/file_watcher.py`: OSError handling
- `frontend/src/hooks/useSession.js`: SSE validation + named error logging
- `frontend/src/pages/Prepare.jsx`: loading state for async LLM config handlers