### PR TITLE
fix(reports): handle delta_e=None in report payload stats (#217)

### DIFF
--- a/calibrator/reports.py
+++ b/calibrator/reports.py
@@ -19,13 +19,15 @@ def report_payload(session: Dict[str, Any]) -> Dict[str, Any]:
 
     def stats(measurements: list) -> Dict[str, Any]:
         if not measurements:
-            return {"avg_de": None, "max_de": None, "measurements": []}
+            return {"avg_de": None, "max_de": None, "measurements": [], "invalid_count": 0}
         items = [m_to_dict(m, target, signal_range, code_scale) for m in measurements]
-        des = [item["delta_e"] for item in items]
+        valid = [item["delta_e"] for item in items if item["delta_e"] is not None]
+        invalid_count = sum(1 for item in items if item["delta_e"] is None)
         return {
-            "avg_de": round(sum(des) / len(des), 2),
-            "max_de": round(max(des), 2),
+            "avg_de": round(sum(valid) / len(valid), 2) if valid else None,
+            "max_de": round(max(valid), 2) if valid else None,
             "measurements": items,
+            "invalid_count": invalid_count,
         }
 
     def gamma_stats(measurements: list) -> Dict[str, Any]:
@@ -59,8 +61,8 @@ def report_payload(session: Dict[str, Any]) -> Dict[str, Any]:
         },
         "pre_cal": pre,
         "post_cal": post,
-        "white_balance": {"avg_de": wb["avg_de"], "max_de": wb["max_de"]},
-        "color_tuner": {"avg_de": cms["avg_de"], "max_de": cms["max_de"]},
+        "white_balance": {"avg_de": wb["avg_de"], "max_de": wb["max_de"], "invalid_count": wb["invalid_count"]},
+        "color_tuner": {"avg_de": cms["avg_de"], "max_de": cms["max_de"], "invalid_count": cms["invalid_count"]},
         "gamma": gamma,
         "improvement_pct": improvement,
         "repass_count": session.get("repass_count", 0),

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -1965,3 +1965,108 @@ class TestHistoryGuardedByCompletion:
         client.get(f"/api/session/{session_id}/report")
         client.get(f"/api/session/{session_id}/report")
         assert len(recorded) == 1
