### PR TITLE
Add before/after delta report and predictive patch density (#168, #173)

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,8 @@ The assistant system has four integrated capabilities:
 | **Display memory** | Prior sessions for this TV model are injected into every prompt as a compressed history block (up to 3 sessions + baseline). The LLM can detect drift, thermal aging, and repeat known compromises. |
 | **Gamut expert** | `POST /api/session/{sid}/gamut/advise` runs a deterministic gamut feasibility check per primary, then asks the LLM to explain trade-offs in plain English when a primary is outside the ADB CMS correction range. |
 | **Patch strategy** | After each import the LLM also recommends which patches to add or skip next (`patch_strategy` SSE event). Strategies with confidence ≥ 0.6 are flagged for auto-apply; lower-confidence ones surface for user review. |
+| **Predictive patch density** | `GET /api/session/{sid}/suggested-patches` analyzes per-patch ΔE residuals and returns an optimized patch list — denser where error is highest, sparser where results are within tolerance. Capped at a configurable budget (default 30). |
+| **Delta summary** | `POST /api/report/compare/delta_summary` compares two sessions and asks the LLM to write a plain-English paragraph describing what improved, what regressed, and likely causes. |
 
 Configure under the **AI Assistant** section on the Prepare page. All AI features are non-blocking — the workflow runs fully without an LLM endpoint configured.
 
@@ -314,6 +316,67 @@ ADB must be installed and your TV must have ADB debugging enabled over the netwo
 
 A live server log stream is available in the UI for debugging. The panel tails the FastAPI process log in real time via `GET /api/logs/stream` (SSE). Log entries include CSV import events, LLM trigger attempts, Dogegen process lifecycle, and any server-side errors. The panel is collapsed by default; expand it from the header bar.
 
+### Before/After Delta Report
+
+Compare any two calibration sessions side-by-side to quantify the impact of adjustments over time — useful for comparing SDR vs. HDR10, pre-treatment vs. post-treatment, or any two arbitrary sessions.
+
+**API:**
+
+```
+GET  /api/report/compare?a={session_id}&b={session_id}           → JSON delta payload
+GET  /api/report/compare?a={session_id}&b={session_id}&format=html → side-by-side HTML
+GET  /api/report/compare?a={session_id}&b={session_id}&format=pdf  → printable PDF
+POST /api/report/compare/delta_summary?a={id}&b={id}             → LLM prose paragraph
+```
+
+The delta payload includes per-metric differences (Δ Pre-Cal ΔE, Δ Post-Cal ΔE, Δ WB ΔE, Δ CMS ΔE, Δ Gamma, Δ Improvement %, Δ Peak Luminance) plus a `tv_mismatch` and `mode_mismatch` flag when sessions aren't directly comparable.
+
+The optional LLM delta summary endpoint asks the configured AI assistant to write a plain-English paragraph explaining what improved, what regressed, and why.
+
+**CLI:**
+
+```bash
+python cli.py compare session_a.json session_b.json
+python cli.py compare session_a.json session_b.json \
+  --llm-endpoint http://localhost:4000 --llm-model tvcal-analyst
+```
+
+Accepts either saved session JSON files or history-entry JSON files from `.calibration-history/`.
+
+### Predictive Patch Density
+
+Instead of a fixed measurement grid, the AI assistant can analyze current ΔE and gamma residuals and recommend a custom next-round patch set: denser sampling where error is highest, sparser where results are already within tolerance.
+
+**API:**
+
+```
+GET  /api/session/{sid}/suggested-patches?budget=30
+POST /api/session/{sid}/suggested-patches/run
+```
+
+`GET suggested-patches` returns a `PatchOptimization` object:
+
+```json
+{
+  "patches": [
+    {
+      "nits": 80.0, "r": 200, "g": 200, "b": 200,
+      "priority": "high",
+      "label": "Gray 78%",
+      "rationale": "ΔE 4.2 at this stimulus — add finer interpolation steps"
+    }
+  ],
+  "rationale": "Dense sampling added in 60–85% range where gamma deviates > 0.15",
+  "confidence": 0.82,
+  "auto_apply": true,
+  "patch_count": 12
+}
+```
+
+Patches with `auto_apply: true` (confidence ≥ 0.7) can be forwarded directly to the ZRO Bridge via `POST suggested-patches/run`, which sends them to `{bridge_url}/measure/sequence` for immediate measurement.
+
+The patch count is capped by the `budget` query parameter (default 30, maximum 200).
+
 ### PDF and HTML Reports
 
 The Report page offers three export formats:
@@ -370,6 +433,18 @@ Options:
 | `--target-space bt709\|p3d65\|bt2020` | Target color gamut |
 | `--watch` | Watch for new CSV files and re-analyze on change |
 
+### Comparing Sessions (CLI)
+
+Compare two saved session or report JSON files from the command line:
+
+```bash
+python cli.py compare before.json after.json
+python cli.py compare before.json after.json \
+  --llm-endpoint http://localhost:4000 --llm-model tvcal-analyst
+```
+
+Accepts session report JSON files (exported via `GET /api/session/{sid}/report`) or `.calibration-history/{tv_key}/sessions.jsonl` entries. When an LLM endpoint is configured, appends a plain-English analysis paragraph below the delta table.
+
 ---
 
 ## Project Structure
@@ -398,8 +473,10 @@ calcore/
   targets.py          Target XYZ computation per patch (grayscale + color primaries)
   csv_import.py       Generic ColourSpace CSV parser (header and headerless formats)
   gamut.py            Per-primary gamut feasibility check (PrimaryConstraint, GamutDiagnosis)
+  patch_planner.py    Predictive patch density planning (SuggestedPatch, PatchOptimization)
   phase.py            Calibration phase determination logic
-  llm.py              LLM client — guidance, history injection, patch strategy, remediation
+  llm.py              LLM client — guidance, history injection, patch strategy, remediation,
+                      delta summary, patch optimization
 
 server.py             FastAPI application (REST + SSE)
 cli.py                Command-line batch analysis entry point
@@ -532,6 +609,12 @@ The LLM prompt contains **only pre-aggregated data** — no raw per-patch XYZ ar
 | `GET` | `/api/prefs` | Read persisted user preferences |
 | `POST` | `/api/prefs` | Write user preferences (watch path, LLM config, Dogegen, bridge URL) |
 | `GET` | `/api/logs/stream` | SSE stream of server log lines (for the in-UI logs panel) |
+| `GET` | `/api/report/compare?a={id}&b={id}` | JSON delta payload comparing two sessions |
+| `GET` | `/api/report/compare?a={id}&b={id}&format=html` | Side-by-side HTML comparison report |
+| `GET` | `/api/report/compare?a={id}&b={id}&format=pdf` | Printable PDF comparison report |
+| `POST` | `/api/report/compare/delta_summary?a={id}&b={id}` | LLM-authored plain-English delta summary |
+| `GET` | `/api/session/{sid}/suggested-patches?budget=30` | LLM-optimized patch list from residual analysis |
+| `POST` | `/api/session/{sid}/suggested-patches/run` | Forward suggested patches to the ZRO Bridge |
 
 SSE stream (`GET /api/session/{sid}/llm/stream`) now emits two event types:
 

--- a/calcore/llm.py
+++ b/calcore/llm.py
@@ -748,5 +748,198 @@ def probe_llm(cfg: Dict[str, Any], timeout: float = 8.0) -> tuple[bool, str]:
         return False, str(exc)[:300]
 
 
+def query_delta_summary(
+    report_a: Dict[str, Any],
+    report_b: Dict[str, Any],
+    deltas: Dict[str, Any],
+    llm: LLMConfig,
+) -> Optional[str]:
+    """Ask the LLM to narrate the before/after delta between two calibration sessions.
+
+    Returns a plain-language paragraph describing what improved, what regressed,
+    and what likely caused the changes. Returns None if LLM is not configured or
+    the response cannot be retrieved.
+    """
+    if not llm.endpoint or not llm.model:
+        return None
+
+    def _compact_report(r: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            "tv": r.get("tv"),
+            "mode": r.get("mode"),
+            "date": str(r.get("date", ""))[:10],
+            "pre_cal_avg_de": r.get("pre_cal", {}).get("avg_de"),
+            "post_cal_avg_de": r.get("post_cal", {}).get("avg_de"),
+            "wb_avg_de": r.get("white_balance", {}).get("avg_de"),
+            "cms_avg_de": r.get("color_tuner", {}).get("avg_de"),
+            "gamma_avg": r.get("gamma", {}).get("avg_gamma"),
+            "improvement_pct": r.get("improvement_pct"),
+            "peak_luminance": r.get("peak_luminance"),
+            "target_gamut": r.get("target", {}).get("gamut"),
+            "target_eotf": r.get("target", {}).get("eotf"),
+        }
+
+    payload = {
+        "session_a": _compact_report(report_a),
+        "session_b": _compact_report(report_b),
+        "deltas": deltas,
+    }
+
+    prompt = (
+        "You are a professional display calibration analyst. "
+        "Two calibration sessions for the same TV are shown below. "
+        "Session A is the earlier/baseline; Session B is the more recent.\n\n"
+        "Write a single plain-English paragraph (3-5 sentences) that:\n"
+        "1. States what improved between sessions (lower ΔE, better gamma, etc.)\n"
+        "2. States anything that regressed or stayed roughly the same\n"
+        "3. Provides a brief calibration interpretation (e.g. 'The white balance "
+        "correction in session B significantly reduced grayscale tracking error')\n\n"
+        "Be concise and technical. Do not use JSON — respond with prose only.\n\n"
+        f"DATA:\n{json.dumps(payload, indent=2, default=str)}"
+    )
+
+    url = resolve_endpoint(llm.endpoint)
+    body = {
+        "model": llm.model,
+        "messages": [
+            {
+                "role": "system",
+                "content": "You are a concise display calibration analyst. Write plain prose, no JSON.",
+            },
+            {"role": "user", "content": prompt},
+        ],
+        "temperature": 0.3,
+    }
+
+    data = json.dumps(body).encode("utf-8")
+    req = urllib.request.Request(
+        url, data=data, headers={"Content-Type": "application/json"}, method="POST"
+    )
+    if llm.api_key:
+        req.add_header("Authorization", f"Bearer {llm.api_key}")
+
+    try:
+        with urllib.request.urlopen(req, timeout=min(llm.timeout, 45.0)) as resp:
+            raw = resp.read().decode("utf-8")
+        parsed = json.loads(raw)
+        choices = parsed.get("choices") or []
+        if not choices:
+            raise ValueError(f"LLM returned empty choices: {raw[:300]}")
+        return choices[0]["message"]["content"].strip()
+    except urllib.error.HTTPError as e:
+        logger.error("LLM HTTP error in query_delta_summary: %s - %s", e.code, e.reason)
+        return None
+    except Exception as e:
+        logger.error("Unexpected error in query_delta_summary: %s: %s", type(e).__name__, e)
+        return None
+
+
+def query_patch_optimization(
+    grayscale_rows: List[Dict[str, Any]],
+    color_rows: List[Dict[str, Any]],
+    phase: str,
+    patch_budget: int,
+    llm: LLMConfig,
+) -> Optional[Any]:
+    """Ask the LLM to recommend an optimized patch set from per-patch residuals.
+
+    Sends full per-patch error data (not just top-N) so the LLM can identify
+    stimulus regions that need denser sampling. Returns a structured patch list
+    or None if LLM is not configured / response cannot be parsed.
+    """
+    if not llm.endpoint or not llm.model:
+        return None
+
+    from .patch_planner import plan_patches, PatchOptimization, SuggestedPatch
+
+    planning_payload = plan_patches(grayscale_rows, color_rows, budget=patch_budget)
+
+    prompt = (
+        "You are a TV calibration measurement strategist. "
+        "Given per-patch ΔE residuals from the current calibration sweep, "
+        "recommend an optimized patch set for the next measurement pass.\n\n"
+        "Rules:\n"
+        f"- Total patches must not exceed {patch_budget}\n"
+        "- Add denser sampling where ΔE > 3 or gamma deviates > 0.1 from target\n"
+        "- Skip patches where ΔE < 1 to save measurement time\n"
+        "- For grayscale patches, specify r=g=b values (0-255 for 8-bit, 0-1023 for 10-bit)\n"
+        "- For color patches, specify r/g/b independently\n"
+        "- Estimate nits from stimulus level and typical display brightness\n\n"
+        "Respond with ONLY a JSON object in this exact schema (no markdown, no extra text):\n"
+        "{\n"
+        '  "patches": [\n'
+        "    {\n"
+        '      "nits": <estimated_nits>,\n'
+        '      "r": <0-1023>,\n'
+        '      "g": <0-1023>,\n'
+        '      "b": <0-1023>,\n'
+        '      "priority": "high" | "medium" | "low",\n'
+        '      "label": "<human-readable label>",\n'
+        '      "rationale": "<why this patch was added or kept>"\n'
+        "    }\n"
+        "  ],\n"
+        '  "rationale": "<1-2 sentence summary of the optimization strategy>",\n'
+        '  "confidence": <0.0-1.0>\n'
+        "}\n\n"
+        f"PHASE: {phase}\n"
+        f"RESIDUALS:\n{json.dumps(planning_payload, indent=2, default=str)}"
+    )
+
+    url = resolve_endpoint(llm.endpoint)
+    body = {
+        "model": llm.model,
+        "messages": [
+            {
+                "role": "system",
+                "content": "You are a strict JSON-only responder. Output only valid JSON.",
+            },
+            {"role": "user", "content": prompt},
+        ],
+        "temperature": 0.0,
+    }
+
+    data = json.dumps(body).encode("utf-8")
+    req = urllib.request.Request(
+        url, data=data, headers={"Content-Type": "application/json"}, method="POST"
+    )
+    if llm.api_key:
+        req.add_header("Authorization", f"Bearer {llm.api_key}")
+
+    try:
+        with urllib.request.urlopen(req, timeout=min(llm.timeout, 60.0)) as resp:
+            raw = resp.read().decode("utf-8")
+        parsed = json.loads(raw)
+        choices = parsed.get("choices") or []
+        if not choices:
+            raise ValueError(f"LLM returned empty choices: {raw[:300]}")
+        content = _extract_json(choices[0]["message"]["content"].strip())
+        obj = json.loads(content)
+
+        raw_patches = obj.get("patches") or []
+        # Cap at budget
+        raw_patches = raw_patches[:patch_budget]
+        patches = [SuggestedPatch.from_dict(p) for p in raw_patches]
+        confidence = float(obj.get("confidence", 0.5))
+
+        return PatchOptimization(
+            patches=patches,
+            rationale=str(obj.get("rationale", "")),
+            confidence=confidence,
+            auto_apply=confidence >= 0.7,
+        )
+    except urllib.error.HTTPError as e:
+        logger.error("LLM HTTP error in query_patch_optimization: %s - %s", e.code, e.reason)
+        return None
+    except json.JSONDecodeError as e:
+        logger.error("LLM response parsing failed in query_patch_optimization: %s", e)
+        return None
+    except Exception as e:
+        logger.error(
+            "Unexpected error in query_patch_optimization: %s: %s", type(e).__name__, e
+        )
+        return None
+
+
+# Type alias for callers that import PatchOptimization from here
 _resolve_endpoint = resolve_endpoint
 call_local_llm = call_llm

--- a/calcore/patch_planner.py
+++ b/calcore/patch_planner.py
@@ -1,0 +1,124 @@
+"""Predictive patch density planning from LLM residual analysis.
+
+Analyzes post-grayscale or post-CMS residuals and recommends a custom
+next-round patch set: denser sampling where ΔE or gamma deviation is highest,
+sparser where results are already within tolerance.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+MAX_PATCH_BUDGET: int = 30  # configurable default cap on recommended patches
+
+_PRIORITY_RANK = {"high": 0, "medium": 1, "low": 2}
+
+
+@dataclass
+class SuggestedPatch:
+    """A single patch recommended by the LLM-driven patch optimizer."""
+
+    nits: float
+    r: int
+    g: int
+    b: int
+    priority: str  # "high" | "medium" | "low"
+    label: str = ""
+    rationale: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "nits": self.nits,
+            "r": self.r,
+            "g": self.g,
+            "b": self.b,
+            "priority": self.priority,
+            "label": self.label,
+            "rationale": self.rationale,
+        }
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "SuggestedPatch":
+        return cls(
+            nits=float(d.get("nits", 0.0)),
+            r=int(d.get("r", 0)),
+            g=int(d.get("g", 0)),
+            b=int(d.get("b", 0)),
+            priority=str(d.get("priority", "medium")),
+            label=str(d.get("label", "")),
+            rationale=str(d.get("rationale", "")),
+        )
+
+
+@dataclass
+class PatchOptimization:
+    """LLM-generated optimized patch list derived from measurement residuals."""
+
+    patches: List[SuggestedPatch] = field(default_factory=list)
+    rationale: str = ""  # plain-English summary of the optimization strategy
+    confidence: float = 0.5  # 0.0–1.0
+    auto_apply: bool = False  # True when confidence >= 0.7
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "patches": [p.to_dict() for p in self.patches],
+            "rationale": self.rationale,
+            "confidence": self.confidence,
+            "auto_apply": self.auto_apply,
+            "patch_count": len(self.patches),
+        }
+
+
+def _extract_residuals(
+    grayscale_rows: List[Dict[str, Any]],
+    color_rows: List[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Distil per-patch residuals into a compact LLM-friendly summary.
+
+    Includes all patches sorted by ΔE descending so the LLM can clearly see
+    where the worst errors are and recommend denser sampling.
+    """
+    gray_sorted = sorted(
+        grayscale_rows,
+        key=lambda r: r.get("dE2000") or 0,
+        reverse=True,
+    )
+    color_sorted = sorted(
+        color_rows,
+        key=lambda r: r.get("dE2000") or 0,
+        reverse=True,
+    )
+
+    def _row_summary(r: Dict[str, Any]) -> Dict[str, Any]:
+        out: Dict[str, Any] = {"label": r.get("label", "")}
+        if r.get("dE2000") is not None:
+            out["dE2000"] = round(r["dE2000"], 2)
+        if r.get("gamma") is not None:
+            out["gamma"] = round(r["gamma"], 3)
+        if r.get("pq_error_pct") is not None:
+            out["pq_error_pct"] = round(r["pq_error_pct"], 1)
+        if r.get("dE2000_chroma_only") is not None:
+            out["dE2000_chroma"] = round(r["dE2000_chroma_only"], 2)
+        return out
+
+    return {
+        "grayscale_by_error": [_row_summary(r) for r in gray_sorted],
+        "color_by_error": [_row_summary(r) for r in color_sorted[:20]],
+    }
+
+
+def plan_patches(
+    grayscale_rows: List[Dict[str, Any]],
+    color_rows: List[Dict[str, Any]],
+    budget: int = MAX_PATCH_BUDGET,
+) -> Dict[str, Any]:
+    """Build a compact residual summary to pass to the LLM for patch planning.
+
+    Returns a dict ready to embed in an LLM prompt payload.
+    """
+    residuals = _extract_residuals(grayscale_rows, color_rows)
+    return {
+        "residuals": residuals,
+        "patch_budget": budget,
+    }

--- a/calibrator/reports.py
+++ b/calibrator/reports.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from html import escape
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from fastapi import HTTPException
 
@@ -66,6 +66,230 @@ def report_payload(session: Dict[str, Any]) -> Dict[str, Any]:
         "cms_measurements": cms["measurements"],
         "gamma_measurements": gamma["measurements"],
     }
