### PR TITLE
fix(reports): is-not-None guards for improvement_pct + history completion guard (#[220] #[221])

### DIFF
--- a/calibrator/reports.py
+++ b/calibrator/reports.py
@@ -42,7 +42,7 @@ def report_payload(session: Dict[str, Any]) -> Dict[str, Any]:
     cms = stats(session["cms_measurements"])
     gamma = gamma_stats(session["gamma_measurements"])
     improvement = None
-    if pre["avg_de"] and post["avg_de"] and pre["avg_de"] > 0:
+    if pre["avg_de"] is not None and post["avg_de"] is not None and pre["avg_de"] > 0:
         improvement = round((1 - post["avg_de"] / pre["avg_de"]) * 100, 1)
 
     return {

--- a/server.py
+++ b/server.py
@@ -1358,7 +1358,13 @@ def get_report(sid: str):
     session = store.get(sid)
     report = _report_payload(session)
     # Record to per-TV calibration history on first fetch (idempotent via session flag).
-    if not session.get("_history_recorded"):
+    # Only record completed sessions — skip sessions that are still in-flight or have
+    # no meaningful measurements (they pollute history with null entries).
+    completed_steps = {"luminance", "white_balance", "gamma", "report"}
+    has_measurements = (
+        session.get("post_measurements") and len(session["post_measurements"]) > 0
+    )
+    if not session.get("_history_recorded") and session.get("step") in completed_steps and has_measurements:
         try:
             _record_session(
                 tv_key=session.get("tv_key", "unknown"),

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -1800,3 +1800,168 @@ def test_cors_blocks_credentials_on_unknown_origin(client):
     )
     assert resp.status_code == 200
     assert resp.headers.get("access-control-allow-origin") != "http://evil.example.com"
+
+
+# ── Bug fix: #220 improvement_pct with zero post ΔE ────────────────
+
+class TestImprovementPercentZeroDeltaE:
+    def test_perfect_post_cal_yields_100_pct_improvement(self, client, session_id):
+        """#220: perfect post-cal ΔE of 0.0 should give 100% improvement, not None."""
+        from calibrator.reports import report_payload
+
+        _sessions[session_id]["step"] = "report"
+        _sessions[session_id]["target"] = type("T", (), {
+            "gamut": "bt709", "eotf": "bt1886",
+            "peak_luminance_nits": 500, "white_point_xy": (0.3127, 0.3290),
+            "gamma": 2.4,
+        })()
+        _sessions[session_id]["pre_measurements"] = [
+            Measurement(x=0.35, y=0.35, Y=50.0, X=48.0, Z=56.0,
+                        stimulus_rgb=(255, 0, 0), label="Red 100%"),
+        ]
+        _sessions[session_id]["post_measurements"] = [
+            Measurement(x=0.3127, y=0.3290, Y=50.0, X=48.3, Z=55.1,
+                        stimulus_rgb=(255, 0, 0), label="Red 100%"),
+        ]
+        _sessions[session_id]["wb_measurements"] = []
+        _sessions[session_id]["gamma_measurements"] = []
+        _sessions[session_id]["cms_measurements"] = []
+        _sessions[session_id]["lum_measurements"] = []
+        _sessions[session_id]["peak_luminance"] = 200.0
+
+        report = report_payload(_sessions[session_id])
+        assert report["improvement_pct"] == 100.0
+
+    def test_normal_improvement_calculation_with_nonzero_post(self, client, session_id):
+        """Ensure normal improvement calc still works for non-zero post ΔE."""
+        from calibrator.reports import report_payload
+
+        _sessions[session_id]["step"] = "report"
+        _sessions[session_id]["target"] = type("T", (), {
+            "gamut": "bt709", "eotf": "bt1886",
+            "peak_luminance_nits": 500, "white_point_xy": (0.3127, 0.3290),
+            "gamma": 2.4,
+        })()
+        _sessions[session_id]["pre_measurements"] = [
+            Measurement(x=0.40, y=0.40, Y=50.0, X=40.0, Z=48.0,
+                        stimulus_rgb=(255, 0, 0), label="Red 100%"),
+        ]
+        _sessions[session_id]["post_measurements"] = [
+            Measurement(x=0.35, y=0.35, Y=50.0, X=48.0, Z=56.0,
+                        stimulus_rgb=(255, 0, 0), label="Red 100%"),
+        ]
+        _sessions[session_id]["wb_measurements"] = []
+        _sessions[session_id]["gamma_measurements"] = []
+        _sessions[session_id]["cms_measurements"] = []
+        _sessions[session_id]["lum_measurements"] = []
+        _sessions[session_id]["peak_luminance"] = 200.0
+
+        report = report_payload(_sessions[session_id])
+        assert report["improvement_pct"] is not None
+        assert report["improvement_pct"] > 0
+        assert report["improvement_pct"] < 100
+
+
+# ── Bug fix: #221 incomplete sessions don't pollute history ───────
+
+class TestHistoryGuardedByCompletion:
+    def test_report_does_not_record_history_for_incomplete_session(self, client, session_id, monkeypatch):
+        """#221: sessions in 'select_mode' should not record to history."""
+        recorded = []
+        def mock_record(*a, **kw):
+            recorded.append((a, kw))
+        monkeypatch.setattr(server_module, "_record_session", mock_record)
+
+        # Session is still in select_mode — no post_measurements
+        resp = client.get(f"/api/session/{session_id}/report")
+        assert resp.status_code == 400  # no target selected
+
+        assert len(recorded) == 0
+
+    def test_report_does_not_record_history_without_post_measurements(self, client, session_id, monkeypatch):
+        """Sessions at report step but without post_measurements should not record to history."""
+        recorded = []
+        def mock_record(*a, **kw):
+            recorded.append((a, kw))
+        monkeypatch.setattr(server_module, "_record_session", mock_record)
+
+        _sessions[session_id]["step"] = "report"
+        _sessions[session_id]["target"] = type("T", (), {
+            "gamut": "bt709", "eotf": "bt1886",
+            "peak_luminance_nits": 500, "white_point_xy": (0.3127, 0.3290),
+            "gamma": 2.4,
+        })()
+        _sessions[session_id]["pre_measurements"] = []
+        _sessions[session_id]["post_measurements"] = []
+        _sessions[session_id]["wb_measurements"] = []
+        _sessions[session_id]["gamma_measurements"] = []
+        _sessions[session_id]["cms_measurements"] = []
+        _sessions[session_id]["lum_measurements"] = []
+        _sessions[session_id]["peak_luminance"] = 0.0
+
+        resp = client.get(f"/api/session/{session_id}/report")
+        assert resp.status_code == 200
+        assert len(recorded) == 0
+
+    def test_report_records_history_for_completed_session(self, client, session_id, monkeypatch):
+        """Only sessions with post_measurements at a completed step should record to history."""
+        recorded = []
+        def mock_record(*a, **kw):
+            recorded.append((a, kw))
+        monkeypatch.setattr(server_module, "_record_session", mock_record)
+
+        _sessions[session_id]["step"] = "report"
+        _sessions[session_id]["target"] = type("T", (), {
+            "gamut": "bt709", "eotf": "bt1886",
+            "peak_luminance_nits": 500, "white_point_xy": (0.3127, 0.3290),
+            "gamma": 2.4,
+        })()
+        _sessions[session_id]["pre_measurements"] = [
+            Measurement(x=0.3127, y=0.3290, Y=50.0, X=48.3, Z=55.1,
+                        stimulus_rgb=(128, 128, 128), label="50% Gray"),
+        ]
+        _sessions[session_id]["post_measurements"] = [
+            Measurement(x=0.3127, y=0.3290, Y=50.0, X=48.3, Z=55.1,
+                        stimulus_rgb=(128, 128, 128), label="50% Gray"),
+        ]
+        _sessions[session_id]["wb_measurements"] = []
+        _sessions[session_id]["gamma_measurements"] = []
+        _sessions[session_id]["cms_measurements"] = []
+        _sessions[session_id]["lum_measurements"] = []
+        _sessions[session_id]["peak_luminance"] = 200.0
+
+        resp = client.get(f"/api/session/{session_id}/report")
+        assert resp.status_code == 200
+        assert len(recorded) == 1
+        assert recorded[0][1]["session_id"] == session_id
+
+    def test_second_report_fetch_is_idempotent(self, client, session_id, monkeypatch):
+        """Subsequent report fetches should not record history again."""
+        recorded = []
+        def mock_record(*a, **kw):
+            recorded.append((a, kw))
+        monkeypatch.setattr(server_module, "_record_session", mock_record)
+
+        _sessions[session_id]["step"] = "report"
+        _sessions[session_id]["target"] = type("T", (), {
+            "gamut": "bt709", "eotf": "bt1886",
+            "peak_luminance_nits": 500, "white_point_xy": (0.3127, 0.3290),
+            "gamma": 2.4,
+        })()
+        _sessions[session_id]["pre_measurements"] = [
+            Measurement(x=0.3127, y=0.3290, Y=50.0, X=48.3, Z=55.1,
+                        stimulus_rgb=(128, 128, 128), label="50% Gray"),
+        ]
+        _sessions[session_id]["post_measurements"] = [
+            Measurement(x=0.3127, y=0.3290, Y=50.0, X=48.3, Z=55.1,
+                        stimulus_rgb=(128, 128, 128), label="50% Gray"),
+        ]
+        _sessions[session_id]["wb_measurements"] = []
+        _sessions[session_id]["gamma_measurements"] = []
+        _sessions[session_id]["cms_measurements"] = []
+        _sessions[session_id]["lum_measurements"] = []
+        _sessions[session_id]["peak_luminance"] = 200.0
+
+        client.get(f"/api/session/{session_id}/report")
+        client.get(f"/api/session/{session_id}/report")
+        assert len(recorded) == 1


### PR DESCRIPTION
## Summary
- Fix #220: `report_payload()` used truthiness checks (`pre["avg_de"] and post["avg_de"]`) which treated `0.0` as falsy, causing perfect post-cal to skip improvement calculation entirely. Changed to explicit `is not None` guards.
- Fix #221: `GET /api/session/{sid}/report` recorded sessions into calibration history unconditionally, polluting it with incomplete/partial sessions. Added guards requiring session step to be in completed steps set (luminance/white_balance/gamma/report) and at least one post_measurement present.
- Add tests for both fixes in `tests/test_server_api.py`: `TestImprovementPercentZeroDeltaE` and `TestHistoryGuardedByCompletion` suites.

## Changes
- `calibrator/reports.py:45`: `if pre["avg_de"] is not None and post["avg_de"] is not None and pre["avg_de"] > 0:`
- `server.py:1356-1379`: Added `completed_steps` set and `has_measurements` check before calling `_record_session`
- `tests/test_server_api.py`: 6 new tests covering zero ΔE improvement calculation and history recording guards

## Tests
All 139 existing tests pass plus 6 new tests.

Closes #220, Closes #221