### PR TITLE
fix(llm): clear LLM states on session create and delete

### DIFF
--- a/frontend/src/hooks/useSession.js
+++ b/frontend/src/hooks/useSession.js
@@ -248,15 +248,23 @@ export function useSession() {
 
   async function deleteSession() {
     if (!session?.id) return;
+    stopLlmSSE();
     await api.deleteSession(session.id);
     sseRef.current?.close();
     setSession(null);
+    setLlmInsight(null);
+    setLlmError(null);
+    setLlmStreaming(false);
   }
 
   async function createSession(tv, mode, sdrPeakNits) {
+    stopLlmSSE();
     const sess = await api.createSession(tv, mode, sdrPeakNits);
     setSession(sess);
     startSSE(sess.id);
+    setLlmInsight(null);
+    setLlmError(null);
+    setLlmStreaming(false);
     return sess;
   }
 


### PR DESCRIPTION
## Summary

Fixes #223

`deleteSession()` and `createSession()` only cleared the session object and didn't reset:
- `llmInsight`
- `llmError`
- `llmStreaming`

This caused stale LLM guidance to persist across session reset/new session boundaries.

## Changes

- `deleteSession()`: now calls `stopLlmSSE()` and clears `llmInsight`, `llmError`, and `llmStreaming`
- `createSession()`: now calls `stopLlmSSE()` and resets `llmInsight`, `llmError`, and `llmStreaming` before setting the new session

## Repro steps (before)
1. Run a session with LLM configured until an insight or error is shown
2. Click Start Over / delete the session
3. Create a new session in the same tab
4. Observe: previous session's LLM card remains visible

## Expected

New sessions start with empty LLM state.