+
+
+def comparison_payload(
+    session_a: Dict[str, Any],
+    session_b: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Build a delta comparison payload between two calibration sessions.
+
+    session_a is the baseline/earlier session; session_b is the more recent.
+    Reports scalars for all metric fields; flags TV and mode mismatches so callers
+    can surface a warning rather than crashing.
+    """
+    report_a = report_payload(session_a)
+    report_b = report_payload(session_b)
+
+    def _delta(val_b: Optional[float], val_a: Optional[float]) -> Optional[float]:
+        if val_b is None or val_a is None:
+            return None
+        return round(val_b - val_a, 2)
+
+    deltas: Dict[str, Any] = {
+        "pre_cal_avg_de": _delta(
+            report_b["pre_cal"]["avg_de"], report_a["pre_cal"]["avg_de"]
+        ),
+        "post_cal_avg_de": _delta(
+            report_b["post_cal"]["avg_de"], report_a["post_cal"]["avg_de"]
+        ),
+        "pre_cal_max_de": _delta(
+            report_b["pre_cal"]["max_de"], report_a["pre_cal"]["max_de"]
+        ),
+        "post_cal_max_de": _delta(
+            report_b["post_cal"]["max_de"], report_a["post_cal"]["max_de"]
+        ),
+        "wb_avg_de": _delta(
+            report_b["white_balance"]["avg_de"], report_a["white_balance"]["avg_de"]
+        ),
+        "cms_avg_de": _delta(
+            report_b["color_tuner"]["avg_de"], report_a["color_tuner"]["avg_de"]
+        ),
+        "gamma_avg": _delta(
+            report_b["gamma"]["avg_gamma"], report_a["gamma"]["avg_gamma"]
+        ),
+        "improvement_pct": _delta(
+            report_b["improvement_pct"], report_a["improvement_pct"]
+        ),
+        "peak_luminance": _delta(
+            report_b["peak_luminance"], report_a["peak_luminance"]
+        ),
+    }
+
+    return {
+        "session_a": {
+            "id": session_a.get("id", ""),
+            "date": session_a.get("created_at", ""),
+            "mode": session_a.get("mode", ""),
+            "tv": report_a["tv"],
+            "report": report_a,
+        },
+        "session_b": {
+            "id": session_b.get("id", ""),
+            "date": session_b.get("created_at", ""),
+            "mode": session_b.get("mode", ""),
+            "tv": report_b["tv"],
+            "report": report_b,
+        },
+        "deltas": deltas,
+        "tv_mismatch": session_a.get("tv_key") != session_b.get("tv_key"),
+        "mode_mismatch": session_a.get("mode") != session_b.get("mode"),
+    }
+
+
+def render_comparison_html(comparison: Dict[str, Any]) -> str:
+    """Render a side-by-side HTML comparison report for two calibration sessions."""
+
+    def fmt(value: Any, digits: int = 2, suffix: str = "") -> str:
+        if value is None:
+            return "—"
+        if isinstance(value, (int, float)):
+            return f"{value:.{digits}f}{suffix}"
+        return f"{value}{suffix}"
+
+    def delta_cell(val: Optional[float], *, lower_is_better: bool = True) -> str:
+        if val is None:
+            return "<td>—</td>"
+        improved = (val < 0) if lower_is_better else (val > 0)
+        color = "#0b6e4f" if improved else "#c0392b"
+        sign = "+" if val > 0 else ""
+        return f'<td style="color:{color};font-weight:600">{sign}{val:.2f}</td>'
+
+    sess_a = comparison["session_a"]
+    sess_b = comparison["session_b"]
+    rep_a = sess_a["report"]
+    rep_b = sess_b["report"]
+    deltas = comparison["deltas"]
+
+    title_a = escape(f'{sess_a["tv"]} — {sess_a["mode"]} ({str(sess_a["date"])[:10]})')
+    title_b = escape(f'{sess_b["tv"]} — {sess_b["mode"]} ({str(sess_b["date"])[:10]})')
+
+    mismatch_banner = ""
+    if comparison.get("tv_mismatch"):
+        mismatch_banner = (
+            '<div class="banner warn">⚠ Sessions are from different TV models — '
+            "delta values may not be meaningful.</div>"
+        )
+    elif comparison.get("mode_mismatch"):
+        mismatch_banner = (
+            '<div class="banner warn">⚠ Sessions use different calibration modes — '
+            "some metrics may not be directly comparable.</div>"
+        )
+
+    def stat_row(label: str, key_a: Any, key_b: Any, delta_key: str, lower_is_better: bool = True, digits: int = 2, suffix: str = "") -> str:
+        return (
+            f"<tr><th>{escape(label)}</th>"
+            f"<td>{fmt(key_a, digits, suffix)}</td>"
+            f"<td>{fmt(key_b, digits, suffix)}</td>"
+            f"{delta_cell(deltas.get(delta_key), lower_is_better=lower_is_better)}</tr>"
+        )
+
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Calibration Comparison</title>
+  <style>
+    :root {{--bg:#f5f1e8;--card:#fffdf8;--ink:#1f1b16;--muted:#6f6558;--border:#d9cfbf;--accent:#0b6e4f;}}
+    *{{box-sizing:border-box;}}
+    body{{margin:0;font-family:Georgia,serif;color:var(--ink);background:var(--bg);}}
+    .wrap{{max-width:1100px;margin:0 auto;padding:32px 20px 48px;}}
+    .hero{{background:var(--card);border:1px solid var(--border);border-radius:18px;padding:28px;margin-bottom:20px;}}
+    .eyebrow{{font-size:12px;text-transform:uppercase;letter-spacing:.14em;color:var(--muted);margin-bottom:8px;}}
+    h1{{margin:0 0 8px;font-size:28px;}} h2{{margin:24px 0 12px;font-size:20px;}}
+    .banner{{padding:12px 16px;border-radius:10px;margin-bottom:16px;font-size:14px;}}
+    .banner.warn{{background:#fff3cd;border:1px solid #ffc107;}}
+    table{{width:100%;border-collapse:collapse;background:var(--card);border:1px solid var(--border);border-radius:14px;overflow:hidden;margin-bottom:20px;}}
+    th,td{{padding:10px 12px;border-bottom:1px solid var(--border);text-align:left;font-size:14px;}}
+    thead th{{background:#f3ede3;color:var(--muted);font-weight:600;}}
+    th:first-child{{width:220px;}}
+    tr:last-child td,tr:last-child th{{border-bottom:none;}}
+    .col-a{{background:#f0f8ff;}}
+    .col-b{{background:#f0fff4;}}
+    .col-delta{{background:#fafafa;}}
+    .section{{margin-top:24px;}}
+    @media print {{
+      body{{background:#fff;}}
+      .section{{page-break-inside:avoid;}}
+    }}
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <section class="hero">
+      <div class="eyebrow">Session Comparison — ZRO Helper</div>
+      <h1>Before / After Delta Report</h1>
+    </section>
+    {mismatch_banner}
+    <section class="section">
+      <h2>Key Metrics</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Metric</th>
+            <th class="col-a">Session A (Before)<br><small>{title_a}</small></th>
+            <th class="col-b">Session B (After)<br><small>{title_b}</small></th>
+            <th class="col-delta">Δ (B − A)</th>
+          </tr>
+        </thead>
+        <tbody>
+          {stat_row("Pre-Cal Avg ΔE", rep_a["pre_cal"]["avg_de"], rep_b["pre_cal"]["avg_de"], "pre_cal_avg_de")}
+          {stat_row("Pre-Cal Max ΔE", rep_a["pre_cal"]["max_de"], rep_b["pre_cal"]["max_de"], "pre_cal_max_de")}
+          {stat_row("Post-Cal Avg ΔE", rep_a["post_cal"]["avg_de"], rep_b["post_cal"]["avg_de"], "post_cal_avg_de")}
+          {stat_row("Post-Cal Max ΔE", rep_a["post_cal"]["max_de"], rep_b["post_cal"]["max_de"], "post_cal_max_de")}
+          {stat_row("WB Avg ΔE", rep_a["white_balance"]["avg_de"], rep_b["white_balance"]["avg_de"], "wb_avg_de")}
+          {stat_row("CMS Avg ΔE", rep_a["color_tuner"]["avg_de"], rep_b["color_tuner"]["avg_de"], "cms_avg_de")}
+          {stat_row("Avg Gamma", rep_a["gamma"]["avg_gamma"], rep_b["gamma"]["avg_gamma"], "gamma_avg", lower_is_better=False, digits=3)}
+          {stat_row("Improvement %", rep_a["improvement_pct"], rep_b["improvement_pct"], "improvement_pct", lower_is_better=False, digits=1, suffix="%")}
+          {stat_row("Peak Luminance", rep_a["peak_luminance"], rep_b["peak_luminance"], "peak_luminance", lower_is_better=False, digits=1, suffix=" nits")}
+        </tbody>
+      </table>
+    </section>
+    <section class="section">
+      <h2>Pre-Calibration Grayscale</h2>
+      <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px;">
+        <div>
+          <h3 style="font-size:15px;margin:0 0 8px;">Session A</h3>
+          <table><thead><tr><th>Label</th><th>Nits</th><th>x</th><th>y</th></tr></thead>
+          <tbody>{render_measurement_rows(rep_a["pre_cal"]["measurements"])}</tbody></table>
+        </div>
+        <div>
+          <h3 style="font-size:15px;margin:0 0 8px;">Session B</h3>
+          <table><thead><tr><th>Label</th><th>Nits</th><th>x</th><th>y</th></tr></thead>
+          <tbody>{render_measurement_rows(rep_b["pre_cal"]["measurements"])}</tbody></table>
+        </div>
+      </div>
+    </section>
+    <section class="section">
+      <h2>Post-Calibration Grayscale</h2>
+      <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px;">
+        <div>
+          <h3 style="font-size:15px;margin:0 0 8px;">Session A</h3>
+          <table><thead><tr><th>Label</th><th>Nits</th><th>x</th><th>y</th></tr></thead>
+          <tbody>{render_measurement_rows(rep_a["post_cal"]["measurements"])}</tbody></table>
+        </div>
+        <div>
+          <h3 style="font-size:15px;margin:0 0 8px;">Session B</h3>
+          <table><thead><tr><th>Label</th><th>Nits</th><th>x</th><th>y</th></tr></thead>
+          <tbody>{render_measurement_rows(rep_b["post_cal"]["measurements"])}</tbody></table>
+        </div>
+      </div>
+    </section>
+  </div>
+</body>
+</html>"""
+
+
+def render_comparison_pdf(comparison: Dict[str, Any]) -> bytes:
+    try:
+        import weasyprint
+    except ImportError as exc:
+        raise RuntimeError(
+            "weasyprint is not installed. Run: pip install weasyprint"
+        ) from exc
+    html = render_comparison_html(comparison)
+    return weasyprint.HTML(string=html).write_pdf()
 
 
 def render_report_pdf(report: Dict[str, Any]) -> bytes:

--- a/cli.py
+++ b/cli.py
@@ -10,7 +10,7 @@ import os
 import time
 from dataclasses import asdict
 from pathlib import Path
-from typing import Optional
+from typing import Any, Dict, Optional
 
 from calcore import (
     AnalysisConfig,
@@ -21,7 +21,7 @@ from calcore import (
     determine_phase,
     parse_measurement_csv,
 )
-from calcore.llm import hash_summary
+from calcore.llm import hash_summary, query_delta_summary
 from calcore.models import Summary
 
 
@@ -215,11 +215,139 @@ def watch(csv_path: Path, state_path: Path, state: SessionState, interval: float
         time.sleep(interval)
 
 
+def _compare_sessions(
+    path_a: Path,
+    path_b: Path,
+    llm_cfg: Optional[LLMConfig] = None,
+) -> None:
+    """Print a before/after delta comparison for two session JSON report files."""
+    import json as _json
+
+    def _load_report(p: Path) -> Dict[str, Any]:
+        raw = _json.loads(p.read_text(encoding="utf-8"))
+        # Accept either a raw session JSON or an already-computed report payload.
+        # A session JSON has "pre_measurements"; a report payload has "pre_cal".
+        if "pre_cal" in raw:
+            return raw
+        # Build a minimal synthetic report from history-style entries
+        pre_de = raw.get("pre_grayscale_avg_de")
+        post_de = raw.get("post_grayscale_avg_de")
+        return {
+            "tv": raw.get("tv", str(p)),
+            "mode": raw.get("mode", ""),
+            "date": raw.get("date", ""),
+            "peak_luminance": raw.get("peak_luminance"),
+            "pre_cal": {"avg_de": pre_de, "max_de": None, "measurements": []},
+            "post_cal": {"avg_de": post_de, "max_de": None, "measurements": []},
+            "white_balance": {"avg_de": raw.get("wb_avg_de"), "max_de": None},
+            "color_tuner": {"avg_de": raw.get("cms_avg_de"), "max_de": None},
+            "gamma": {"avg_gamma": raw.get("gamma_avg"), "measurements": []},
+            "improvement_pct": raw.get("improvement_pct"),
+            "target": {},
+            "wb_measurements": [],
+            "cms_measurements": [],
+            "gamma_measurements": [],
+        }
+
+    rep_a = _load_report(path_a)
+    rep_b = _load_report(path_b)
+
+    def _delta(b_val: Optional[float], a_val: Optional[float]) -> str:
+        if b_val is None or a_val is None:
+            return "n/a"
+        d = b_val - a_val
+        sign = "+" if d > 0 else ""
+        return f"{sign}{d:.2f}"
+
+    deltas: Dict[str, Any] = {}
+    for key, (b_path, a_path) in {
+        "pre_cal_avg_de": (rep_b["pre_cal"]["avg_de"], rep_a["pre_cal"]["avg_de"]),
+        "post_cal_avg_de": (rep_b["post_cal"]["avg_de"], rep_a["post_cal"]["avg_de"]),
+        "wb_avg_de": (rep_b["white_balance"]["avg_de"], rep_a["white_balance"]["avg_de"]),
+        "cms_avg_de": (rep_b["color_tuner"]["avg_de"], rep_a["color_tuner"]["avg_de"]),
+        "gamma_avg": (rep_b["gamma"]["avg_gamma"], rep_a["gamma"]["avg_gamma"]),
+        "improvement_pct": (rep_b["improvement_pct"], rep_a["improvement_pct"]),
+        "peak_luminance": (rep_b["peak_luminance"], rep_a["peak_luminance"]),
+    }.items():
+        if b_path is not None and a_path is not None:
+            deltas[key] = round(b_path - a_path, 3)
+
+    print("\n" + "═" * 78)
+    print("BEFORE / AFTER DELTA REPORT")
+    print("═" * 78)
+    print(f"Session A (Before): {rep_a.get('tv', '')} — {rep_a.get('mode', '')} — {str(rep_a.get('date', ''))[:10]}")
+    print(f"Session B (After):  {rep_b.get('tv', '')} — {rep_b.get('mode', '')} — {str(rep_b.get('date', ''))[:10]}")
+    print()
+    print(f"{'Metric':<30} {'Session A':>12} {'Session B':>12} {'Δ (B-A)':>12}")
+    print("─" * 70)
+
+    def _row(label: str, a_val: Any, b_val: Any, delta_key: str, digits: int = 2, suffix: str = "") -> None:
+        a_str = f"{a_val:.{digits}f}{suffix}" if a_val is not None else "—"
+        b_str = f"{b_val:.{digits}f}{suffix}" if b_val is not None else "—"
+        d_str = _delta(b_val, a_val)
+        print(f"{label:<30} {a_str:>12} {b_str:>12} {d_str:>12}")
+
+    _row("Pre-Cal Avg ΔE", rep_a["pre_cal"]["avg_de"], rep_b["pre_cal"]["avg_de"], "pre_cal_avg_de")
+    _row("Post-Cal Avg ΔE", rep_a["post_cal"]["avg_de"], rep_b["post_cal"]["avg_de"], "post_cal_avg_de")
+    _row("WB Avg ΔE", rep_a["white_balance"]["avg_de"], rep_b["white_balance"]["avg_de"], "wb_avg_de")
+    _row("CMS Avg ΔE", rep_a["color_tuner"]["avg_de"], rep_b["color_tuner"]["avg_de"], "cms_avg_de")
+    _row("Avg Gamma", rep_a["gamma"]["avg_gamma"], rep_b["gamma"]["avg_gamma"], "gamma_avg", digits=3)
+    _row("Improvement %", rep_a["improvement_pct"], rep_b["improvement_pct"], "improvement_pct", digits=1, suffix="%")
+    _row("Peak Luminance", rep_a["peak_luminance"], rep_b["peak_luminance"], "peak_luminance", digits=1, suffix=" nit")
+    print("═" * 78)
+
+    if llm_cfg and llm_cfg.endpoint and llm_cfg.model:
+        print("\nGenerating LLM delta summary...")
+        try:
+            summary_text = query_delta_summary(rep_a, rep_b, deltas, llm_cfg)
+            if summary_text:
+                print("\nLLM ANALYSIS:")
+                for line in summary_text.splitlines():
+                    print(f"  {line}")
+        except Exception as exc:
+            print(f"[llm unavailable] {exc}")
+    print()
+
+
 def main() -> None:
     ap = argparse.ArgumentParser(
         description="Live calibration coach for ColourSpace CSV files."
     )
-    ap.add_argument("--csv", required=True, help="Path to the measurement CSV file")
+    subparsers = ap.add_subparsers(dest="command")
+
+    # ── compare subcommand ────────────────────────────────────────────────
+    compare_p = subparsers.add_parser(
+        "compare",
+        help="Compare two session report JSON files and print a delta table.",
+    )
+    compare_p.add_argument(
+        "session_a",
+        metavar="SESSION_A",
+        help="Path to the baseline session report JSON (before).",
+    )
+    compare_p.add_argument(
+        "session_b",
+        metavar="SESSION_B",
+        help="Path to the more recent session report JSON (after).",
+    )
+    compare_p.add_argument(
+        "--llm-endpoint",
+        default=os.environ.get("TVCAL_LLM_ENDPOINT", ""),
+        help="OpenAI-compatible endpoint for LLM delta summary (optional).",
+    )
+    compare_p.add_argument(
+        "--llm-model",
+        default=os.environ.get("TVCAL_LLM_MODEL", ""),
+        help="Model name for LLM delta summary (optional).",
+    )
+    compare_p.add_argument(
+        "--llm-api-key",
+        default=os.environ.get("TVCAL_LLM_API_KEY", ""),
+        help="API key for LLM endpoint.",
+    )
+
+    # ── watch/run subcommand (original behaviour) ─────────────────────────
+    ap.add_argument("--csv", help="Path to the measurement CSV file")
     ap.add_argument("--mode", choices=["sdr", "hdr"], default="hdr", help="Calibration mode")
     ap.add_argument(
         "--eotf",
@@ -268,6 +396,21 @@ def main() -> None:
         help="LLM timeout seconds",
     )
     args = ap.parse_args()
+
+    # ── compare subcommand ────────────────────────────────────────────────
+    if args.command == "compare":
+        llm_cfg: Optional[LLMConfig] = None
+        if args.llm_endpoint and args.llm_model:
+            llm_cfg = LLMConfig(
+                endpoint=args.llm_endpoint.strip(),
+                model=args.llm_model.strip(),
+                api_key=getattr(args, "llm_api_key", "").strip(),
+            )
+        _compare_sessions(Path(args.session_a), Path(args.session_b), llm_cfg)
+        return
+
+    if not args.csv:
+        ap.error("--csv is required when not using a subcommand")
 
     cfg = AnalysisConfig(
         mode=args.mode,

--- a/server.py
+++ b/server.py
@@ -43,8 +43,10 @@ from calcore.llm import (
     call_llm as _call_llm,
     parse_adjustment_plan as _parse_adjustment_plan,
     probe_llm as _probe_llm,
+    query_delta_summary as _query_delta_summary,
     query_gamut_advice as _query_gamut_advice,
     query_next_patch_strategy as _query_next_patch_strategy,
+    query_patch_optimization as _query_patch_optimization,
     query_remediation as _query_remediation,
 )
 from calcore.models import AnalysisConfig, LLMConfig, Patch, TVSettings
@@ -73,6 +75,9 @@ from calibrator.guidance import (
 )
 from calibrator.quality import QG_LUMINANCE_PCT, step_quality as _step_quality
 from calibrator.reports import (
+    comparison_payload as _comparison_payload,
+    render_comparison_html as _render_comparison_html,
+    render_comparison_pdf as _render_comparison_pdf,
     render_report_html as _render_report_html,
     render_report_pdf as _render_report_pdf,
     report_payload as _report_payload,
@@ -1325,6 +1330,185 @@ def get_report_pdf(sid: str):
         media_type="application/pdf",
         headers={"Content-Disposition": f'attachment; filename="{filename}"'},
     )
+
+
+# ── Before/After Delta Report endpoints (#168) ────────────────────────────────
+
+
+def _load_session_by_id(sid: str) -> Dict[str, Any]:
+    """Load a session from memory or disk. Raises 404 if not found."""
+    try:
+        return store.get(sid)
+    except HTTPException:
+        pass
+    path = SESSION_STORE_DIR / f"{sid}.json"
+    if not path.exists():
+        raise HTTPException(404, f"Session not found: {sid}")
+    try:
+        from calibrator.session import deserialize_session
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return deserialize_session(data)
+    except Exception as exc:
+        raise HTTPException(500, f"Could not load session {sid}: {exc}") from exc
+
+
+@app.get("/api/report/compare")
+def get_report_compare(a: str, b: str, format: str = "json"):
+    """Compare two sessions side-by-side.
+
+    Query params:
+      a: session ID of the baseline/earlier session
+      b: session ID of the more recent session
+      format: "json" (default) | "html" | "pdf"
+    """
+    session_a = _load_session_by_id(a)
+    session_b = _load_session_by_id(b)
+    comparison = _comparison_payload(session_a, session_b)
+
+    if format == "html":
+        return HTMLResponse(_render_comparison_html(comparison))
+    if format == "pdf":
+        try:
+            pdf_bytes = _render_comparison_pdf(comparison)
+        except RuntimeError as exc:
+            raise HTTPException(503, str(exc)) from exc
+        from fastapi.responses import Response
+        filename = f"comparison_{a[:8]}_vs_{b[:8]}.pdf"
+        return Response(
+            content=pdf_bytes,
+            media_type="application/pdf",
+            headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+        )
+    return comparison
+
+
+@app.post("/api/report/compare/delta_summary")
+def post_delta_summary(a: str, b: str):
+    """Generate an LLM-authored plain-language delta summary for two sessions.
+
+    Returns {"summary": "<prose paragraph>"} or {"summary": null} if no LLM is configured.
+    Uses the LLM configuration from session B.
+    """
+    session_a = _load_session_by_id(a)
+    session_b = _load_session_by_id(b)
+    comparison = _comparison_payload(session_a, session_b)
+
+    llm_cfg_dict = session_b.get("llm_config") or session_a.get("llm_config") or {}
+    if not (llm_cfg_dict.get("endpoint") and llm_cfg_dict.get("model")):
+        return {"summary": None, "reason": "LLM not configured"}
+
+    llm_cfg = LLMConfig(
+        endpoint=llm_cfg_dict.get("endpoint", ""),
+        model=llm_cfg_dict.get("model", ""),
+        api_key=llm_cfg_dict.get("api_key", ""),
+        temperature=float(llm_cfg_dict.get("temperature", 0.3)),
+        timeout=float(llm_cfg_dict.get("timeout", 45.0)),
+    )
+    summary_text = _query_delta_summary(
+        comparison["session_a"]["report"],
+        comparison["session_b"]["report"],
+        comparison["deltas"],
+        llm_cfg,
+    )
+    return {"summary": summary_text, "deltas": comparison["deltas"]}
+
+
+# ── Suggested patches endpoint (#173) ─────────────────────────────────────────
+
+
+@app.get("/api/session/{sid}/suggested-patches")
+def get_suggested_patches(sid: str, budget: int = 30):
+    """Return an LLM-optimized patch list based on current measurement residuals.
+
+    Analyzes per-patch ΔE from all imported measurements and asks the LLM to
+    recommend denser sampling where error is highest.  budget caps the total
+    patch count (default 30, configurable via query param).
+
+    Returns {"optimization": {...}} with patches list, rationale, confidence,
+    and auto_apply flag.  Returns {"optimization": null} if LLM is not configured.
+    """
+    if budget < 1 or budget > 200:
+        raise HTTPException(400, "budget must be between 1 and 200")
+
+    session = store.get(sid)
+
+    all_measurements = (
+        session.get("pre_measurements", [])
+        + session.get("wb_measurements", [])
+        + session.get("gamma_measurements", [])
+        + session.get("cms_measurements", [])
+        + session.get("post_measurements", [])
+    )
+    if not all_measurements:
+        raise HTTPException(400, "No measurements in session; import data first.")
+
+    llm_cfg_dict = session.get("llm_config", {})
+    if not (llm_cfg_dict.get("endpoint") and llm_cfg_dict.get("model")):
+        return {"optimization": None, "reason": "LLM not configured"}
+
+    cfg = _session_to_analysis_config(session)
+    patches_core = [_measurement_to_patch(m) for m in all_measurements]
+    summary = _calcore_analyze(patches_core, cfg)
+
+    llm_cfg = LLMConfig(
+        endpoint=llm_cfg_dict.get("endpoint", ""),
+        model=llm_cfg_dict.get("model", ""),
+        api_key=llm_cfg_dict.get("api_key", ""),
+        temperature=float(llm_cfg_dict.get("temperature", 0.2)),
+        timeout=float(llm_cfg_dict.get("timeout", 60.0)),
+    )
+    phase = session.get("step", "baseline")
+    optimization = _query_patch_optimization(
+        summary.grayscale_rows,
+        summary.color_rows,
+        phase=phase,
+        patch_budget=budget,
+        llm=llm_cfg,
+    )
+
+    if optimization is None:
+        return {"optimization": None, "reason": "LLM returned no result"}
+
+    return {"optimization": optimization.to_dict()}
+
+
+@app.post("/api/session/{sid}/suggested-patches/run")
+def run_suggested_patches(sid: str, body: dict):
+    """Forward a patch sequence to the ZRO bridge for measurement.
+
+    Body: {"patches": [{nits, r, g, b, priority, label}, ...]}
+    Sends a POST to {_zro_bridge_url}/measure/sequence with the patch list.
+    The ZRO bridge must support arbitrary patch sequences (not just fixed grids).
+    """
+    global _zro_bridge_url
+    if not _zro_bridge_url:
+        raise HTTPException(
+            400,
+            'ZRO Bridge URL not configured. Set ZRO_BRIDGE_URL env var or POST /api/zro/bridge/config.',
+        )
+    patches = body.get("patches")
+    if not patches or not isinstance(patches, list):
+        raise HTTPException(400, "Body must include a non-empty 'patches' list.")
+    if len(patches) > 200:
+        raise HTTPException(400, "Patch sequence too long (max 200).")
+
+    try:
+        resp = httpx.post(
+            f"{_zro_bridge_url}/measure/sequence",
+            json={"patches": patches},
+            timeout=30.0,
+        )
+        resp.raise_for_status()
+        return resp.json()
+    except httpx.ConnectError:
+        raise HTTPException(
+            502,
+            f"Cannot reach ZRO Bridge at {_zro_bridge_url} — is start.bat running on the Windows PC?",
+        )
+    except httpx.HTTPStatusError as exc:
+        raise HTTPException(502, f"ZRO Bridge error: {exc.response.text}")
+    except Exception as exc:
+        raise HTTPException(500, f"ZRO Bridge proxy error: {exc}")
 
 
 @app.get("/api/adb/status")

--- a/tests/test_delta_report.py
+++ b/tests/test_delta_report.py
@@ -37,6 +37,7 @@ def _reset_globals():
         },
     }
     server_module._llm_queues.clear()
+    server_module._zro_bridge_url = ""
 
 
 @pytest.fixture(autouse=True)
@@ -252,12 +253,12 @@ class TestSuggestedPatches:
         assert resp.status_code == 400
 
     def test_suggested_patches_run_bridge_unreachable_returns_502(self, client):
+        server_module._zro_bridge_url = "http://localhost:19999"  # nothing listening here
         sid = _make_session_with_measurements(client)
         resp = client.post(
             f"/api/session/{sid}/suggested-patches/run",
             json={"patches": [{"nits": 100.0, "r": 200, "g": 200, "b": 200, "priority": "high", "label": "Test"}]},
         )
-        # Bridge URL is set by default (http://localhost:7070) but nothing is running
         assert resp.status_code == 502
 
 

--- a/tests/test_delta_report.py
+++ b/tests/test_delta_report.py
@@ -1,0 +1,323 @@
+"""Tests for Before/After Delta Report (issue #168) and Predictive Patch Density (issue #173)."""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from calibrator import Measurement
+from calibrator.reports import comparison_payload
+import server as server_module
+from server import app, _sessions
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+def _reset_globals():
+    _sessions.clear()
+    server_module._watched_session_id = None
+    server_module._dogegen_proc = None
+    server_module._dogegen_started_at = None
+    server_module._dogegen_launch_cmd = []
+    server_module._dogegen_last_error = None
+    server_module._dogegen_config = {
+        "path": "",
+        "resolve_host": "",
+        "window_pct": 10,
+        "maxcll": 1000,
+    }
+    server_module._prefs = {
+        "dogegen": {},
+        "bridge_url": "",
+        "watch_folder": "",
+        "llm": {"endpoint": "", "model": ""},
+        "session_defaults": {
+            "signal_range": "full",
+            "code_scale": "8bit",
+            "pattern_generator": "dogegen",
+        },
+    }
+    server_module._llm_queues.clear()
+
+
+@pytest.fixture(autouse=True)
+def clear_sessions():
+    _reset_globals()
+    yield
+    _reset_globals()
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+def _make_session_with_measurements(client, mode="SDR"):
+    """Create a session with SDR measurements ready for report generation."""
+    resp = client.post("/api/session", json={"tv_key": "u8g"})
+    sid = resp.json()["id"]
+    client.post(f"/api/session/{sid}/mode", json={"mode": mode})
+    client.post(f"/api/session/{sid}/prepared")
+
+    measurements = [
+        Measurement(
+            x=0.3127, y=0.3290,
+            Y=float(pct),
+            X=float(pct) * 0.95,
+            Z=float(pct) * 1.09,
+            label=f"{pct}% Gray",
+            stimulus_rgb=(pct * 2, pct * 2, pct * 2),
+        )
+        for pct in [10, 20, 30, 40, 50, 60, 70, 80, 90, 100]
+    ]
+
+    _sessions[sid]["pre_measurements"] = measurements
+    _sessions[sid]["post_measurements"] = [
+        Measurement(
+            x=0.3127, y=0.3290,
+            Y=float(pct) * 1.02,
+            X=float(pct) * 0.97,
+            Z=float(pct) * 1.07,
+            label=f"{pct}% Gray",
+            stimulus_rgb=(pct * 2, pct * 2, pct * 2),
+        )
+        for pct in [10, 20, 30, 40, 50, 60, 70, 80, 90, 100]
+    ]
+    _sessions[sid]["peak_luminance"] = 500.0
+
+    return sid
+
+
+# ── comparison_payload unit tests ─────────────────────────────────────────────
+
+class TestComparisonPayload:
+    def test_comparison_payload_structure(self, client):
+        sid_a = _make_session_with_measurements(client)
+        sid_b = _make_session_with_measurements(client)
+
+        sess_a = _sessions[sid_a]
+        sess_b = _sessions[sid_b]
+
+        result = comparison_payload(sess_a, sess_b)
+
+        assert "session_a" in result
+        assert "session_b" in result
+        assert "deltas" in result
+        assert "tv_mismatch" in result
+        assert "mode_mismatch" in result
+
+    def test_comparison_same_session_zero_deltas(self, client):
+        sid = _make_session_with_measurements(client)
+        sess = _sessions[sid]
+
+        result = comparison_payload(sess, sess)
+        deltas = result["deltas"]
+
+        # Same session: all non-None deltas should be 0.0
+        for key, val in deltas.items():
+            if val is not None:
+                assert abs(val) < 0.01, f"Expected ~0 delta for {key}, got {val}"
+
+    def test_comparison_no_tv_mismatch_same_key(self, client):
+        sid_a = _make_session_with_measurements(client)
+        sid_b = _make_session_with_measurements(client)
+
+        result = comparison_payload(_sessions[sid_a], _sessions[sid_b])
+        assert result["tv_mismatch"] is False
+        assert result["mode_mismatch"] is False
+
+    def test_comparison_flags_mode_mismatch(self, client):
+        sid_a = _make_session_with_measurements(client, mode="SDR")
+        sid_b = _make_session_with_measurements(client, mode="HDR10")
+
+        result = comparison_payload(_sessions[sid_a], _sessions[sid_b])
+        assert result["mode_mismatch"] is True
+
+    def test_comparison_deltas_are_b_minus_a(self, client):
+        sid_a = _make_session_with_measurements(client)
+        sid_b = _make_session_with_measurements(client)
+        # Inflate session B's peak luminance to create a detectable delta
+        _sessions[sid_b]["peak_luminance"] = 600.0
+
+        result = comparison_payload(_sessions[sid_a], _sessions[sid_b])
+        delta_peak = result["deltas"]["peak_luminance"]
+        assert delta_peak is not None
+        assert abs(delta_peak - 100.0) < 1.0  # 600 - 500 = 100
+
+    def test_comparison_reports_include_tv_name(self, client):
+        sid_a = _make_session_with_measurements(client)
+        result = comparison_payload(_sessions[sid_a], _sessions[sid_a])
+        assert result["session_a"]["tv"]
+        assert result["session_b"]["tv"]
+
+
+# ── GET /api/report/compare ────────────────────────────────────────────────────
+
+class TestCompareEndpoint:
+    def test_compare_returns_json(self, client):
+        sid_a = _make_session_with_measurements(client)
+        sid_b = _make_session_with_measurements(client)
+
+        resp = client.get(f"/api/report/compare?a={sid_a}&b={sid_b}")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "deltas" in data
+        assert "session_a" in data
+        assert "session_b" in data
+
+    def test_compare_returns_html(self, client):
+        sid_a = _make_session_with_measurements(client)
+        sid_b = _make_session_with_measurements(client)
+
+        resp = client.get(f"/api/report/compare?a={sid_a}&b={sid_b}&format=html")
+        assert resp.status_code == 200
+        assert "text/html" in resp.headers["content-type"]
+        assert "Before / After Delta Report" in resp.text
+
+    def test_compare_404_for_unknown_session_a(self, client):
+        sid_b = _make_session_with_measurements(client)
+        resp = client.get(f"/api/report/compare?a=doesnotexist&b={sid_b}")
+        assert resp.status_code == 404
+
+    def test_compare_404_for_unknown_session_b(self, client):
+        sid_a = _make_session_with_measurements(client)
+        resp = client.get(f"/api/report/compare?a={sid_a}&b=doesnotexist")
+        assert resp.status_code == 404
+
+    def test_compare_html_includes_delta_section(self, client):
+        sid_a = _make_session_with_measurements(client)
+        sid_b = _make_session_with_measurements(client)
+
+        resp = client.get(f"/api/report/compare?a={sid_a}&b={sid_b}&format=html")
+        assert "Key Metrics" in resp.text
+        assert "Pre-Cal Avg" in resp.text
+        assert "Post-Cal Avg" in resp.text
+
+    def test_compare_same_session_is_valid(self, client):
+        sid = _make_session_with_measurements(client)
+        resp = client.get(f"/api/report/compare?a={sid}&b={sid}")
+        assert resp.status_code == 200
+
+    def test_compare_without_llm_delta_summary_returns_null(self, client):
+        sid_a = _make_session_with_measurements(client)
+        sid_b = _make_session_with_measurements(client)
+
+        resp = client.post(
+            f"/api/report/compare/delta_summary?a={sid_a}&b={sid_b}"
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["summary"] is None
+
+
+# ── GET /api/session/{sid}/suggested-patches ──────────────────────────────────
+
+class TestSuggestedPatches:
+    def test_suggested_patches_no_llm_returns_null(self, client):
+        sid = _make_session_with_measurements(client)
+        resp = client.get(f"/api/session/{sid}/suggested-patches")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["optimization"] is None
+        assert "reason" in data
+
+    def test_suggested_patches_no_measurements_returns_400(self, client):
+        resp = client.post("/api/session", json={"tv_key": "u8g"})
+        sid = resp.json()["id"]
+        client.post(f"/api/session/{sid}/mode", json={"mode": "SDR"})
+        client.post(f"/api/session/{sid}/prepared")
+        # Ensure no measurements are present and LLM is configured to bypass the LLM gate
+        _sessions[sid]["llm_config"] = {"endpoint": "http://localhost:4000", "model": "test"}
+
+        resp = client.get(f"/api/session/{sid}/suggested-patches")
+        assert resp.status_code == 400
+
+    def test_suggested_patches_invalid_budget_returns_400(self, client):
+        sid = _make_session_with_measurements(client)
+        resp = client.get(f"/api/session/{sid}/suggested-patches?budget=0")
+        assert resp.status_code == 400
+
+        resp = client.get(f"/api/session/{sid}/suggested-patches?budget=201")
+        assert resp.status_code == 400
+
+    def test_suggested_patches_404_for_unknown_session(self, client):
+        resp = client.get("/api/session/doesnotexist/suggested-patches")
+        assert resp.status_code == 404
+
+    def test_suggested_patches_run_with_empty_list_returns_400(self, client):
+        sid = _make_session_with_measurements(client)
+        resp = client.post(
+            f"/api/session/{sid}/suggested-patches/run",
+            json={"patches": []},
+        )
+        assert resp.status_code == 400
+
+    def test_suggested_patches_run_bridge_unreachable_returns_502(self, client):
+        sid = _make_session_with_measurements(client)
+        resp = client.post(
+            f"/api/session/{sid}/suggested-patches/run",
+            json={"patches": [{"nits": 100.0, "r": 200, "g": 200, "b": 200, "priority": "high", "label": "Test"}]},
+        )
+        # Bridge URL is set by default (http://localhost:7070) but nothing is running
+        assert resp.status_code == 502
+
+
+# ── calcore/patch_planner unit tests ──────────────────────────────────────────
+
+class TestPatchPlanner:
+    def test_plan_patches_returns_residuals(self):
+        from calcore.patch_planner import plan_patches
+
+        gray_rows = [
+            {"label": "10% Gray", "dE2000": 5.2, "gamma": 2.1},
+            {"label": "50% Gray", "dE2000": 1.1, "gamma": 2.2},
+            {"label": "90% Gray", "dE2000": 3.8, "gamma": 2.3},
+        ]
+        color_rows = [
+            {"label": "Red 100%", "dE2000": 4.0, "dE2000_chroma_only": 3.0},
+            {"label": "Blue 75%", "dE2000": 1.5, "dE2000_chroma_only": 1.0},
+        ]
+        result = plan_patches(gray_rows, color_rows, budget=15)
+
+        assert "residuals" in result
+        assert "patch_budget" in result
+        assert result["patch_budget"] == 15
+        assert "grayscale_by_error" in result["residuals"]
+        assert "color_by_error" in result["residuals"]
+
+    def test_plan_patches_sorts_by_error_descending(self):
+        from calcore.patch_planner import plan_patches
+
+        gray_rows = [
+            {"label": "A", "dE2000": 1.0},
+            {"label": "B", "dE2000": 5.0},
+            {"label": "C", "dE2000": 3.0},
+        ]
+        result = plan_patches(gray_rows, [], budget=30)
+        sorted_labels = [r["label"] for r in result["residuals"]["grayscale_by_error"]]
+        assert sorted_labels == ["B", "C", "A"]
+
+    def test_suggested_patch_from_dict_round_trips(self):
+        from calcore.patch_planner import SuggestedPatch
+
+        p = SuggestedPatch(nits=100.0, r=200, g=200, b=200, priority="high", label="Test", rationale="Because")
+        d = p.to_dict()
+        p2 = SuggestedPatch.from_dict(d)
+        assert p2.nits == p.nits
+        assert p2.r == p.r
+        assert p2.priority == p.priority
+        assert p2.label == p.label
+
+    def test_patch_optimization_to_dict(self):
+        from calcore.patch_planner import PatchOptimization, SuggestedPatch
+
+        opt = PatchOptimization(
+            patches=[SuggestedPatch(nits=80.0, r=200, g=200, b=200, priority="high", label="G80")],
+            rationale="Dense 60-85% range",
+            confidence=0.85,
+            auto_apply=True,
+        )
+        d = opt.to_dict()
+        assert d["patch_count"] == 1
+        assert d["auto_apply"] is True
+        assert d["confidence"] == 0.85
+        assert d["patches"][0]["label"] == "G80"


### PR DESCRIPTION
## Summary

Implements two new features:

- **[#168 Before/After Delta Report](https://github.com/jweber93/tv-calibration/issues/168)** — compare any two calibration sessions side-by-side, with JSON/HTML/PDF output and an optional LLM-narrated delta paragraph
- **[#173 Predictive Patch Density via LLM](https://github.com/jweber93/tv-calibration/issues/173)** — LLM analyzes per-patch ΔE residuals and recommends an optimized next-round patch set; forwards to ZRO Bridge for immediate measurement

## Changes

**New file:** `calcore/patch_planner.py`
- `SuggestedPatch` dataclass `{nits, r, g, b, priority, label, rationale}`
- `PatchOptimization` dataclass with `patches`, `rationale`, `confidence`, `auto_apply`
- `plan_patches()` extracts residuals sorted by ΔE for LLM prompt construction

**`calcore/llm.py`** — two new LLM functions:
- `query_patch_optimization()` — sends full per-patch residuals, returns structured patch list (JSON mode, capped at configurable budget)
- `query_delta_summary()` — narrates before/after session comparison in plain English

**`calibrator/reports.py`** — comparison report functions:
- `comparison_payload(session_a, session_b)` — computes Δ for all scalar metrics; flags TV/mode mismatches
- `render_comparison_html()` — side-by-side stat table with colour-coded Δ column (green = improved, red = regressed)
- `render_comparison_pdf()` — WeasyPrint wrapper

**`server.py`** — new endpoints:
- `GET /api/report/compare?a={id}&b={id}[&format=html|pdf]`
- `POST /api/report/compare/delta_summary?a={id}&b={id}`
- `GET /api/session/{sid}/suggested-patches?budget=30`
- `POST /api/session/{sid}/suggested-patches/run` (forwards to `{bridge}/measure/sequence`)

**`cli.py`** — `compare` subcommand:
```bash
python cli.py compare before.json after.json [--llm-endpoint URL --llm-model MODEL]
```

**`README.md`** — documented both features under Feature Details, updated AI capabilities table and API reference table

## Test plan

- [x] 23 new tests in `tests/test_delta_report.py`
- [x] Covers: comparison payload structure, zero-delta invariant, mode mismatch detection, HTML rendering, 404 handling, budget validation, patch planner unit tests, `SuggestedPatch` round-trip
- [x] All 126 tests pass (`python3 -m pytest tests/test_delta_report.py tests/test_server_api.py --no-cov`)
- [x] All files compile cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)