### PR TITLE
Add OSD Command Translator — deterministic menu-path resolution (#167)

### DIFF
--- a/calibrator/osd.py
+++ b/calibrator/osd.py
@@ -143,7 +143,6 @@ def _derive_setting_key(setting_name: str, menu: str) -> str:
         "Backlight": "backlight",
         "Backlight Level": "backlight",
         "OLED Light": "backlight",
-        "Brightness": "black_level",
         "Black Level": "black_level",
         "Contrast": "contrast",
         "Colour Temperature": "color_temperature",
@@ -548,10 +547,7 @@ def _has_schema_for_setting(tv_profile: Any, adj: Dict[str, Any]) -> bool:
         return True
 
     known_settings = {"backlight", "black_level", "contrast", "color_temperature", "color_space"}
-    if setting_key in known_settings:
-        return True
-
-    return False
+    return setting_key in known_settings
 
 
 def translate_corrections(

--- a/calibrator/osd.py
+++ b/calibrator/osd.py
@@ -1,0 +1,660 @@
+"""
+OSD Command Translator - deterministic menu-path resolution for TV calibration corrections.
+
+Maps LLM-generated adjustment vectors (e.g. red_gain += 3, gamma_curve = 2.28) to
+step-by-step OSD navigation instructions using the TV profile's llm_schema and menu paths.
+
+For known TV profiles: fully deterministic, no LLM call needed.
+For unknown TVs: returns empty list (caller can fall back to LLM-driven approach).
+
+Architecture
+------------
+Each TV profile's llm_schema contains a "settings" dict keyed by setting name. Each
+setting entry has:
+
+  - path: string - OSD menu navigation (arrow-separated)
+  - type: "slider" | "enum" | "toggle" | "multipoint" | "cms" | "2pt_wb"
+  - channels / colors / params - sub-controls for complex settings
+  - range / options / increment - value constraints
+  - calibration_target / calibration_default - recommended values
+
+The translator walks the adjustment vector, matches each correction to a schema entry,
+and emits an ordered list of OSD navigation steps.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class OSDStep:
+    """A single OSD navigation instruction for the user."""
+
+    step_number: int
+    menu_path: str  # e.g. "Settings -> Picture -> White Balance -> IRE 80"
+    action: str  # e.g. "Adjust R-Gain", "Select BT.1886", "Set Saturation to 3"
+    value: Optional[str] = None  # target value or delta (e.g. "+3", "2.28", "Off")
+    rationale: str = ""  # brief explanation for the user
+    completed: bool = False  # frontend checkbox state
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "step_number": self.step_number,
+            "menu_path": self.menu_path,
+            "action": self.action,
+            "value": self.value,
+            "rationale": self.rationale,
+            "completed": self.completed,
+        }
+
+
+@dataclass
+class OSDTranslationResult:
+    """Result of translating a correction vector into OSD steps."""
+
+    tv_model: str  # display name, e.g. "Hisense U8G"
+    tv_key: str  # profile key, e.g. "u8g"
+    steps: List[OSDStep] = field(default_factory=list)
+    skipped_reasons: List[str] = field(default_factory=list)  # why some corrections were skipped
+    uses_adb: bool = False  # True if ADB can apply corrections directly (skip OSD)
+    adb_instructions: Optional[str] = None  # if uses_adb, the ADB commands
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "tv_model": self.tv_model,
+            "tv_key": self.tv_key,
+            "steps": [s.to_dict() for s in self.steps],
+            "skipped_reasons": self.skipped_reasons,
+            "uses_adb": self.uses_adb,
+            "adb_instructions": self.adb_instructions,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Adjustment normalisation helpers
+# ---------------------------------------------------------------------------
+
+
+def _normalise_adjustment(adj: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalise an adjustment dict from the LLM into a canonical form.
+
+    Accepts both the old AdjustmentPlan format (menu, setting, from, to) and
+    the raw correction vector format (setting_name, delta, target_value).
+    """
+    # Already canonical?
+    if "setting_key" in adj:
+        return adj
+
+    setting_name = adj.get("setting", "")
+    menu = adj.get("menu", "")
+    from_val = adj.get("from")
+    to_val = adj.get("to")
+    scope = adj.get("scope", "local")
+    reason = adj.get("reason", "")
+
+    # Try to derive a setting_key from the setting name and menu path
+    setting_key = _derive_setting_key(setting_name, menu)
+
+    return {
+        "setting_key": setting_key,
+        "setting_name": setting_name,
+        "menu": menu,
+        "from": from_val,
+        "to": to_val,
+        "delta": _compute_delta(from_val, to_val),
+        "scope": scope,
+        "reason": reason,
+    }
+
+
+def _derive_setting_key(setting_name: str, menu: str) -> str:
+    """Derive a canonical setting_key from the LLM's setting name and menu.
+
+    Maps human-readable names to schema keys used in llm_schema.settings.
+    """
+    key_map = {
+        # White balance channels
+        "R-Gain": "white_balance_2pt.channels.R_gain",
+        "G-Gain": "white_balance_2pt.channels.G_gain",
+        "B-Gain": "white_balance_2pt.channels.B_gain",
+        "R-Offset": "white_balance_2pt.channels.R_offset",
+        "G-Offset": "white_balance_2pt.channels.G_offset",
+        "B-Offset": "white_balance_2pt.channels.B_offset",
+        "Red Gain": "white_balance_2pt.channels.R_gain",
+        "Green Gain": "white_balance_2pt.channels.G_gain",
+        "Blue Gain": "white_balance_2pt.channels.B_gain",
+        "Red Offset": "white_balance_2pt.channels.R_offset",
+        "Green Offset": "white_balance_2pt.channels.G_offset",
+        "Blue Offset": "white_balance_2pt.channels.B_offset",
+        # CMS channels
+        "Hue": "cms.params.Hue",
+        "Saturation": "cms.params.Saturation",
+        "Brightness": "cms.params.Brightness",
+        "Luminance": "cms.params.Luminance",
+        # Gamma
+        "Gamma": "gamma",
+        "gamma": "gamma",
+        # Picture controls
+        "Backlight": "backlight",
+        "Backlight Level": "backlight",
+        "OLED Light": "backlight",
+        "Brightness": "black_level",
+        "Black Level": "black_level",
+        "Contrast": "contrast",
+        "Colour Temperature": "color_temperature",
+        "Color Temperature": "color_temperature",
+        "Colour Space": "color_space",
+        "Color Space": "color_space",
+    }
+    return key_map.get(setting_name, setting_name.lower().replace(" ", "_").replace("-", "_"))
+
+
+def _compute_delta(from_val, to_val) -> Optional[float]:
+    """Compute the numeric delta between from and to values."""
+    if from_val is None or to_val is None:
+        return None
+    try:
+        return float(to_val) - float(from_val)
+    except (TypeError, ValueError):
+        return None
+
+
+def _lookup_nested(d: Dict[str, Any], dotted_key: str) -> Optional[Any]:
+    """Look up a dotted key in a nested dict (e.g. 'channels.R_gain').
+
+    Also checks inside d['settings'] for keys like 'white_balance_2pt'.
+    """
+    keys = dotted_key.split(".")
+    current = d
+    for key in keys:
+        if isinstance(current, dict):
+            current = current.get(key)
+        else:
+            return None
+    # If the direct lookup failed and d has a 'settings' dict, try there
+    if current is None and isinstance(d, dict) and "settings" in d:
+        settings = d["settings"]
+        current = settings.get(dotted_key)
+        if current is not None:
+            return current
+        # Try nested lookup inside settings (e.g. channels.R_gain)
+        nested_keys = dotted_key.split(".")
+        for key in nested_keys:
+            if isinstance(current, dict):
+                current = current.get(key)
+            else:
+                return None
+    return current
+
+
+def _get_settings_from_profile(tv_profile: Any) -> Dict[str, Any]:
+    """Extract the settings dict from a TV profile's llm_schema."""
+    if hasattr(tv_profile, "llm_schema") and isinstance(tv_profile.llm_schema, dict):
+        return tv_profile.llm_schema.get("settings", {})
+    return {}
+
+
+def _format_value(val: Any, setting_type: str) -> Optional[str]:
+    """Format a raw value into a user-friendly display string."""
+    if val is None:
+        return None
+    try:
+        f = float(val)
+        if setting_type == "enum":
+            return str(val)  # keep enum labels as-is
+        if abs(f) == int(f):
+            return str(int(f))
+        return f"{f:.2f}".rstrip("0").rstrip(".")
+    except (TypeError, ValueError):
+        return str(val)
+
+
+def _format_delta(delta: float, setting_type: str) -> str:
+    """Format a numeric delta for display."""
+    if abs(delta) == int(abs(delta)):
+        sign = "+" if delta > 0 else "-"
+        return f"{sign}{int(abs(delta))}"
+    sign = "+" if delta > 0 else "-"
+    return f"{sign}{abs(delta):.2f}".rstrip("0").rstrip(".")
+
+
+def _build_menu_path(base_path: str, channel_name: Optional[str] = None) -> str:
+    """Build a user-friendly menu path with -> separators."""
+    if channel_name:
+        return f"{base_path} -> {channel_name}"
+    # Normalise arrow separators
+    return base_path.replace(">", "").replace("> ", " ")
+
+
+def _channel_label_for_key(schema_key: str, schema_entry: Dict) -> Optional[str]:
+    """Extract the display label for a channel within a multipoint setting."""
+    if "channels" in schema_entry:
+        parts = schema_key.split(".")
+        if len(parts) >= 2:
+            channel_part = parts[-1]
+            channels = schema_entry["channels"]
+            for ck, cv in channels.items():
+                if ck == channel_part:
+                    return cv.get("label", ck)
+    return None
+
+
+def _extract_cms_colour(adj: Dict[str, Any]) -> str:
+    """Extract the CMS colour name from an adjustment dict."""
+    if "colour" in adj:
+        return str(adj["colour"])
+    if "color" in adj:
+        return str(adj["color"])
+    menu = adj.get("menu", "")
+    setting = adj.get("setting_name", adj.get("setting", ""))
+    for colour in ["Red", "Green", "Blue", "Cyan", "Magenta", "Yellow"]:
+        if colour.lower() in menu.lower() or colour.lower() in setting.lower():
+            return colour
+    return "Red"  # default fallback
+
+
+def _build_cms_menu_path(base_path: str, colour_name: Optional[str], param_name: Optional[str]) -> str:
+    """Build CMS-specific menu path with colour and parameter."""
+    parts = [base_path]
+    if colour_name:
+        parts.append(colour_name)
+    if param_name and param_name not in (colour_name or ""):
+        parts.append(param_name)
+    return " -> ".join(parts).replace(">", "").replace("> ", " ")
+
+
+def _generate_wb_steps(tv_profile: Any, adj: Dict[str, Any], step_start: int = 1) -> List[OSDStep]:
+    """Generate white balance OSD steps from an adjustment."""
+    setting_key = adj.get("setting_key", "")
+    channel_part = setting_key.split(".")[-1] if "." in setting_key else setting_key
+    channel_label = {
+        "R_gain": "Red",
+        "G_gain": "Green",
+        "B_gain": "Blue",
+        "R_offset": "Red",
+        "G_offset": "Green",
+        "B_offset": "Blue",
+    }.get(channel_part, channel_part)
+
+    is_gain = "gain" in channel_part.lower() and "offset" not in channel_part.lower()
+    is_offset = "offset" in channel_part.lower()
+
+    wb_path = tv_profile.WB_MENU_PATH if hasattr(tv_profile, "WB_MENU_PATH") else ""
+    if not wb_path:
+        return []
+
+    value_label = None
+    if adj.get("to") is not None:
+        value_label = _format_value(adj["to"], "slider")
+    elif adj.get("delta") is not None:
+        value_label = _format_delta(adj["delta"], "slider")
+
+    rationale = adj.get("reason", "") or (
+        f"{'Gain' if is_gain else 'Offset'} adjustment for {channel_label} channel"
+    )
+
+    # Check if TV has 2-point WB with IRE points
+    wb_schema = _lookup_nested(tv_profile.llm_schema, "white_balance_2pt")
+    has_2pt = wb_schema and (wb_schema.get("type") == "slider" or "channels" in wb_schema)
+
+    if has_2pt and (is_gain or is_offset):
+        ire_label = "IRE 80" if is_gain else "IRE 20"
+        menu_path = _build_menu_path(wb_path, f"{ire_label} -> {channel_label}")
+        return [OSDStep(
+            step_number=step_start,
+            menu_path=menu_path,
+            action=f"Adjust {channel_label}",
+            value=value_label,
+            rationale=rationale,
+        )]
+
+    # Fallback: single step
+    menu_path = _build_menu_path(wb_path, channel_label)
+    return [OSDStep(
+        step_number=step_start,
+        menu_path=menu_path,
+        action=f"Adjust {channel_label}",
+        value=value_label,
+        rationale=rationale,
+    )]
+
+
+def _generate_cms_steps(tv_profile: Any, adj: Dict[str, Any], step_start: int = 1) -> List[OSDStep]:
+    """Generate CMS/Colour Tuner OSD steps from an adjustment."""
+    setting_key = adj.get("setting_key", "")
+    parts = setting_key.split(".") if "." in setting_key else [setting_key]
+    param_name = parts[-1] if len(parts) > 1 else setting_key
+
+    colour_name = _extract_cms_colour(adj)
+
+    cms_path = tv_profile.CMS_MENU_PATH if hasattr(tv_profile, "CMS_MENU_PATH") else ""
+    if not cms_path:
+        return []
+
+    value_label = None
+    if adj.get("to") is not None:
+        value_label = _format_value(adj["to"], "slider")
+    elif adj.get("delta") is not None:
+        value_label = _format_delta(adj["delta"], "slider")
+
+    rationale = adj.get("reason", "") or f"Adjust {param_name} for {colour_name}"
+    menu_path = _build_cms_menu_path(cms_path, colour_name, param_name)
+
+    return [OSDStep(
+        step_number=step_start,
+        menu_path=menu_path,
+        action=f"Adjust {param_name}",
+        value=value_label,
+        rationale=rationale,
+    )]
+
+
+def _generate_gamma_steps(tv_profile: Any, adj: Dict[str, Any], step_start: int = 1) -> List[OSDStep]:
+    """Generate gamma OSD steps from an adjustment."""
+    gamma_path = tv_profile.GAMMA_MENU_PATH if hasattr(tv_profile, "GAMMA_MENU_PATH") else ""
+    if not gamma_path:
+        return []
+
+    to_val = adj.get("to")
+    delta = adj.get("delta")
+
+    if to_val is not None:
+        value_label = _format_value(to_val, "enum")
+    elif delta is not None:
+        value_label = _format_delta(delta, "slider")
+    else:
+        value_label = None
+
+    rationale = adj.get("reason", "") or "Gamma adjustment to improve tracking."
+    menu_path = _build_menu_path(gamma_path)
+
+    return [OSDStep(
+        step_number=step_start,
+        menu_path=menu_path,
+        action="Set gamma preset",
+        value=value_label,
+        rationale=rationale,
+    )]
+
+
+def _generate_picture_control_steps(tv_profile: Any, adj: Dict[str, Any], step_start: int = 1) -> List[OSDStep]:
+    """Generate OSD steps for basic picture controls (backlight, contrast, etc)."""
+    to_val = adj.get("to")
+    delta = adj.get("delta")
+
+    if to_val is not None:
+        value_label = _format_value(to_val, "slider")
+    elif delta is not None:
+        value_label = _format_delta(delta, "slider")
+    else:
+        value_label = None
+
+    # Extract setting name from setting_key when setting_name/setting not present
+    raw_name = adj.get("setting_name", adj.get("setting"))
+    if not raw_name:
+        setting_key = adj.get("setting_key", "")
+        raw_name = setting_key.split(".")[-1] if setting_key else "Setting"
+    setting_name = raw_name.title()
+    rationale = adj.get("reason", "") or f"Adjust {raw_name}"
+    menu_path = _build_menu_path(f"Picture -> {setting_name}")
+
+    return [OSDStep(
+        step_number=step_start,
+        menu_path=menu_path,
+        action=f"Set {setting_name}",
+        value=value_label,
+        rationale=rationale,
+    )]
+
+
+def _generate_fallback_steps(
+    tv_profile: Any, adj: Dict[str, Any], setting_key: str,
+    setting_entry: Dict, step_start: int
+) -> List[OSDStep]:
+    """Generate steps for settings found in llm_schema but not matched by prefix."""
+    setting_type = setting_entry.get("type", "slider")
+    base_path = setting_entry.get("path", "")
+    to_val = adj.get("to")
+    delta = adj.get("delta")
+
+    if to_val is not None:
+        value_label = _format_value(to_val, setting_type)
+    elif delta is not None:
+        value_label = _format_delta(delta, setting_type)
+    else:
+        value_label = None
+
+    rationale = adj.get("reason", "") or f"Adjust {setting_key}"
+
+    if setting_type == "cms":
+        colour_name = _extract_cms_colour(adj)
+        params = setting_entry.get("params", {})
+        param_name = list(params.keys())[0] if params else "Saturation"
+        menu_path = _build_cms_menu_path(base_path, colour_name, param_name)
+        return [OSDStep(
+            step_number=step_start,
+            menu_path=menu_path,
+            action=f"Adjust {param_name}",
+            value=value_label,
+            rationale=rationale,
+        )]
+
+    if setting_type == "2pt_wb" or (setting_type == "slider" and "channels" in setting_entry):
+        channels = setting_entry.get("channels", {})
+        channel_part = setting_key.split(".")[-1] if "." in setting_key else setting_key
+        channel_info = channels.get(channel_part, {})
+        channel_label = channel_info.get("label", channel_part.replace("_", " ").title())
+        wb_path = tv_profile.WB_MENU_PATH if hasattr(tv_profile, "WB_MENU_PATH") and tv_profile.WB_MENU_PATH else base_path
+        if not wb_path:
+            wb_path = base_path
+        is_gain = "gain" in channel_part.lower() and "offset" not in channel_part.lower()
+        ire_label = "IRE 80" if is_gain else "IRE 20"
+        menu_path = _build_menu_path(wb_path, f"{ire_label} -> {channel_label}")
+        return [OSDStep(
+            step_number=step_start,
+            menu_path=menu_path,
+            action=f"Adjust {channel_label}",
+            value=value_label,
+            rationale=rationale,
+        )]
+
+    setting_name = setting_entry.get("term", setting_key.replace("_", " ").title())
+    menu_path = _build_menu_path(base_path) if base_path else f"Picture -> {setting_key}"
+
+    return [OSDStep(
+        step_number=step_start,
+        menu_path=menu_path,
+        action=f"Set {setting_name}",
+        value=value_label,
+        rationale=rationale,
+    )]
+
+
+def _generate_steps_for_adjustment(tv_profile: Any, adj: Dict[str, Any], step_start: int = 1) -> List[OSDStep]:
+    """Route an adjustment to the correct step generator based on setting type."""
+    setting_key = adj.get("setting_key", "")
+
+    if setting_key.startswith("white_balance_"):
+        return _generate_wb_steps(tv_profile, adj, step_start)
+    if setting_key.startswith("cms."):
+        return _generate_cms_steps(tv_profile, adj, step_start)
+    if setting_key in ("gamma", "white_balance_20pt"):
+        return _generate_gamma_steps(tv_profile, adj, step_start)
+    if setting_key in ("backlight", "black_level", "contrast", "color_temperature", "color_space"):
+        return _generate_picture_control_steps(tv_profile, adj, step_start)
+
+    # Fallback: try to look up in llm_schema.settings
+    settings = tv_profile.llm_schema.get("settings", {}) if hasattr(tv_profile, "llm_schema") else {}
+    setting_entry = settings.get(setting_key)
+    if setting_entry:
+        return _generate_fallback_steps(tv_profile, adj, setting_key, setting_entry, step_start)
+
+    # Unknown setting - return a generic step
+    setting_name = adj.get("setting_name", adj.get("setting", "Unknown Setting")).title()
+    value_label = None
+    if adj.get("to") is not None:
+        value_label = _format_value(adj["to"], "slider")
+    elif adj.get("delta") is not None:
+        value_label = _format_delta(adj["delta"], "slider")
+    return [OSDStep(
+        step_number=step_start,
+        menu_path=f"Picture -> {setting_name}",
+        action=f"Adjust {setting_name}",
+        value=value_label,
+        rationale=adj.get("reason", "Manual adjustment required.") or "Manual adjustment required.",
+    )]
+
+
+def _check_adb_skip(tv_profile: Any) -> tuple:
+    """Check if this TV supports ADB-based direct control (skip OSD).
+
+    Returns (uses_adb, adb_instructions).
+    Hisense U8G supports ADB CMS control - for CMS adjustments, we can skip OSD.
+    """
+    if tv_profile.short_name == "u8g":
+        return True, (
+            "Use the ADB CMS controls in this app to apply corrections directly. "
+            "Open the Color Tuner step and click 'Apply' on each adjustment row."
+        )
+    return False, None
+
+
+def _has_schema_for_setting(tv_profile: Any, adj: Dict[str, Any]) -> bool:
+    """Check if the TV profile has schema data for a given adjustment."""
+    setting_key = adj.get("setting_key", "")
+
+    # Check direct match in settings
+    settings = tv_profile.llm_schema.get("settings", {}) if hasattr(tv_profile, "llm_schema") else {}
+    if setting_key in settings:
+        return True
+
+    # Check nested (e.g. white_balance_2pt.channels.R_gain)
+    if "." in setting_key:
+        parent_key = setting_key.split(".")[0]
+        if parent_key in settings:
+            return True
+
+    # Check TV profile has relevant path attributes
+    if setting_key.startswith("white_balance_") and tv_profile.WB_MENU_PATH:
+        return True
+    if setting_key.startswith("cms.") and tv_profile.CMS_MENU_PATH:
+        return True
+    if setting_key == "gamma" and tv_profile.GAMMA_MENU_PATH:
+        return True
+
+    known_settings = {"backlight", "black_level", "contrast", "color_temperature", "color_space"}
+    if setting_key in known_settings:
+        return True
+
+    return False
+
+
+def translate_corrections(
+    adjustments: List[Dict[str, Any]],
+    tv_profile: Any,
+) -> OSDTranslationResult:
+    """Translate a list of LLM adjustment dicts into ordered OSD navigation steps.
+
+    Parameters
+    ----------
+    adjustments : list of dict
+        Adjustment dicts from the LLM (AdjustmentPlan.adjustments format).
+    tv_profile : TVProfile
+        The user's TV profile (from calibrator.profiles).
+
+    Returns
+    -------
+    OSDTranslationResult with ordered steps, or empty steps + skipped_reasons.
+    """
+    result = OSDTranslationResult(
+        tv_model=tv_profile.name,
+        tv_key=tv_profile.short_name,
+    )
+
+    if not adjustments:
+        return result
+
+    # Normalise all adjustments
+    normalised = [_normalise_adjustment(a) for a in adjustments]
+
+    # Filter out corrections that can't be mapped
+    valid_adjustments = []
+    for adj in normalised:
+        setting_key = adj.get("setting_key", "")
+        if not setting_key:
+            result.skipped_reasons.append(
+                f"Cannot map adjustment '{adj.get('setting_name', adj.get('setting', '?'))}': unknown setting."
+            )
+            continue
+
+        # Check if we have schema data for this setting
+        has_schema = _has_schema_for_setting(tv_profile, adj)
+        if not has_schema and setting_key.startswith(("white_balance_", "cms.", "gamma", "backlight", "black_level", "contrast")):
+            # Known category but no schema — still generate steps from TV profile paths
+            valid_adjustments.append(adj)
+        elif has_schema:
+            valid_adjustments.append(adj)
+        else:
+            result.skipped_reasons.append(
+                f"Cannot map adjustment '{adj.get('setting_name', adj.get('setting', '?'))}': no menu path found for this setting on {tv_profile.name}."
+            )
+            continue
+
+        has_schema = _has_schema_for_setting(tv_profile, adj)
+        if not has_schema and setting_key.startswith(("white_balance_", "cms.", "gamma", "backlight", "black_level", "contrast")):
+            # Known category but no schema - still generate steps from TV profile paths
+            valid_adjustments.append(adj)
+        elif has_schema:
+            valid_adjustments.append(adj)
+        else:
+            result.skipped_reasons.append(
+                f"Cannot map adjustment '{adj.get('setting', '?')}': no menu path found for this setting on {tv_profile.name}."
+            )
+
+    if not valid_adjustments:
+        return result
+
+    # Generate steps for each adjustment
+    step_num = 1
+    all_steps: List[OSDStep] = []
+
+    for adj in valid_adjustments:
+        steps = _generate_steps_for_adjustment(tv_profile, adj, step_num)
+        all_steps.extend(steps)
+        step_num += len(steps)
+
+    # Check if ADB can handle all corrections
+    uses_adb, adb_instructions = _check_adb_skip(tv_profile)
+    if uses_adb:
+        for step in all_steps:
+            step.rationale += " (Can be applied via ADB - skip manual OSD navigation.)"
+
+    result.steps = all_steps
+    result.uses_adb = uses_adb
+    result.adb_instructions = adb_instructions
+    return result
+
+
+def translate_from_adjustment_plan(
+    plan_dict: Dict[str, Any],
+    tv_profile: Any,
+) -> OSDTranslationResult:
+    """Convenience wrapper that accepts an AdjustmentPlan dict (from LLM).
+
+    Parameters
+    ----------
+    plan_dict : dict
+        Dict with keys: adjustments, next_step, confidence.
+    tv_profile : TVProfile
+
+    Returns
+    -------
+    OSDTranslationResult
+    """
+    adjustments = plan_dict.get("adjustments", [])
+    return translate_corrections(adjustments, tv_profile)

--- a/calibrator/profiles.py
+++ b/calibrator/profiles.py
@@ -440,6 +440,112 @@ def _build_tcl7105x_profile() -> TVProfile:
             ),
         ],
         supported_gamuts=["bt709", "p3d65", "bt2020"],
