### PR TITLE
Strengthen PR discipline and add post-merge branch cleanup

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,0 +1,26 @@
+name: Delete merged branch
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  delete-branch:
+    if: github.event.pull_request.merged == true && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const branch = context.payload.pull_request.head.ref;
+            if (['main', 'master', 'develop'].includes(branch)) return;
+            try {
+              await github.rest.git.deleteRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: `heads/${branch}`,
+              });
+              console.log(`Deleted branch: ${branch}`);
+            } catch (e) {
+              console.log(`Could not delete ${branch}: ${e.message}`);
+            }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,15 +7,15 @@
 
 ## Standard Commands
 
-When I say **"resolve issue [URL]"**, execute the Issue Resolution Protocol:
+When I say **"resolve issue [URL]"**, **"fix bug"**, **"debug"**, **"work on"**, or describe any bug/defect, execute the Bug Resolution Protocol:
 - Read full relevant codebase context before writing any code
 - Identify root cause, not symptom
 - Reuse existing patterns and abstractions
 - Flag scope creep before proceeding
 - Write unit + integration tests, all must pass
 - Atomic commits, imperative mood, <72 chars, no "fix"/"update"/"misc"
-- Branch: [feat|fix|chore]/[short-slug]
-- Push and create PR when done
+- Branch: `fix/[short-slug]`
+- Push and **open a draft PR** — always, without being asked
 
 When I say **"implement feature"**, execute the Feature Implementation Protocol:
 - Read AGENTS.md and CONTRIBUTING.md first
@@ -23,6 +23,7 @@ When I say **"implement feature"**, execute the Feature Implementation Protocol:
 - Flag hidden complexity before proceeding
 - Production quality, full test coverage, docs updated
 - Follow commit/branch/PR conventions above
+- Push and **open a draft PR** — always, without being asked
 
 When I say **"audit codebase"**, execute the Codebase Audit Protocol:
 - Act as Principal Engineer + Color Scientist
@@ -41,13 +42,25 @@ When I say **"audit QE"**, execute the QE Audit Protocol:
 1. `git checkout -b [feat|fix|chore]/[short-slug]`
 2. Atomic commits, imperative mood, <72 chars, no "fix"/"update"/"misc"
 3. `git push -u origin HEAD`
-4. Open PR
+4. **Open a draft PR immediately after first push** — do not wait to be asked
+
+## Post-Merge Cleanup
+
+When I say **"cleanup"** or **"branch was merged"** or **"PR [number] merged"**, execute the Cleanup Protocol:
+- `git fetch -p` to prune remote tracking refs
+- `git checkout main && git pull origin main`
+- `git branch -d [merged-branch]` (local cleanup)
+- Check for any stale fix/* or feat/* branches older than 7 days and list them
+- Report what was cleaned
+
+> Note: Auto-delete on GitHub is handled by the `.github/workflows/cleanup.yml` action — you only need the local steps above.
 
 ## Non-negotiables
 - Tests must pass. Never leave broken tests.
 - No mocking things that don't need mocking.
 - If blocked or ambiguous, stop and report — do not work around it.
 - No TODOs or placeholders. Production quality only.
+- **Every task that touches code ends with a pushed branch and an open PR.** No exceptions.
 
 ## Memory Protocol
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **AGENTS.md**: Expands bug-fix triggers to catch natural language ("fix bug", "debug", "work on") — not just `"resolve issue [URL]"`
- **AGENTS.md**: Makes draft PR creation unconditional after any code task, plus adds a `cleanup` / "branch was merged" command so qwen3.6 knows the local cleanup steps
- **cleanup.yml**: New GH Actions workflow that auto-deletes the remote branch whenever a PR is merged (guards main/master/develop)

## Why

The old AGENTS.md only fired the full PR workflow on exact keyword matches. Agents doing general bug work would finish without opening a PR. Also, qwen3.6 doesn't have native merge-event subscriptions like Claude Desktop — the GH Actions workflow fills that gap automatically, and the AGENTS.md protocol covers the local side when the agent is told a merge happened.

## Test plan

- [ ] Tell an agent "fix bug in file_watcher.py" and confirm it opens a draft PR without being prompted
- [ ] Merge any feature branch PR and verify the remote branch is deleted by the cleanup action
- [ ] Tell qwen3.6 "cleanup, branch was merged" and verify it runs the local prune/pull/delete steps

https://claude.ai/code/session_01FiMY9jarstKzFNGJyVtj66
EOF
)