### PR TITLE
Route grayscale CSV patches by stimulus level and session step

### DIFF
--- a/calibrator/csv_adapter.py
+++ b/calibrator/csv_adapter.py
@@ -57,9 +57,7 @@ def _bucket_for_grayscale(stim_pct: float, session_step: Optional[str]) -> List[
         buckets.append("lum_measurements")
 
     # White balance: 80% gain, 30% offset
-    if _nearest_target_pct(stim_pct, (WB_GAIN_TARGET_PCT,)) is not None:
-        buckets.append("wb_measurements")
-    elif _nearest_target_pct(stim_pct, (WB_OFFSET_TARGET_PCT,)) is not None:
+    if _nearest_target_pct(stim_pct, (WB_GAIN_TARGET_PCT, WB_OFFSET_TARGET_PCT)) is not None:
         buckets.append("wb_measurements")
 
     # Gamma tracking: snap to nearest 5% step

--- a/calibrator/csv_adapter.py
+++ b/calibrator/csv_adapter.py
@@ -1,25 +1,92 @@
 import logging
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional
 from datetime import datetime, timezone
 
 from calcore.models import Measurement, Patch
 from calibrator.session import ZROImportResult, CalibrationTarget
+from calibrator.utils import stimulus_pct_from_code_value
 
 logger = logging.getLogger(__name__)
 
+# Grayscale stimulus levels used by the calibration workflow (% of signal range)
+WB_GAIN_TARGET_PCT = 80.0
+WB_OFFSET_TARGET_PCT = 30.0
+GAMMA_TARGET_PCTS = tuple(float(pct) for pct in range(5, 100, 5))
+PCT_SNAP_TOLERANCE = 7.0
+
+# Session steps that should route grayscale to pre/post buckets
+_PRE_STEPS = {"pre_grayscale", "prepare", "select_mode"}
+_POST_STEPS = {"post_grayscale", "suggested_patches", "report"}
+
+
+def _nearest_target_pct(stim: float, targets: tuple) -> Optional[float]:
+    matches = [t for t in targets if abs(stim - t) <= PCT_SNAP_TOLERANCE]
+    if not matches:
+        return None
+    return min(matches, key=lambda t: abs(stim - t))
+
+
+def _stimulus_pct_from_patch(patch: Patch) -> float:
+    """Derive stimulus percentage from a grayscale patch's RGB target values."""
+    if not patch.is_grayscale:
+        return 0.0
+    val = patch.r_target  # r == g == b for grayscale
+    return stimulus_pct_from_code_value(val)
+
+
+def _bucket_for_grayscale(stim_pct: float, session_step: Optional[str]) -> List[str]:
+    """
+    Return the list of bucket names a grayscale patch belongs to.
+
+    A single patch can populate multiple buckets (e.g. 80% gray goes to both
+    wb_measurements and gamma_measurements), plus the primary grayscale bucket.
+    """
+    buckets: List[str] = []
+
+    # Primary grayscale bucket based on session step
+    if session_step in _PRE_STEPS:
+        buckets.append("pre_measurements")
+    elif session_step in _POST_STEPS:
+        buckets.append("post_measurements")
+    else:
+        # No session step or mid-workflow: fall back to lum_measurements
+        buckets.append("lum_measurements")
+
+    # Luminance reference: 100% white
+    if stim_pct >= 99.0:
+        buckets.append("lum_measurements")
+
+    # White balance: 80% gain, 30% offset
+    if _nearest_target_pct(stim_pct, (WB_GAIN_TARGET_PCT,)) is not None:
+        buckets.append("wb_measurements")
+    elif _nearest_target_pct(stim_pct, (WB_OFFSET_TARGET_PCT,)) is not None:
+        buckets.append("wb_measurements")
+
+    # Gamma tracking: snap to nearest 5% step
+    if _nearest_target_pct(stim_pct, GAMMA_TARGET_PCTS) is not None:
+        buckets.append("gamma_measurements")
+
+    # Deduplicate while preserving order (e.g. lum_measurements may be added twice)
+    return list(dict.fromkeys(buckets))
+
 
 def patches_to_session_buckets(
-    patches: List[Patch], target: CalibrationTarget
+    patches: List[Patch],
+    target: CalibrationTarget,
+    session_step: Optional[str] = None,
 ) -> Dict[str, List[Dict[str, Any]]]:
     """
     Convert a list of generic measurement patches into the session bucket structure.
 
     Mapping logic:
-    - Grayscale patches (r=g=b) go to lum_measurements.
     - Color patches go to cms_measurements.
-
-    This is a simple heuristic; a more sophisticated approach could consider the
-    session step and target configuration.
+    - Grayscale patches are routed by stimulus level:
+        * 100% white (>=99%) -> lum_measurements
+        * ~80% gray -> wb_measurements (Gain)
+        * ~30% gray -> wb_measurements (Offset)
+        * 5-95% in 5% steps -> gamma_measurements
+      Additionally, the session step determines whether grayscale patches land
+      in pre_measurements (pre-calibration) or post_measurements (post-calibration).
     """
     buckets: Dict[str, List[Dict[str, Any]]] = {
         "pre_measurements": [],
@@ -33,42 +100,16 @@ def patches_to_session_buckets(
     now_iso = datetime.now(timezone.utc).isoformat()
 
     for patch in patches:
-        # Determine which bucket to use
-        if patch.is_grayscale:
-            bucket = "lum_measurements"
+        if not patch.is_grayscale:
+            buckets["cms_measurements"].append(
+                _build_measurement_dict(patch, now_iso)
+            )
         else:
-            bucket = "cms_measurements"
-
-        # Convert meas_xyz and meas_yxy to Measurement fields
-        # Patch.meas_xyz is (X, Y, Z)
-        # Patch.meas_yxy is (Y, x, y) if available
-        X, Y, Z = patch.meas_xyz
-        if patch.meas_yxy is not None:
-            Y_yxy, x, y = patch.meas_yxy
-            # Y may differ; use Y from meas_yxy? We'll keep Y from meas_yxy for consistency
-            Y = Y_yxy
-        else:
-            # Compute x, y from X, Y, Z
-            sum_xyz = X + Y + Z
-            if sum_xyz > 0:
-                x = X / sum_xyz
-                y = Y / sum_xyz
-            else:
-                x = y = 0.0
-
-        # Build dict matching Measurement fields
-        meas_dict = {
-            "X": X,
-            "Y": Y,
-            "Z": Z,
-            "x": x,
-            "y": y,
-            "timestamp": now_iso,
-            "label": patch.label,
-            "stimulus_rgb": [patch.r_target, patch.g_target, patch.b_target],
-        }
-
-        buckets[bucket].append(meas_dict)
+            stim_pct = _stimulus_pct_from_patch(patch)
+            patch_buckets = _bucket_for_grayscale(stim_pct, session_step)
+            meas_dict = _build_measurement_dict(patch, now_iso)
+            for bucket in patch_buckets:
+                buckets[bucket].append(meas_dict)
 
     # Log for debugging
     for bucket, items in buckets.items():
@@ -78,3 +119,29 @@ def patches_to_session_buckets(
             )
 
     return buckets
+
+
+def _build_measurement_dict(patch: Patch, now_iso: str) -> Dict[str, Any]:
+    """Build a measurement dict from a Patch object."""
+    X, Y, Z = patch.meas_xyz
+    if patch.meas_yxy is not None:
+        Y_yxy, x, y = patch.meas_yxy
+        Y = Y_yxy
+    else:
+        sum_xyz = X + Y + Z
+        if sum_xyz > 0:
+            x = X / sum_xyz
+            y = Y / sum_xyz
+        else:
+            x = y = 0.0
+
+    return {
+        "X": X,
+        "Y": Y,
+        "Z": Z,
+        "x": x,
+        "y": y,
+        "timestamp": now_iso,
+        "label": patch.label,
+        "stimulus_rgb": [patch.r_target, patch.g_target, patch.b_target],
+    }

--- a/calibrator/session.py
+++ b/calibrator/session.py
@@ -2095,7 +2095,7 @@ class SessionStore:
             patches = parse_measurement_csv(contents)
         except Exception as exc:
             raise HTTPException(400, f"Generic CSV parse error: {exc}") from exc
-        bucket_map = patches_to_session_buckets(patches, session["target"])
+        bucket_map = patches_to_session_buckets(patches, session["target"], session.get("step"))
         step_warnings = []
         counts: Dict[str, int] = {}
         for key, meas_dicts in bucket_map.items():

--- a/tests/test_csv_adapter.py
+++ b/tests/test_csv_adapter.py
@@ -1,0 +1,372 @@
+"""Tests for calibrator.csv_adapter — generic CSV patch bucket routing."""
+from __future__ import annotations
+
+import pytest
+
+from calcore.models import Patch, CalibrationTarget, CalMode
+from calibrator.csv_adapter import (
+    patches_to_session_buckets,
+    _nearest_target_pct,
+    _stimulus_pct_from_patch,
+    _bucket_for_grayscale,
+    WB_GAIN_TARGET_PCT,
+    WB_OFFSET_TARGET_PCT,
+    GAMMA_TARGET_PCTS,
+)
+
+SDR_TARGET = CalibrationTarget(
+    mode=CalMode.SDR,
+    gamma=2.2,
+    peak_luminance_nits=120.0,
+    gamut="bt709",
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _gray_patch(label: str, code_value: int) -> Patch:
+    """Create a grayscale patch at the given 8-bit code value."""
+    return Patch(
+        label=label,
+        r_target=code_value,
+        g_target=code_value,
+        b_target=code_value,
+        meas_xyz=(float(code_value), float(code_value) * 1.2, float(code_value)),
+        meas_yxy=(float(code_value) * 1.2, 0.3127, 0.3290),
+        kind="grayscale",
+    )
+
+
+def _color_patch(label: str, r: int, g: int, b: int) -> Patch:
+    return Patch(
+        label=label,
+        r_target=r,
+        g_target=g,
+        b_target=b,
+        meas_xyz=(10.0, 12.0, 8.0),
+        meas_yxy=(12.0, 0.45, 0.40),
+        kind="color",
+    )
+
+
+# ---------------------------------------------------------------------------
+# _nearest_target_pct
+# ---------------------------------------------------------------------------
+class TestNearestTargetPct:
+    def test_exact_match(self):
+        assert _nearest_target_pct(50.0, (45.0, 50.0, 55.0)) == 50.0
+
+    def test_no_match_outside_tolerance(self):
+        assert _nearest_target_pct(7.0, (30.0, 80.0)) is None
+
+    def test_nearest_within_tolerance(self):
+        # 75% is within 7 of 80
+        result = _nearest_target_pct(75.0, (30.0, 80.0))
+        assert result == 80.0
+
+    def test_empty_targets(self):
+        assert _nearest_target_pct(50.0, ()) is None
+
+    def test_multiple_matches_returns_closest(self):
+        # 37% is within tolerance of both 30 and some other target
+        result = _nearest_target_pct(37.0, (30.0, 45.0))
+        assert result == 30.0
+
+
+# ---------------------------------------------------------------------------
+# _stimulus_pct_from_patch
+# ---------------------------------------------------------------------------
+class TestStimulusPctFromPatch:
+    def test_grayscale_returns_pct(self):
+        p = _gray_patch("50% Gray", 128)
+        pct = _stimulus_pct_from_patch(p)
+        assert pct > 0
+
+    def test_color_returns_zero(self):
+        p = _color_patch("Red", 255, 0, 0)
+        assert _stimulus_pct_from_patch(p) == 0.0
+
+    def test_black_returns_zero(self):
+        p = _gray_patch("Black", 16)
+        assert _stimulus_pct_from_patch(p) == 0.0
+
+    def test_white_returns_100(self):
+        p = _gray_patch("White", 235)
+        assert _stimulus_pct_from_patch(p) >= 99.0
+
+
+# ---------------------------------------------------------------------------
+# _bucket_for_grayscale
+# ---------------------------------------------------------------------------
+class TestBucketForGrayscale:
+    def test_black_no_session_step(self):
+        # 0% gray, no session step → lum_measurements only
+        buckets = _bucket_for_grayscale(0.0, None)
+        assert "lum_measurements" in buckets
+
+    def test_white_no_session_step(self):
+        # 100% gray → lum_measurements
+        buckets = _bucket_for_grayscale(100.0, None)
+        assert "lum_measurements" in buckets
+
+    def test_80_pct_gains_wb(self):
+        buckets = _bucket_for_grayscale(80.0, None)
+        assert "wb_measurements" in buckets
+
+    def test_30_pct_gains_wb(self):
+        buckets = _bucket_for_grayscale(30.0, None)
+        assert "wb_measurements" in buckets
+
+    def test_50_pct_gains_gamma(self):
+        buckets = _bucket_for_grayscale(50.0, None)
+        assert "gamma_measurements" in buckets
+
+    def test_pre_step(self):
+        buckets = _bucket_for_grayscale(50.0, "pre_grayscale")
+        assert "pre_measurements" in buckets
+
+    def test_post_step(self):
+        buckets = _bucket_for_grayscale(50.0, "post_grayscale")
+        assert "post_measurements" in buckets
+
+    def test_multi_bucket_80_pct(self):
+        # 80% gray should hit wb_measurements AND gamma_measurements
+        buckets = _bucket_for_grayscale(80.0, None)
+        assert "wb_measurements" in buckets
+        assert "gamma_measurements" in buckets
+
+    def test_multi_bucket_100_pct(self):
+        # 100% white should hit lum_measurements
+        buckets = _bucket_for_grayscale(100.0, None)
+        assert "lum_measurements" in buckets
+
+
+# ---------------------------------------------------------------------------
+# patches_to_session_buckets — color patches
+# ---------------------------------------------------------------------------
+class TestColorPatches:
+    def test_color_goes_to_cms(self):
+        patches = [_color_patch("Red", 255, 0, 0)]
+        result = patches_to_session_buckets(patches, SDR_TARGET)
+        assert len(result["cms_measurements"]) == 1
+        assert result["lum_measurements"] == []
+        assert result["wb_measurements"] == []
+
+    def test_multiple_color_patches(self):
+        patches = [
+            _color_patch("Red", 255, 0, 0),
+            _color_patch("Green", 0, 255, 0),
+            _color_patch("Blue", 0, 0, 255),
+        ]
+        result = patches_to_session_buckets(patches, SDR_TARGET)
+        assert len(result["cms_measurements"]) == 3
+
+    def test_color_preserves_measurement_data(self):
+        patches = [_color_patch("Red", 255, 0, 0)]
+        result = patches_to_session_buckets(patches, SDR_TARGET)
+        meas = result["cms_measurements"][0]
+        assert meas["label"] == "Red"
+        assert meas["stimulus_rgb"] == [255, 0, 0]
+        assert "X" in meas
+        assert "Y" in meas
+        assert "Z" in meas
+        assert "x" in meas
+        assert "y" in meas
+        assert "timestamp" in meas
+
+
+# ---------------------------------------------------------------------------
+# patches_to_session_buckets — grayscale no session step (backward compat)
+# ---------------------------------------------------------------------------
+class TestGrayscaleNoStep:
+    def test_50_percent_gray(self):
+        """Grayscale without session step should land in lum_measurements."""
+        patches = [_gray_patch("50% Gray", 128)]
+        result = patches_to_session_buckets(patches, SDR_TARGET)
+        assert len(result["lum_measurements"]) == 1
+        # Also should populate gamma since 50% is a gamma target
+        assert len(result["gamma_measurements"]) == 1
+
+    def test_80_percent_gray_gains_wb(self):
+        """80% gray should populate wb_measurements."""
+        patches = [_gray_patch("WB Gain", 204)]
+        result = patches_to_session_buckets(patches, SDR_TARGET)
+        assert len(result["wb_measurements"]) == 1
+        wb = result["wb_measurements"][0]
+        assert wb["stimulus_rgb"] == [204, 204, 204]
+
+    def test_30_percent_gray_gains_wb(self):
+        """30% gray should populate wb_measurements."""
+        patches = [_gray_patch("WB Offset", 77)]
+        result = patches_to_session_buckets(patches, SDR_TARGET)
+        assert len(result["wb_measurements"]) == 1
+
+    def test_100_percent_gray_gains_lum(self):
+        """100% white should populate lum_measurements."""
+        patches = [_gray_patch("White", 235)]
+        result = patches_to_session_buckets(patches, SDR_TARGET)
+        assert len(result["lum_measurements"]) == 1
+
+    def test_0_percent_gray(self):
+        """Black should land in lum_measurements."""
+        patches = [_gray_patch("Black", 16)]
+        result = patches_to_session_buckets(patches, SDR_TARGET)
+        assert len(result["lum_measurements"]) == 1
+
+    def test_gamma_steps_populate_gamma_bucket(self):
+        """5%, 10%, ..., 95% should all land in gamma_measurements."""
+        patches = [_gray_patch(f"{p}% Gray", int(p * 255 / 100)) for p in range(5, 100, 5)]
+        result = patches_to_session_buckets(patches, SDR_TARGET)
+        assert len(result["gamma_measurements"]) == 19
+
+    def test_mixed_color_and_grayscale(self):
+        patches = [
+            _gray_patch("50% Gray", 128),
+            _color_patch("Red", 255, 0, 0),
+            _gray_patch("White", 235),
+        ]
+        result = patches_to_session_buckets(patches, SDR_TARGET)
+        assert len(result["cms_measurements"]) == 1
+        assert len(result["lum_measurements"]) >= 1
+
+
+# ---------------------------------------------------------------------------
+# patches_to_session_buckets — grayscale with pre_grayscale step
+# ---------------------------------------------------------------------------
+class TestGrayscalePreStep:
+    def test_pre_grayscale_routes_to_pre(self):
+        patches = [_gray_patch("50% Gray", 128)]
+        result = patches_to_session_buckets(patches, SDR_TARGET, "pre_grayscale")
+        assert len(result["pre_measurements"]) == 1
+        meas = result["pre_measurements"][0]
+        assert meas["stimulus_rgb"] == [128, 128, 128]
+
+    def test_pre_step_still_gains_wb(self):
+        patches = [_gray_patch("WB Gain", 204)]
+        result = patches_to_session_buckets(patches, SDR_TARGET, "pre_grayscale")
+        assert len(result["wb_measurements"]) == 1
+        # Also in pre_measurements
+        assert len(result["pre_measurements"]) == 1
+
+    def test_pre_step_still_gains_gamma(self):
+        patches = [_gray_patch("50% Gray", 128)]
+        result = patches_to_session_buckets(patches, SDR_TARGET, "pre_grayscale")
+        assert len(result["gamma_measurements"]) == 1
+        assert len(result["pre_measurements"]) == 1
+
+    def test_pre_step_100_pct_gains_lum(self):
+        patches = [_gray_patch("White", 235)]
+        result = patches_to_session_buckets(patches, SDR_TARGET, "pre_grayscale")
+        assert len(result["lum_measurements"]) == 1
+        # Also in pre_measurements as primary grayscale bucket
+        assert len(result["pre_measurements"]) == 1
+
+    def test_multiple_pre_patches(self):
+        patches = [
+            _gray_patch("Black", 16),
+            _gray_patch("50% Gray", 128),
+            _gray_patch("White", 235),
+        ]
+        result = patches_to_session_buckets(patches, SDR_TARGET, "pre_grayscale")
+        assert len(result["pre_measurements"]) == 3
+
+
+# ---------------------------------------------------------------------------
+# patches_to_session_buckets — grayscale with post_grayscale step
+# ---------------------------------------------------------------------------
+class TestGrayscalePostStep:
+    def test_post_grayscale_routes_to_post(self):
+        patches = [_gray_patch("50% Gray", 128)]
+        result = patches_to_session_buckets(patches, SDR_TARGET, "post_grayscale")
+        assert len(result["post_measurements"]) == 1
+        meas = result["post_measurements"][0]
+        assert meas["stimulus_rgb"] == [128, 128, 128]
+
+    def test_post_step_still_gains_wb(self):
+        patches = [_gray_patch("WB Gain", 204)]
+        result = patches_to_session_buckets(patches, SDR_TARGET, "post_grayscale")
+        assert len(result["wb_measurements"]) == 1
+        assert len(result["post_measurements"]) == 1
+
+    def test_post_step_still_gains_gamma(self):
+        patches = [_gray_patch("50% Gray", 128)]
+        result = patches_to_session_buckets(patches, SDR_TARGET, "post_grayscale")
+        assert len(result["gamma_measurements"]) == 1
+        assert len(result["post_measurements"]) == 1
+
+    def test_post_step_100_pct_gains_lum(self):
+        patches = [_gray_patch("White", 235)]
+        result = patches_to_session_buckets(patches, SDR_TARGET, "post_grayscale")
+        assert len(result["lum_measurements"]) == 1
+        assert len(result["post_measurements"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# patches_to_session_buckets — edge cases
+# ---------------------------------------------------------------------------
+class TestEdgeCases:
+    def test_empty_patches(self):
+        result = patches_to_session_buckets([], SDR_TARGET)
+        for bucket in result:
+            assert len(result[bucket]) == 0
+
+    def test_patch_without_yxy(self):
+        p = Patch(
+            label="Test",
+            r_target=128,
+            g_target=128,
+            b_target=128,
+            meas_xyz=(10.0, 12.0, 8.0),
+            meas_yxy=None,
+            kind="grayscale",
+        )
+        result = patches_to_session_buckets([p], SDR_TARGET)
+        meas = result["lum_measurements"][0]
+        # x, y should be computed from X, Y, Z
+        assert meas["x"] == pytest.approx(10.0 / 30.0)
+        assert meas["y"] == pytest.approx(12.0 / 30.0)
+
+    def test_patch_with_yxy(self):
+        p = Patch(
+            label="Test",
+            r_target=128,
+            g_target=128,
+            b_target=128,
+            meas_xyz=(10.0, 12.0, 8.0),
+            meas_yxy=(15.0, 0.32, 0.33),
+            kind="grayscale",
+        )
+        result = patches_to_session_buckets([p], SDR_TARGET)
+        meas = result["lum_measurements"][0]
+        assert meas["Y"] == 15.0
+        assert meas["x"] == pytest.approx(0.32)
+        assert meas["y"] == pytest.approx(0.33)
+
+    def test_all_buckets_initialized(self):
+        result = patches_to_session_buckets([], SDR_TARGET)
+        expected = {
+            "pre_measurements", "cms_measurements", "lum_measurements",
+            "wb_measurements", "gamma_measurements", "post_measurements",
+        }
+        assert set(result.keys()) == expected
+
+    def test_preparation_step_routes_to_pre(self):
+        patches = [_gray_patch("50% Gray", 128)]
+        result = patches_to_session_buckets(patches, SDR_TARGET, "prepare")
+        assert len(result["pre_measurements"]) == 1
+
+    def test_select_mode_step_routes_to_pre(self):
+        patches = [_gray_patch("50% Gray", 128)]
+        result = patches_to_session_buckets(patches, SDR_TARGET, "select_mode")
+        assert len(result["pre_measurements"]) == 1
+
+    def test_suggested_patches_routes_to_post(self):
+        patches = [_gray_patch("50% Gray", 128)]
+        result = patches_to_session_buckets(patches, SDR_TARGET, "suggested_patches")
+        assert len(result["post_measurements"]) == 1
+
+    def test_report_step_routes_to_post(self):
+        patches = [_gray_patch("50% Gray", 128)]
+        result = patches_to_session_buckets(patches, SDR_TARGET, "report")
+        assert len(result["post_measurements"]) == 1


### PR DESCRIPTION
## Summary
- Generic CSV imports now route grayscale patches by stimulus level (lum/wb/gamma) instead of dumping everything into `lum_measurements`
- Grayscale patches are assigned to pre/post measurement buckets based on the active session step
- Matches the ZRO import routing logic: 100% white → lum, ~80% gray → wb (Gain), ~30% gray → wb (Offset), 5-95% steps → gamma
- Adds `session_step` parameter to `patches_to_session_buckets()` (backward compatible, defaults to `None`)

## Changes
- **`calibrator/csv_adapter.py`**: Rewrote `patches_to_session_buckets()` with stimulus-based grayscale routing using the same constants and tolerance as ZRO import (`PCT_SNAP_TOLERANCE = 7.0`, `GAMMA_TARGET_PCTS = range(5,100,5)`, WB at 30%/80%)
- **`calibrator/session.py`**: Pass `session.get("step")` to `patches_to_session_buckets()` in `import_generic_bytes()`
- **`tests/test_csv_adapter.py`**: 45 new tests covering stimulus-based routing, session step classification, edge cases (yxy/xy computation, empty input, multi-bucket patches)

## Testing
- All 782 existing tests pass (0 regressions)
- 45 new unit tests in `tests/test_csv_adapter.py` all pass

Closes #202