+        llm_schema={
+            "model": "TCL 7105X",
+            "variants": ["557105X", "657105X", "757105X"],
+            "nomenclature": {
+                "backlight": {
+                    "term": "Backlight",
+                    "function": "Overall panel illumination (nits). Sets peak white output.",
+                    "path": "Settings > Picture > Backlight",
+                },
+                "black_level": {
+                    "term": "Brightness",
+                    "function": "Black level control. Set so near-black test patterns are just visible.",
+                    "path": "Settings > Picture > Brightness",
+                },
+            },
+            "settings": {
+                "gamma": {
+                    "path": "Settings > Picture > Advanced Picture > Gamma",
+                    "type": "enum",
+                    "options": [1.8, 2.0, 2.2, 2.4],
+                    "default": 2.2,
+                    "calibration_target": 2.2,
+                    "note": "Numbered presets only. No BT.1886 option.",
+                },
+                "color_space": {
+                    "path": "Settings > Picture > Advanced Picture > Color Space",
+                    "type": "enum",
+                    "options": ["Auto", "Native", "Wide"],
+                    "calibration_target": "Auto for SDR, Wide for HDR",
+                },
+                "color_temperature": {
+                    "path": "Settings > Picture > Advanced Picture > Color Temperature",
+                    "type": "enum",
+                    "options": ["Warm", "Cool"],
+                    "calibration_target": "Warm",
+                },
+                "white_balance_2pt": {
+                    "path": "Settings > Picture > Advanced Picture > White Balance",
+                    "type": "slider",
+                    "channels": {
+                        "R_gain": {
+                            "label": "Red Gain",
+                            "affects": "red highlights (80% gray)",
+                            "range": "-50 to +50",
+                            "neutral": 0,
+                        },
+                        "G_gain": {
+                            "label": "Green Gain",
+                            "affects": "green highlights (80% gray)",
+                            "range": "-50 to +50",
+                            "neutral": 0,
+                        },
+                        "B_gain": {
+                            "label": "Blue Gain",
+                            "affects": "blue highlights (80% gray)",
+                            "range": "-50 to +50",
+                            "neutral": 0,
+                        },
+                        "R_offset": {
+                            "label": "Red Offset",
+                            "affects": "red shadows (30% gray)",
+                            "range": "-50 to +50",
+                            "neutral": 0,
+                        },
+                        "G_offset": {
+                            "label": "Green Offset",
+                            "affects": "green shadows (30% gray)",
+                            "range": "-50 to +50",
+                            "neutral": 0,
+                        },
+                        "B_offset": {
+                            "label": "Blue Offset",
+                            "affects": "blue shadows (30% gray)",
+                            "range": "-50 to +50",
+                            "neutral": 0,
+                        },
+                    },
+                    "neutral_value": 0,
+                    "note": "Use 80% gray for Gain, 30% gray for Offset. Scale is -50 to +50.",
+                },
+                "cms": {
+                    "path": "Settings > Picture > Advanced Picture > Color Tuner",
+                    "type": "cms",
+                    "colors": ["Red", "Green", "Blue", "Cyan", "Magenta", "Yellow"],
+                    "params": {
+                        "Hue": "Shifts relative colour angle.",
+                        "Saturation": "Adjusts purity / vibrancy.",
+                        "Brightness": "Controls luminance of that specific colour.",
+                    },
+                    "neutral_value": 0,
+                    "note": "Zero all CMS values before loading a 3D LUT.",
+                },
+                "contrast": {
+                    "path": "Settings > Picture > Contrast",
+                    "type": "slider",
+                    "calibration_default": 90,
+                    "note": "Controls peak white levels. Back down if 100% whites clip.",
+                },
+                "brightness": {
+                    "path": "Settings > Picture > Brightness",
+                    "type": "slider",
+                    "calibration_default": 50,
+                    "note": "Black level control — NOT luminance. Set so 5% near-black is just visible.",
+                },
+            },
+        },
     )
 
 
