### PR TITLE
ci: publish calcore-server to ghcr.io on main/tag push

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,57 @@
+name: Docker Publish
+
+# Publishes calcore-server to ghcr.io/jweber93/tv-calibration.
+#
+# Triggers:
+#   push to main  → ghcr.io/jweber93/tv-calibration:latest
+#   v* tag        → ghcr.io/jweber93/tv-calibration:v1.2.3  (+ latest)
+#   workflow_dispatch → manual publish of current branch/tag
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    name: Build and push to ghcr.io
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/jweber93/tv-calibration
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=ref,event=tag
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/README.md
+++ b/README.md
@@ -195,6 +195,13 @@ uvicorn server:app --port 8000
 
 The repository ships with a `Dockerfile` and `docker-compose.yml` that run the FastAPI backend, LiteLLM proxy, and a Samba share (for ZRO CSV auto-import from Windows) as a single composed stack.
 
+A pre-built image is published to GitHub Container Registry on every push to `main` and every version tag:
+
+```
+ghcr.io/jweber93/tv-calibration:latest
+ghcr.io/jweber93/tv-calibration:v1.2.3   # tagged releases
+```
+
 ### Docker Compose (recommended)
 
 ```bash
@@ -241,14 +248,24 @@ Then in the AI Assistant section on the Prepare page, set the endpoint to `http:
 
 ### Standalone container (no LiteLLM or Samba)
 
+Pull the published image or build locally:
+
 ```bash
-docker build -t tv-calibration/calcore-server:latest .
+# Pull from GHCR (no build required)
+docker pull ghcr.io/jweber93/tv-calibration:latest
 
 docker run -d --name tv-cal \
   -p 8000:8000 \
   -v calcore-data:/app/data \
   -e LITELLM_ENDPOINT= \
   -e LITELLM_MODEL= \
+  ghcr.io/jweber93/tv-calibration:latest
+
+# Or build locally from source
+docker build -t tv-calibration/calcore-server:latest .
+docker run -d --name tv-cal \
+  -p 8000:8000 \
+  -v calcore-data:/app/data \
   tv-calibration/calcore-server:latest
 ```
 
@@ -269,27 +286,22 @@ AI features require a separately-reachable LLM endpoint; set `LITELLM_ENDPOINT` 
 
 ## Unraid
 
-An Unraid container template (`unraid-template.xml`) is included in the repository. It is also registered at the template URL below, which means it can be found in **Community Applications** once the image is published to a registry.
+An Unraid container template (`unraid-template.xml`) is included in the repository and registered at its `<TemplateURL>`, so it will appear in **Community Applications** automatically.
 
-> **Note:** The image is not yet published to Docker Hub or GHCR. Until it is, follow the manual install steps below to build it locally on your Unraid server.
+The image is published to `ghcr.io/jweber93/tv-calibration:latest` — no local build required.
+
+### Install on Unraid via Community Applications
+
+Search for **tv-calibration** in the Community Applications plugin and click Install. The template pre-fills all paths; you only need to set the **ZRO Drops Share** path to match your ColourSpace export directory.
 
 ### Manual install on Unraid
 
-1. SSH into your Unraid server and clone the repo:
-
-   ```bash
-   cd /tmp
-   git clone https://github.com/jweber93/tv-calibration.git
-   cd tv-calibration
-   docker build -t tv-calibration/calcore-server:latest .
-   ```
-
-2. In the Unraid web UI go to **Docker → Add Container** and fill in:
+1. In the Unraid web UI go to **Docker → Add Container** and fill in:
 
    | Field | Value |
    |---|---|
    | **Name** | `tv-calibration` |
-   | **Repository** | `tv-calibration/calcore-server:latest` |
+   | **Repository** | `ghcr.io/jweber93/tv-calibration:latest` |
    | **Network type** | Bridge |
    | **Port** | `8000 → 8000 (TCP)` |
 

--- a/unraid-template.xml
+++ b/unraid-template.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <Container version="2">
   <Name>tv-calibration</Name>
-  <Repository>tv-calibration/calcore-server:latest</Repository>
-  <Registry>https://hub.docker.com/</Registry>
+  <Repository>ghcr.io/jweber93/tv-calibration:latest</Repository>
+  <Registry>https://ghcr.io</Registry>
   <Network>bridge</Network>
   <MyIP/>
   <Shell>sh</Shell>


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/docker-publish.yml` — logs in to GHCR with `GITHUB_TOKEN` (no extra secrets needed) and pushes the image on every merge to `main` and every `v*` tag
- Updates `unraid-template.xml` `<Repository>` from the placeholder `tv-calibration/calcore-server:latest` to `ghcr.io/jweber93/tv-calibration:latest`
- Updates README Docker and Unraid sections to reference the published image and add `docker pull` instructions

## Published image names

| Trigger | Tag(s) pushed |
|---|---|
| Push to `main` | `ghcr.io/jweber93/tv-calibration:latest` |
| `v1.2.3` tag | `ghcr.io/jweber93/tv-calibration:v1.2.3`, `:1.2`, `:latest` |
| `workflow_dispatch` | same as `main` push |

## No extra secrets required

The workflow uses `secrets.GITHUB_TOKEN` which is automatically available in all GitHub Actions runs. The repo just needs to have **packages: write** permission, which is set in the workflow's `permissions` block.

## Test plan

- [ ] Merge to `main` → verify image appears at `https://github.com/jweber93/tv-calibration/pkgs/container/tv-calibration`
- [ ] `docker pull ghcr.io/jweber93/tv-calibration:latest` succeeds
- [ ] Push a `v0.1.0` tag → verify versioned tag is also published
- [ ] Unraid: confirm `ghcr.io/jweber93/tv-calibration:latest` resolves in the Docker UI

https://claude.ai/code/session_013TQNX18sbXJAiggvpJA8Pr