### PR TITLE
Switch MCP memory server from LM Studio to Ollama

### DIFF
--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""
+MCP server exposing mem0 session memory via Ollama.
+"""
+
+from pathlib import Path
+from mcp.server.fastmcp import FastMCP
+from mem0 import Memory
+
+mem0_config = {
+    "llm": {
+        "provider": "ollama",
+        "config": {
+            "model": "qwen/qwen3.6-35b-a3b",
+            "ollama_base_url": "http://localhost:11434",
+        }
+    },
+    "embedder": {
+        "provider": "ollama",
+        "config": {
+            "model": "text-embedding-nomic-embed-text-v1.5",
+            "ollama_base_url": "http://localhost:11434",
+        }
+    },
+    "vector_store": {
+        "provider": "chroma",
+        "config": {
+            "collection_name": "session_memory",
+            "path": str(Path.home() / ".local/share/opencode-mem/chroma"),
+        }
+    }
+}
+
+memory = Memory.from_config(mem0_config)
+mcp = FastMCP("opencode-mem")
+
+@mcp.tool()
+def save_memory(content: str, user_id: str = "jweber") -> str:
+    """Save something to persistent memory."""
+    result = memory.add(content, user_id=user_id)
+    return f"Saved: {result}"
+
+@mcp.tool()
+def search_memory(query: str, user_id: str = "jweber", limit: int = 5) -> str:
+    """Search persistent memory for relevant context."""
+    results = memory.search(query, user_id=user_id, limit=limit)
+    if not results:
+        return "No relevant memories found."
+    return "\n\n".join([f"- {r['memory']}" for r in results.get("results", [])])
+
+@mcp.tool()
+def list_memories(user_id: str = "jweber") -> str:
+    """List all stored memories."""
+    results = memory.get_all(user_id=user_id)
+    if not results:
+        return "No memories stored yet."
+    return "\n\n".join([f"- {r['memory']}" for r in results.get("results", [])])
+
+@mcp.tool()
+def delete_memory(memory_id: str) -> str:
+    """Delete a specific memory by ID."""
+    memory.delete(memory_id)
+    return f"Deleted memory {memory_id}"
+
+if __name__ == "__main__":
+    mcp.run()


### PR DESCRIPTION
## Summary

- Replaces LM Studio (`openai` provider, port 1234) with Ollama (`ollama` provider, port 11434) for both LLM and embedder
- Keeps the same models: `qwen/qwen3.6-35b-a3b` and `text-embedding-nomic-embed-text-v1.5`
- Removes LM Studio-specific `api_key` and `lmstudio_base_url` config keys

## Deploy

Copy `mcp_server.py` to `~/.local/share/opencode-mem/server.py` and restart the MCP server.

https://claude.ai/code/session_01QuL74USABxM1iem7u9eNy5