@@ -876,6 +982,118 @@ def _build_vizio_v4k55m_profile() -> TVProfile:
                 "Factory uniformity correction (do not change unless you know what you are doing)",
             ),
         ],
+        llm_schema={
+            "model": "Vizio V4K55M",
+            "variants": ["V4K55M-0801", "V555M-K01"],
+            "nomenclature": {
+                "backlight": {
+                    "term": "Backlight",
+                    "function": "Overall panel illumination (nits). Sets peak white output.",
+                    "path": "Settings > Picture > Backlight",
+                },
+                "black_level": {
+                    "term": "Brightness",
+                    "function": "Black level control. Set so near-black test patterns are just visible.",
+                    "path": "Settings > Picture > Brightness",
+                },
+            },
+            "settings": {
+                "gamma": {
+                    "path": "Settings > Picture > Advanced Picture > Gamma",
+                    "type": "enum",
+                    "options": [1.8, 2.0, 2.2, 2.4],
+                    "default": 2.2,
+                    "calibration_target": 2.2,
+                    "note": "Numbered presets only. No BT.1886 option.",
+                },
+                "color_space": {
+                    "path": "Settings > Picture > Advanced Picture > Color Space",
+                    "type": "enum",
+                    "options": ["Auto", "Native"],
+                    "calibration_target": "Auto",
+                },
+                "color_temperature": {
+                    "path": "Settings > Picture > Color Temperature",
+                    "type": "enum",
+                    "options": ["Warm", "Cool"],
+                    "calibration_target": "Warm",
+                },
+                "white_balance_2pt": {
+                    "path": "Service Menu > White Balance",
+                    "type": "slider",
+                    "channels": {
+                        "R_gain": {
+                            "label": "Red Gain",
+                            "affects": "red highlights (80% gray)",
+                            "range": "-50 to +50",
+                            "neutral": 0,
+                        },
+                        "G_gain": {
+                            "label": "Green Gain",
+                            "affects": "green highlights (80% gray)",
+                            "range": "-50 to +50",
+                            "neutral": 0,
+                        },
+                        "B_gain": {
+                            "label": "Blue Gain",
+                            "affects": "blue highlights (80% gray)",
+                            "range": "-50 to +50",
+                            "neutral": 0,
+                        },
+                        "R_offset": {
+                            "label": "Red Offset",
+                            "affects": "red shadows (30% gray)",
+                            "range": "-50 to +50",
+                            "neutral": 0,
+                        },
+                        "G_offset": {
+                            "label": "Green Offset",
+                            "affects": "green shadows (30% gray)",
+                            "range": "-50 to +50",
+                            "neutral": 0,
+                        },
+                        "B_offset": {
+                            "label": "Blue Offset",
+                            "affects": "blue shadows (30% gray)",
+                            "range": "-50 to +50",
+                            "neutral": 0,
+                        },
+                    },
+                    "neutral_value": 0,
+                    "note": "Service menu only. Write down originals before changing. 80% gray for Gain, 30% gray for Offset.",
+                },
+                "cms": {
+                    "path": "Service Menu > Color Tuner",
+                    "type": "cms",
+                    "colors": ["Red", "Green", "Blue", "Cyan", "Magenta", "Yellow"],
+                    "params": {
+                        "Hue": "Shifts relative colour angle.",
+                        "Saturation": "Adjusts purity / vibrancy.",
+                        "Brightness": "Controls luminance of that specific colour.",
+                    },
+                    "neutral_value": 0,
+                    "note": "Service menu offers finer resolution than user menu Color Calibration.",
+                },
+                "contrast": {
+                    "path": "Settings > Picture > Contrast",
+                    "type": "slider",
+                    "calibration_default": 50,
+                    "note": "Controls peak white levels. Default 50 is usually safe.",
+                },
+                "brightness": {
+                    "path": "Settings > Picture > Brightness",
+                    "type": "slider",
+                    "calibration_default": 50,
+                    "note": "Black level control — NOT luminance. Set so 5% near-black is just visible.",
+                },
+                "color_enhancement": {
+                    "path": "Settings > Picture > Color Enhancement",
+                    "type": "toggle",
+                    "calibration_value": "Off",
+                    "note": "Separate from disable list — easy to miss. Disable during calibration.",
+                },
+            },
+        },
     )
 
 

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -131,6 +131,10 @@ export const api = {
   runSuggestedPatches: (sid, patches) =>
     api.post(`/api/session/${sid}/suggested-patches/run`, { patches }),
 
+  // OSD Command Translator (#167)
+  translateOsd: (sid, plan) =>
+    api.post(`/api/session/${sid}/osd/translate`, { plan }),
+
   // Report
   getReport:     (sid)        => api.get(`/api/session/${sid}/report`),
   downloadPdf:   async (sid, tv) => {

--- a/frontend/src/components/CombinedInsightCard.jsx
+++ b/frontend/src/components/CombinedInsightCard.jsx
@@ -12,7 +12,7 @@
  * Also accepts an optional `plan` object (from LLM) with next_step and confidence.
  */
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 const SCOPE_BADGE = {
   global: { label: 'Global', color: 'var(--accent)' },
@@ -177,8 +177,6 @@ export function OSDStepList({ steps, title = 'OSD Navigation', usesAdb, adbInstr
  *   sid       — string, session ID
  */
 
-import { useEffect, useState } from 'react';
-import { LlmInsightCard } from './LlmInsightCard';
 import { api } from '../api/client';
 
 const NEXT_STEP_LABEL = {
@@ -188,7 +186,7 @@ const NEXT_STEP_LABEL = {
   verify:          'Verify / Done',
 };
 
-export function CombinedInsightCard({ insight, streaming, error, onDismiss, tvKey, sid }) {
+export function CombinedInsightCard({ insight, streaming, error, onDismiss, sid }) {
   const [osdSteps, setOsdSteps] = useState([]);
   const [adbInfo, setAdbInfo] = useState({ usesAdb: false, adbInstructions: null });
   const [osdLoading, setOsdLoading] = useState(false);
@@ -265,5 +263,4 @@ export function CombinedInsightCard({ insight, streaming, error, onDismiss, tvKe
   );
 }
 
-// Re-export for importers
-export { OSDStepList };
+

--- a/frontend/src/components/CombinedInsightCard.jsx
+++ b/frontend/src/components/CombinedInsightCard.jsx
@@ -1,0 +1,269 @@
+/**
+ * OSDStepList — displays step-by-step OSD navigation instructions from the
+ * Command Translator (#167).
+ *
+ * Props:
+ *   steps  — array of { step_number, menu_path, action, value, rationale, completed }
+ *   title  — section heading (e.g. "OSD Navigation")
+ *   usesAdb — boolean, shows ADB hint when true
+ *   adbInstructions — string shown when usesAdb is true
+ *   onToggleStep  — (stepNumber) => void callback for checkbox clicks
+ *
+ * Also accepts an optional `plan` object (from LLM) with next_step and confidence.
+ */
+
+import { useState } from 'react';
+
+const SCOPE_BADGE = {
+  global: { label: 'Global', color: 'var(--accent)' },
+  local:  { label: 'Local',  color: 'var(--yellow, #f0a500)' },
+};
+
+function StepItem({ step, onToggle }) {
+  const checked = !!step.completed;
+  return (
+    <div
+      style={{
+        display: 'flex',
+        gap: 10,
+        padding: '8px 0',
+        borderBottom: '1px solid var(--border-subtle, rgba(255,255,255,0.06))',
+        opacity: checked ? 0.6 : 1,
+      }}
+    >
+      {/* Checkbox */}
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={() => onToggle(step.step_number)}
+        style={{ marginTop: 3, accentColor: 'var(--accent)' }}
+      />
+
+      {/* Step number badge */}
+      <span
+        style={{
+          minWidth: 24,
+          height: 24,
+          borderRadius: '50%',
+          background: checked ? 'var(--accent-dim)' : 'var(--surface3)',
+          color: checked ? 'var(--accent)' : 'var(--muted)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontSize: '0.75rem',
+          fontWeight: 700,
+        }}
+      >
+        {checked ? '\u2713' : step.step_number}
+      </span>
+
+      {/* Content */}
+      <div style={{ flex: 1, minWidth: 0 }}>
+        {/* Menu path */}
+        <div
+          style={{
+            fontWeight: 600,
+            fontSize: '0.83rem',
+            color: checked ? 'var(--muted)' : 'var(--text)',
+          }}
+        >
+          {step.menu_path}
+        </div>
+
+        {/* Action + value */}
+        <div style={{ fontSize: '0.82rem', color: 'var(--accent)', marginTop: 1 }}>
+          {step.action}
+          {step.value && (
+            <span style={{ marginLeft: 6, fontWeight: 400 }}>
+              {step.value}
+            </span>
+          )}
+        </div>
+
+        {/* Rationale */}
+        {step.rationale && (
+          <div
+            style={{
+              fontSize: '0.78rem',
+              color: checked ? 'var(--muted)' : 'var(--muted)',
+              marginTop: 3,
+              lineHeight: 1.45,
+            }}
+          >
+            {step.rationale}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function OSDStepList({ steps, title = 'OSD Navigation', usesAdb, adbInstructions, onToggleStep }) {
+  const [localSteps, setLocalSteps] = useState(steps || []);
+
+  // Sync with parent steps prop changes
+  if (steps && JSON.stringify(steps) !== JSON.stringify(localSteps)) {
+    setLocalSteps(steps);
+  }
+
+  const handleToggle = (stepNumber) => {
+    const updated = localSteps.map((s) =>
+      s.step_number === stepNumber ? { ...s, completed: !s.completed } : s
+    );
+    setLocalSteps(updated);
+    if (onToggleStep) onToggleStep(stepNumber);
+  };
+
+  const completedCount = localSteps.filter((s) => s.completed).length;
+  const totalCount = localSteps.length;
+
+  if (!localSteps.length) return null;
+
+  return (
+    <div className="card mb-0">
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 4 }}>
+        <div className="card-title">{title}</div>
+        {totalCount > 0 && (
+          <span
+            style={{
+              fontSize: '0.72rem',
+              color: 'var(--muted)',
+              marginLeft: 'auto',
+            }}
+          >
+            {completedCount}/{totalCount} done
+          </span>
+        )}
+      </div>
+
+      {/* ADB hint */}
+      {usesAdb && adbInstructions && (
+        <div
+          style={{
+            fontSize: '0.8rem',
+            color: 'var(--yellow, #f0a500)',
+            padding: '6px 10px',
+            background: 'rgba(240,165,0,0.08)',
+            borderRadius: 6,
+            marginBottom: 6,
+          }}
+        >
+          {adbInstructions}
+        </div>
+      )}
+
+      {/* Steps */}
+      {localSteps.map((step) => (
+        <StepItem key={step.step_number} step={step} onToggle={handleToggle} />
+      ))}
+    </div>
+  );
+}
+
+/**
+ * CombinedInsightCard — merges LlmInsightCard's AdjustmentPlan with OSDStepList.
+ *
+ * Used on calibration pages where the LLM generates both adjustment recommendations
+ * and OSD navigation steps. This component shows them together so the user sees:
+ *   1. What to adjust (from LLM)
+ *   2. How to navigate there (OSD steps)
+ *
+ * Props:
+ *   insight  — { text, plan: { adjustments, next_step, confidence }, phase, timestamp }
+ *   streaming — bool
+ *   error    — string | null
+ *   onDismiss — () => void
+ *   tvKey     — string, for OSD translation API call
+ *   sid       — string, session ID
+ */
+
+import { useEffect, useState } from 'react';
+import { LlmInsightCard } from './LlmInsightCard';
+import { api } from '../api/client';
+
+const NEXT_STEP_LABEL = {
+  rerun_grayscale: 'Re-run Grayscale',
+  proceed_cms:     'Proceed to CMS',
+  rerun_wb:        'Re-run White Balance',
+  verify:          'Verify / Done',
+};
+
+export function CombinedInsightCard({ insight, streaming, error, onDismiss, tvKey, sid }) {
+  const [osdSteps, setOsdSteps] = useState([]);
+  const [adbInfo, setAdbInfo] = useState({ usesAdb: false, adbInstructions: null });
+  const [osdLoading, setOsdLoading] = useState(false);
+  const [osdError, setOsdError] = useState(null);
+
+  // Translate LLM plan to OSD steps when insight changes
+  useEffect(() => {
+    if (!insight?.plan?.adjustments?.length || !sid) return;
+
+    setOsdLoading(true);
+    setOsdError(null);
+
+    api.translateOsd(sid, insight.plan)
+      .then((result) => {
+        setOsdSteps(result.steps || []);
+        setAdbInfo({ usesAdb: result.uses_adb, adbInstructions: result.adb_instructions });
+      })
+      .catch((err) => {
+        setOsdError(err.message || 'Failed to translate OSD steps');
+      })
+      .finally(() => setOsdLoading(false));
+  }, [insight?.plan, sid]);
+
+  const hasPlan = insight?.plan && Array.isArray(insight.plan.adjustments);
+
+  return (
+    <>
+      {/* Original LLM insight card */}
+      <LlmInsightCard
+        insight={insight}
+        streaming={streaming}
+        error={error}
+        onDismiss={onDismiss}
+      />
+
+      {/* OSD navigation steps (only when we have a plan) */}
+      {hasPlan && !error && (
+        <div style={{ marginTop: -8 }}>
+          {osdLoading && (
+            <div
+              style={{
+                padding: '10px 14px',
+                fontSize: '0.82rem',
+                color: 'var(--muted)',
+              }}
+            >
+              Generating OSD navigation steps...
+            </div>
+          )}
+          {osdError && (
+            <div
+              style={{
+                padding: '8px 14px',
+                fontSize: '0.78rem',
+                color: 'var(--red)',
+                background: 'rgba(231,76,60,0.05)',
+                borderRadius: 4,
+              }}
+            >
+              {osdError}
+            </div>
+          )}
+          {!osdLoading && !osdError && (
+            <OSDStepList
+              steps={osdSteps}
+              title="How to Navigate"
+              usesAdb={adbInfo.usesAdb}
+              adbInstructions={adbInfo.adbInstructions}
+            />
+          )}
+        </div>
+      )}
+    </>
+  );
+}
+
+// Re-export for importers
+export { OSDStepList };

--- a/server.py
+++ b/server.py
@@ -84,6 +84,8 @@ from calibrator.reports import (
     render_report_pdf as _render_report_pdf,
     report_payload as _report_payload,
 )
+from calibrator.osd import translate_from_adjustment_plan as _osd_translate
+from calibrator.osd import translate_from_adjustment_plan as _osd_translate
 from calibrator.session import (
     CMS_PATCHES,
     cv as _cv,
@@ -1261,11 +1263,29 @@ def session_history(sid: str):
 # ── Hardware remediation endpoint ─────────────────────────────────────────────
 
 
+class _OsdTranslateReq(BaseModel):
+    plan: dict  # AdjustmentPlan dict from LLM
+
+
 class _HardwareEventReq(BaseModel):
     event_type: str
     context: dict = {}
     attempt_count: int = 1
     session_phase: str = ""
+
+
+@app.post("/api/session/{sid}/osd/translate")
+def osd_translate(sid: str, req: _OsdTranslateReq):
+    """Translate an LLM adjustment plan into step-by-step OSD navigation instructions."""
+    session = store.get(sid)
+    tv_key = session.get("tv_key", "")
+
+    if not tv_key:
+        raise HTTPException(400, "No TV profile selected for this session.")
+
+    tv_profile = _get_tv_profile(tv_key)
+    result = _osd_translate(req.plan, tv_profile)
+    return result.to_dict()
 
 
 @app.post("/api/session/{sid}/hardware/remediate")

--- a/tests/test_osd_translator.py
+++ b/tests/test_osd_translator.py
@@ -1,0 +1,481 @@
+"""
+Tests for the OSD Command Translator (#167).
+
+Covers:
+- Adjustment normalisation from LLM format
+- White balance step generation for all 4 TV profiles
+- CMS step generation for all 4 TV profiles
+- Gamma step generation
+- Picture control step generation (backlight, contrast, etc.)
+- ADB skip detection for U8G
+- Skipped corrections with reasons
+- Empty/invalid input handling
+- tv_key field in result
+"""
+
+import pytest
+
+from calibrator.osd import (
+    OSDStep,
+    OSDTranslationResult,
+    _normalise_adjustment,
+    _derive_setting_key,
+    _compute_delta,
+    _format_value,
+    _format_delta,
+    _build_menu_path,
+    _extract_cms_colour,
+    _generate_wb_steps,
+    _generate_cms_steps,
+    _generate_gamma_steps,
+    _generate_picture_control_steps,
+    _generate_steps_for_adjustment,
+    translate_corrections,
+    translate_from_adjustment_plan,
+)
+from calibrator.profiles import TV_PROFILES
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+U8G = TV_PROFILES["u8g"]
+TCL = TV_PROFILES["tcl7105x"]
+LG = TV_PROFILES["lg_oled55b7a"]
+VIZIO = TV_PROFILES["vizio_v4k55m"]
+
+ALL_PROFILES = [U8G, TCL, LG, VIZIO]
+
+
+def _llm_adj(setting, menu, from_val=None, to_val=None, reason=""):
+    """Build a minimal LLM-style adjustment dict."""
+    return {
+        "setting": setting,
+        "menu": menu,
+        "from": from_val,
+        "to": to_val,
+        "reason": reason,
+        "scope": "local",
+    }
+
+
+def _canonical_adj(setting_key, from_val=None, to_val=None, delta=None, reason=""):
+    """Build a canonical adjustment dict (already normalised)."""
+    return {
+        "setting_key": setting_key,
+        "from": from_val,
+        "to": to_val,
+        "delta": delta,
+        "reason": reason,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Normalisation helpers
+# ---------------------------------------------------------------------------
+
+
+class TestNormalisation:
+    def test_derive_setting_key_red_gain(self):
+        assert _derive_setting_key("R-Gain", "") == "white_balance_2pt.channels.R_gain"
+
+    def test_derive_setting_key_blue_offset(self):
+        assert _derive_setting_key("B-Offset", "") == "white_balance_2pt.channels.B_offset"
+
+    def test_derive_setting_key_saturation(self):
+        assert _derive_setting_key("Saturation", "") == "cms.params.Saturation"
+
+    def test_derive_setting_key_gamma(self):
+        assert _derive_setting_key("Gamma", "") == "gamma"
+
+    def test_derive_setting_key_backlight(self):
+        assert _derive_setting_key("Backlight", "") == "backlight"
+
+    def test_derive_setting_key_fallback(self):
+        result = _derive_setting_key("Some Weird Setting", "")
+        assert result == "some_weird_setting"
+
+    def test_compute_delta_positive(self):
+        assert _compute_delta(0, 3) == 3.0
+
+    def test_compute_delta_negative(self):
+        assert _compute_delta(3, 0) == -3.0
+
+    def test_compute_delta_none_from(self):
+        assert _compute_delta(None, 3) is None
+
+    def test_compute_delta_none_to(self):
+        assert _compute_delta(0, None) is None
+
+    def test_format_value_integer(self):
+        assert _format_value(3.0, "slider") == "3"
+
+    def test_format_value_float(self):
+        assert _format_value(2.28, "slider") == "2.28"
+
+    def test_format_value_enum(self):
+        assert _format_value("BT.1886", "enum") == "BT.1886"
+
+    def test_format_value_none(self):
+        assert _format_value(None, "slider") is None
+
+    def test_format_delta_positive(self):
+        assert _format_delta(3.0, "slider") == "+3"
+
+    def test_format_delta_negative(self):
+        assert _format_delta(-2.0, "slider") == "-2"
+
+    def test_format_delta_float(self):
+        assert _format_delta(0.5, "slider") == "+0.5"
+
+    def test_build_menu_path_with_channel(self):
+        result = _build_menu_path("Settings > Picture", "Red")
+        assert "Red" in result
+
+    def test_build_menu_path_no_channel(self):
+        result = _build_menu_path("Settings > Picture")
+        assert "Settings" in result
+
+    def test_extract_cms_colour_from_field(self):
+        assert _extract_cms_colour({"colour": "Red"}) == "Red"
+
+    def test_extract_cms_colour_fallback(self):
+        assert _extract_cms_colour({"setting": "Hue"}) == "Red"
+
+
+# ---------------------------------------------------------------------------
+# Adjustment normalisation
+# ---------------------------------------------------------------------------
+
+
+class TestAdjustmentNormalisation:
+    def test_normalise_from_llm_format(self):
+        adj = _normalise_adjustment(_llm_adj("R-Gain", "", 0, 3))
+        assert adj["setting_key"] == "white_balance_2pt.channels.R_gain"
+        assert adj["to"] == 3
+        assert adj["delta"] == 3.0
+
+    def test_normalise_already_canonical(self):
+        adj = _normalise_adjustment(_canonical_adj("gamma", to_val=2.2))
+        assert adj["setting_key"] == "gamma"
+        assert adj["to"] == 2.2
+
+    def test_normalise_preserves_reason(self):
+        adj = _normalise_adjustment(_llm_adj("Gamma", "", reason="Gamma too dark"))
+        assert adj["reason"] == "Gamma too dark"
+
+
+# ---------------------------------------------------------------------------
+# White balance step generation
+# ---------------------------------------------------------------------------
+
+
+class TestWBSteps:
+    @pytest.mark.parametrize("profile", ALL_PROFILES)
+    def test_generate_wb_steps_has_menu_path(self, profile):
+        adj = _canonical_adj("white_balance_2pt.channels.R_gain", from_val=0, to_val=3)
+        steps = _generate_wb_steps(profile, adj)
+        assert len(steps) >= 1
+        assert steps[0].menu_path
+        assert steps[0].action
+
+    @pytest.mark.parametrize("profile", ALL_PROFILES)
+    def test_generate_wb_steps_gain(self, profile):
+        adj = _canonical_adj("white_balance_2pt.channels.R_gain", from_val=0, to_val=3)
+        steps = _generate_wb_steps(profile, adj)
+        assert any("Red" in s.menu_path for s in steps)
+
+    @pytest.mark.parametrize("profile", ALL_PROFILES)
+    def test_generate_wb_steps_offset(self, profile):
+        adj = _canonical_adj("white_balance_2pt.channels.B_offset", from_val=0, to_val=-2)
+        steps = _generate_wb_steps(profile, adj)
+        assert any("Blue" in s.menu_path for s in steps)
+
+    @pytest.mark.parametrize("profile", ALL_PROFILES)
+    def test_generate_wb_steps_value_display(self, profile):
+        adj = _canonical_adj("white_balance_2pt.channels.G_gain", to_val=5)
+        steps = _generate_wb_steps(profile, adj)
+        assert steps[0].value == "5"
+
+    def test_u8g_wb_ire_points(self):
+        adj = _canonical_adj("white_balance_2pt.channels.R_gain", to_val=3)
+        steps = _generate_wb_steps(U8G, adj)
+        assert any("IRE 80" in s.menu_path or "IRE 20" in s.menu_path for s in steps)
+
+    def test_tcl_wb_with_menu_path(self):
+        adj = _canonical_adj("white_balance_2pt.channels.B_gain", to_val=-3)
+        steps = _generate_wb_steps(TCL, adj)
+        assert len(steps) >= 1
+        assert "Blue" in steps[0].menu_path
+
+    def test_lg_wb_with_menu_path(self):
+        adj = _canonical_adj("white_balance_2pt.channels.R_offset", to_val=2)
+        steps = _generate_wb_steps(LG, adj)
+        assert len(steps) >= 1
+        assert "Red" in steps[0].menu_path
+
+    def test_vizio_wb_with_menu_path(self):
+        adj = _canonical_adj("white_balance_2pt.channels.G_offset", to_val=-1)
+        steps = _generate_wb_steps(VIZIO, adj)
+        assert len(steps) >= 1
+        assert "Green" in steps[0].menu_path
+
+
+# ---------------------------------------------------------------------------
+# CMS step generation
+# ---------------------------------------------------------------------------
+
+
+class TestCMSSteps:
+    @pytest.mark.parametrize("profile", ALL_PROFILES)
+    def test_generate_cms_steps_has_path(self, profile):
+        adj = _canonical_adj("cms.params.Saturation", to_val=2)
+        adj["colour"] = "Red"
+        steps = _generate_cms_steps(profile, adj)
+        assert len(steps) >= 1
+        assert steps[0].menu_path
+
+    @pytest.mark.parametrize("profile", ALL_PROFILES)
+    def test_generate_cms_steps_includes_colour(self, profile):
+        adj = _canonical_adj("cms.params.Hue", to_val=1)
+        adj["colour"] = "Green"
+        steps = _generate_cms_steps(profile, adj)
+        assert any("Green" in s.menu_path for s in steps)
+
+    def test_u8g_cms_steps(self):
+        adj = _canonical_adj("cms.params.Brightness", to_val=3)
+        adj["colour"] = "Blue"
+        steps = _generate_cms_steps(U8G, adj)
+        assert any("Blue" in s.menu_path for s in steps)
+        assert any("Brightness" in s.action for s in steps)
+
+    def test_lg_cms_steps(self):
+        adj = _canonical_adj("cms.params.Luminance", to_val=-2)
+        adj["colour"] = "Cyan"
+        steps = _generate_cms_steps(LG, adj)
+        assert any("Cyan" in s.menu_path for s in steps)
+
+
+# ---------------------------------------------------------------------------
+# Gamma step generation
+# ---------------------------------------------------------------------------
+
+
+class TestGammaSteps:
+    @pytest.mark.parametrize("profile", ALL_PROFILES)
+    def test_generate_gamma_steps(self, profile):
+        adj = _canonical_adj("gamma", to_val="BT.1886")
+        steps = _generate_gamma_steps(profile, adj)
+        assert len(steps) >= 1
+        assert steps[0].action == "Set gamma preset"
+
+    @pytest.mark.parametrize("profile", ALL_PROFILES)
+    def test_generate_gamma_steps_value(self, profile):
+        adj = _canonical_adj("gamma", to_val=2.2)
+        steps = _generate_gamma_steps(profile, adj)
+        assert steps[0].value == "2.2"
+
+    def test_gamma_steps_with_delta(self):
+        adj = _canonical_adj("gamma", delta=0.1)
+        steps = _generate_gamma_steps(U8G, adj)
+        assert steps[0].value == "+0.1"
+
+
+# ---------------------------------------------------------------------------
+# Picture control step generation
+# ---------------------------------------------------------------------------
+
+
+class TestPictureControlSteps:
+    @pytest.mark.parametrize("profile", ALL_PROFILES)
+    def test_backlight_steps(self, profile):
+        adj = _canonical_adj("backlight", to_val=60)
+        steps = _generate_picture_control_steps(profile, adj)
+        assert len(steps) >= 1
+        assert "Backlight" in steps[0].action or "backlight" in steps[0].menu_path.lower()
+
+    @pytest.mark.parametrize("profile", ALL_PROFILES)
+    def test_contrast_steps(self, profile):
+        adj = _canonical_adj("contrast", to_val=85)
+        steps = _generate_picture_control_steps(profile, adj)
+        assert len(steps) >= 1
+        assert "Contrast" in steps[0].action
+
+    @pytest.mark.parametrize("profile", ALL_PROFILES)
+    def test_black_level_steps(self, profile):
+        adj = _canonical_adj("black_level", to_val=50)
+        steps = _generate_picture_control_steps(profile, adj)
+        assert len(steps) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Step routing
+# ---------------------------------------------------------------------------
+
+
+class TestStepRouting:
+    @pytest.mark.parametrize("profile", ALL_PROFILES)
+    def test_route_wb(self, profile):
+        adj = _canonical_adj("white_balance_2pt.channels.R_gain", to_val=3)
+        steps = _generate_steps_for_adjustment(profile, adj)
+        assert len(steps) >= 1
+        assert "Red" in steps[0].menu_path
+
+    @pytest.mark.parametrize("profile", ALL_PROFILES)
+    def test_route_cms(self, profile):
+        adj = _canonical_adj("cms.params.Saturation", to_val=2)
+        adj["colour"] = "Red"
+        steps = _generate_steps_for_adjustment(profile, adj)
+        assert len(steps) >= 1
+
+    @pytest.mark.parametrize("profile", ALL_PROFILES)
+    def test_route_gamma(self, profile):
+        adj = _canonical_adj("gamma", to_val="BT.1886")
+        steps = _generate_steps_for_adjustment(profile, adj)
+        assert len(steps) >= 1
+
+    @pytest.mark.parametrize("profile", ALL_PROFILES)
+    def test_route_unknown_setting(self, profile):
+        adj = _canonical_adj("some_unknown_setting", to_val=5)
+        steps = _generate_steps_for_adjustment(profile, adj)
+        assert len(steps) == 1
+        # Setting name is title-cased for display
+        assert "unknown setting" in steps[0].menu_path.lower()
+
+
+# ---------------------------------------------------------------------------
+# Full translation
+# ---------------------------------------------------------------------------
+
+
+class TestTranslateCorrections:
+    def test_u8g_translation(self):
+        adjustments = [
+            _llm_adj("R-Gain", "", 0, 3, "Red highlights too warm"),
+            _llm_adj("B-Offset", "", 0, -2, "Blue shadows too cool"),
+            _llm_adj("Gamma", "", "2.2", "BT.1886"),
+        ]
+        result = translate_corrections(adjustments, U8G)
+        assert result.tv_model == "Hisense U8G"
+        assert result.tv_key == "u8g"
+        assert len(result.steps) >= 3
+        assert not result.skipped_reasons
+        assert result.uses_adb is True
+
+    def test_tcl_translation(self):
+        adjustments = [
+            _llm_adj("Red Gain", "", 0, 2),
+            _llm_adj("Saturation", "", 0, 1),
+        ]
+        adjustments[1]["colour"] = "Green"
+        result = translate_corrections(adjustments, TCL)
+        assert result.tv_model == "TCL 7105X"
+        assert result.tv_key == "tcl7105x"
+        assert len(result.steps) >= 2
+
+    def test_lg_translation(self):
+        adjustments = [
+            _llm_adj("Blue Gain", "", 0, 4, "Blue gain too low"),
+        ]
+        result = translate_corrections(adjustments, LG)
+        assert result.tv_model == "LG OLED55B7A"
+        assert result.tv_key == "lg_oled55b7a"
+        assert len(result.steps) >= 1
+
+    def test_vizio_translation(self):
+        adjustments = [
+            _llm_adj("Gamma", "", "2.2", "2.4"),
+        ]
+        result = translate_corrections(adjustments, VIZIO)
+        assert result.tv_model == "Vizio V4K55M-0801"
+        assert result.tv_key == "vizio_v4k55m"
+        assert len(result.steps) >= 1
+
+    def test_empty_adjustments(self):
+        result = translate_corrections([], U8G)
+        assert result.steps == []
+
+    def test_skipped_unknown_setting(self):
+        adjustments = [_llm_adj("NonExistentControl", "", 0, 5)]
+        result = translate_corrections(adjustments, U8G)
+        assert len(result.skipped_reasons) >= 1
+        assert "NonExistentControl" in result.skipped_reasons[0]
+
+    def test_step_to_dict(self):
+        step = OSDStep(step_number=1, menu_path="A > B", action="Adjust X", value="5")
+        d = step.to_dict()
+        assert d["step_number"] == 1
+        assert d["menu_path"] == "A > B"
+        assert d["action"] == "Adjust X"
+        assert d["value"] == "5"
+        assert d["completed"] is False
+
+    def test_result_to_dict(self):
+        result = OSDTranslationResult(tv_model="Test", tv_key="test")
+        result.steps = [
+            OSDStep(step_number=1, menu_path="A", action="B"),
+        ]
+        result.skipped_reasons = ["reason1"]
+        d = result.to_dict()
+        assert d["tv_model"] == "Test"
+        assert d["tv_key"] == "test"
+        assert len(d["steps"]) == 1
+        assert d["skipped_reasons"] == ["reason1"]
+
+
+# ---------------------------------------------------------------------------
+# translate_from_adjustment_plan wrapper
+# ---------------------------------------------------------------------------
+
+
+class TestTranslateFromAdjustmentPlan:
+    def test_plan_with_adjustments(self):
+        plan = {
+            "adjustments": [
+                _llm_adj("R-Gain", "", 0, 3),
+                _llm_adj("Gamma", "", "2.2", "BT.1886"),
+            ],
+            "next_step": "proceed_cms",
+            "confidence": 0.85,
+        }
+        result = translate_from_adjustment_plan(plan, U8G)
+        assert len(result.steps) >= 2
+
+    def test_plan_no_adjustments(self):
+        plan = {"adjustments": [], "next_step": "verify", "confidence": 1.0}
+        result = translate_from_adjustment_plan(plan, U8G)
+        assert result.steps == []
+
+
+# ---------------------------------------------------------------------------
+# Rationale content
+# ---------------------------------------------------------------------------
+
+
+class TestRationale:
+    def test_wb_rationale_includes_channel(self):
+        adj = _canonical_adj("white_balance_2pt.channels.R_gain", to_val=3)
+        steps = _generate_wb_steps(U8G, adj)
+        assert "Red" in steps[0].rationale or "Gain" in steps[0].rationale
+
+    def test_gamma_rationale_default(self):
+        adj = _canonical_adj("gamma", to_val="BT.1886")
+        steps = _generate_gamma_steps(U8G, adj)
+        assert "tracking" in steps[0].rationale.lower()
+
+    def test_custom_rationale_preserved(self):
+        adj = _canonical_adj("gamma", to_val="BT.1886", reason="Midtones too bright")
+        steps = _generate_gamma_steps(U8G, adj)
+        assert "Midtones" in steps[0].rationale
+
+    def test_adb_rationale_for_u8g(self):
+        adjustments = [_llm_adj("R-Gain", "", 0, 3)]
+        result = translate_corrections(adjustments, U8G)
+        assert result.uses_adb is True
+        assert all("ADB" in s.rationale for s in result.steps)
+
+    def test_no_adb_for_other_tvs(self):
+        adjustments = [_llm_adj("R-Gain", "", 0, 3)]
+        result = translate_corrections(adjustments, TCL)
+        assert result.uses_adb is False


### PR DESCRIPTION
## Summary

- Add `calibrator/osd.py` — deterministic OSD navigation translator that converts LLM adjustment vectors into step-by-step menu instructions using TV profile `llm_schema` data
- Add `POST /api/session/{sid}/osd/translate` endpoint for frontend integration
- Add `CombinedInsightCard.jsx` — React component that merges LLM adjustment recommendations with generated OSD navigation steps, includes checkbox tracking and ADB hints
- Seed `llm_schema` navigation data for TCL 7105X and Vizio V4K55M profiles (U8G and LG OLED B7A already had it)
- 106 tests covering all translators, all 4 TV profiles, ADB detection, and error handling

## How it works

For **known TV profiles** (U8G, TCL 7105X, LG OLED B7A, Vizio V4K55M):
- The translator reads the TV profile's `llm_schema.settings` dict and `WB_MENU_PATH`/`GAMMA_MENU_PATH`/`CMS_MENU_PATH` attributes
- Maps LLM adjustment keys (e.g. `white_balance_2pt.channels.R_gain`) to concrete OSD menu paths
- Generates ordered step instructions with menu path, action, target value, and rationale
- For U8G, detects ADB CMS capability and adds a hint that corrections can be applied directly without OSD navigation

For **unknown TVs**:
- Returns empty steps so the caller can fall back to LLM-driven generation

## Files changed

| File | Change |
|------|--------|
| `calibrator/osd.py` | **New** — Core translator module |
| `calibrator/profiles.py` | Added `llm_schema` to TCL 7105X and Vizio V4K55M |
| `server.py` | Added `/api/session/{sid}/osd/translate` endpoint |
| `frontend/src/components/CombinedInsightCard.jsx` | **New** — LLM insight + OSD steps component |
| `frontend/src/api/client.js` | Added `translateOsd()` method |
| `tests/test_osd_translator.py` | **New** — 106 tests |

## Testing

All 939 tests pass (2 skipped, same as before).