+
+
+# ── Bug fix: #217 invalid measurements with delta_e=None don't crash reports ────
+
+class TestReportPayloadInvalidMeasurements:
+    def test_report_payload_handles_delta_e_none_gracefully(self, client, session_id):
+        """#217: invalid measurements with delta_e=None must not crash report generation."""
+        from calibrator.reports import report_payload
+
+        _sessions[session_id]["step"] = "report"
+        _sessions[session_id]["target"] = type("T", (), {
+            "gamut": "bt709", "eotf": "bt1886",
+            "peak_luminance_nits": 500, "white_point_xy": (0.3127, 0.3290),
+            "gamma": 2.4,
+        })()
+        _sessions[session_id]["pre_measurements"] = [
+            Measurement(x=0.35, y=0.35, Y=50.0, X=48.0, Z=56.0,
+                        stimulus_rgb=(128, 128, 128), label="50% Gray"),
+            Measurement(x=-1.0, y=-1.0, Y=-1.0, X=48.0, Z=56.0,
+                        stimulus_rgb=(128, 128, 128), label="Bad Gray"),
+        ]
+        _sessions[session_id]["post_measurements"] = [
+            Measurement(x=0.3127, y=0.3290, Y=50.0, X=48.3, Z=55.1,
+                        stimulus_rgb=(128, 128, 128), label="50% Gray"),
+        ]
+        _sessions[session_id]["wb_measurements"] = [
+            Measurement(x=-1.0, y=-1.0, Y=-1.0, X=48.0, Z=56.0,
+                        stimulus_rgb=(128, 128, 128), label="Bad WB"),
+            Measurement(x=0.3150, y=0.3280, Y=50.0, X=48.3, Z=55.1,
+                        stimulus_rgb=(128, 128, 128), label="Good WB"),
+        ]
+        _sessions[session_id]["gamma_measurements"] = []
+        _sessions[session_id]["cms_measurements"] = []
+        _sessions[session_id]["lum_measurements"] = []
+        _sessions[session_id]["peak_luminance"] = 200.0
+
+        report = report_payload(_sessions[session_id])
+        assert report is not None
+        assert report["pre_cal"]["avg_de"] is not None
+        assert report["pre_cal"]["invalid_count"] == 1
+        assert report["post_cal"]["avg_de"] is not None
+        assert report["post_cal"]["invalid_count"] == 0
+        assert report["white_balance"]["avg_de"] is not None
+        assert report["white_balance"]["invalid_count"] == 1
+
+    def test_report_payload_all_invalid_measurements_yields_none_stats(self, client, session_id):
+        """#217: when all measurements in a group are invalid, stats should be None."""
+        from calibrator.reports import report_payload
+
+        _sessions[session_id]["step"] = "report"
+        _sessions[session_id]["target"] = type("T", (), {
+            "gamut": "bt709", "eotf": "bt1886",
+            "peak_luminance_nits": 500, "white_point_xy": (0.3127, 0.3290),
+            "gamma": 2.4,
+        })()
+        _sessions[session_id]["pre_measurements"] = [
+            Measurement(x=-1.0, y=-1.0, Y=-1.0, X=48.0, Z=56.0,
+                        stimulus_rgb=(128, 128, 128), label="Bad Gray 1"),
+            Measurement(x=0.0, y=0.0, Y=0.0, X=48.0, Z=56.0,
+                        stimulus_rgb=(128, 128, 128), label="Bad Gray 2"),
+        ]
+        _sessions[session_id]["post_measurements"] = []
+        _sessions[session_id]["wb_measurements"] = []
+        _sessions[session_id]["gamma_measurements"] = []
+        _sessions[session_id]["cms_measurements"] = []
+        _sessions[session_id]["lum_measurements"] = []
+        _sessions[session_id]["peak_luminance"] = 0.0
+
+        report = report_payload(_sessions[session_id])
+        assert report["pre_cal"]["avg_de"] is None
+        assert report["pre_cal"]["max_de"] is None
+        assert report["pre_cal"]["invalid_count"] == 2
+        assert report["post_cal"]["avg_de"] is None
+        assert report["post_cal"]["max_de"] is None
+        assert report["improvement_pct"] is None
+
+    def test_report_api_does_not_crash_with_invalid_measurements(self, client, session_id):
+        """#217: the /report endpoint should return 200 even with invalid measurements."""
+        _sessions[session_id]["step"] = "report"
+        _sessions[session_id]["target"] = type("T", (), {
+            "gamut": "bt709", "eotf": "bt1886",
+            "peak_luminance_nits": 500, "white_point_xy": (0.3127, 0.3290),
+            "gamma": 2.4,
+        })()
+        _sessions[session_id]["pre_measurements"] = [
+            Measurement(x=-1.0, y=-1.0, Y=-1.0, X=48.0, Z=56.0,
+                        stimulus_rgb=(128, 128, 128), label="Bad Gray"),
+        ]
+        _sessions[session_id]["post_measurements"] = [
+            Measurement(x=-1.0, y=-1.0, Y=-1.0, X=48.0, Z=56.0,
+                        stimulus_rgb=(128, 128, 128), label="Bad Post"),
+        ]
+        _sessions[session_id]["wb_measurements"] = []
+        _sessions[session_id]["gamma_measurements"] = []
+        _sessions[session_id]["cms_measurements"] = []
+        _sessions[session_id]["lum_measurements"] = []
+        _sessions[session_id]["peak_luminance"] = 0.0
+
+        resp = client.get(f"/api/session/{session_id}/report")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "pre_cal" in data
+        assert "post_cal" in data
+        assert data["pre_cal"]["avg_de"] is None
+        assert data["post_cal"]["avg_de"] is None


### PR DESCRIPTION
## Summary
- Filter out `None` delta_e values before computing avg/max in `report_payload().stats()` — previously invalid measurements (e.g. non-finite xyY, zero chromaticity) caused a `TypeError` crash
- Add `invalid_count` to stats dicts and white_balance/color_tuner payload fields so the UI can surface excluded measurements
- Add 3 tests: mixed valid/invalid measurements, all-invalid group, and /report API endpoint resilience
- All 206 tests pass
- Issues #218 and #219 were already fixed in commit 586dac1

## Changes
- `calibrator/reports.py`: `stats()` now filters `None` delta_e values and returns `invalid_count`; `white_balance` and `color_tuner` include `invalid_count`
- `tests/test_server_api.py`: `TestReportPayloadInvalidMeasurements` class with 3 tests

Closes #217