### PR TITLE
Require issue linking and auto-close in PR body

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,8 +14,11 @@ When I say **"resolve issue [URL]"**, **"fix bug"**, **"debug"**, **"work on"**,
 - Flag scope creep before proceeding
 - Write unit + integration tests, all must pass
 - Atomic commits, imperative mood, <72 chars, no "fix"/"update"/"misc"
+- At least one commit message must reference the issue: `(#[issue-number])`
 - Branch: `fix/[short-slug]`
 - Push and **open a draft PR** — always, without being asked
+- PR body **must** include `Closes #[issue-number]` so GitHub auto-closes the issue on merge
+- If the issue URL was given, extract the number from it; if only a description was given, search for the matching open issue first
 
 When I say **"implement feature"**, execute the Feature Implementation Protocol:
 - Read AGENTS.md and CONTRIBUTING.md first
@@ -24,6 +27,7 @@ When I say **"implement feature"**, execute the Feature Implementation Protocol:
 - Production quality, full test coverage, docs updated
 - Follow commit/branch/PR conventions above
 - Push and **open a draft PR** — always, without being asked
+- If this work originated from an issue, include `Closes #[issue-number]` in the PR body
 
 When I say **"audit codebase"**, execute the Codebase Audit Protocol:
 - Act as Principal Engineer + Color Scientist


### PR DESCRIPTION
## Summary

- Agents were completing bug fixes without `Closes #N` in the PR body, leaving issues open after merge (see #193 which fixed #185 but never closed it)
- Bug protocol now requires `Closes #[issue-number]` in PR body and `(#N)` in at least one commit message
- If only a description was given (no URL), agent must search for the matching open issue first
- Feature protocol gets the same `Closes #N` requirement

## Test plan

- [ ] Tell an agent "fix bug in X" and confirm the resulting PR body contains `Closes #N`
- [ ] Merge the PR and verify the linked issue auto-closes

https://claude.ai/code/session_01FiMY9jarstKzFNGJyVtj66