### PR TITLE
Fix MCP memory server for Ollama + mem0 v2

### DIFF
--- a/mcp_server.py
+++ b/mcp_server.py
@@ -9,17 +9,19 @@ from mem0 import Memory
 
 mem0_config = {
     "llm": {
-        "provider": "ollama",
+        "provider": "openai",
         "config": {
             "model": "qwen/qwen3.6-35b-a3b",
-            "ollama_base_url": "http://localhost:11434",
+            "openai_base_url": "http://localhost:11434/v1",
+            "api_key": "ollama",
         }
     },
     "embedder": {
-        "provider": "ollama",
+        "provider": "openai",
         "config": {
             "model": "nomic-embed-text",
-            "ollama_base_url": "http://localhost:11434",
+            "openai_base_url": "http://localhost:11434/v1",
+            "api_key": "ollama",
         }
     },
     "vector_store": {

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -18,7 +18,7 @@ mem0_config = {
     "embedder": {
         "provider": "ollama",
         "config": {
-            "model": "text-embedding-nomic-embed-text-v1.5",
+            "model": "nomic-embed-text",
             "ollama_base_url": "http://localhost:11434",
         }
     },
@@ -40,21 +40,30 @@ def save_memory(content: str, user_id: str = "jweber") -> str:
     result = memory.add(content, user_id=user_id)
     return f"Saved: {result}"
 
+def _extract_results(results) -> list:
+    if isinstance(results, dict):
+        return results.get("results", [])
+    if isinstance(results, list):
+        return results
+    return []
+
 @mcp.tool()
 def search_memory(query: str, user_id: str = "jweber", limit: int = 5) -> str:
     """Search persistent memory for relevant context."""
     results = memory.search(query, user_id=user_id, limit=limit)
-    if not results:
+    items = _extract_results(results)
+    if not items:
         return "No relevant memories found."
-    return "\n\n".join([f"- {r['memory']}" for r in results.get("results", [])])
+    return "\n\n".join([f"- {r['memory']}" for r in items])
 
 @mcp.tool()
 def list_memories(user_id: str = "jweber") -> str:
     """List all stored memories."""
     results = memory.get_all(user_id=user_id)
-    if not results:
+    items = _extract_results(results)
+    if not items:
         return "No memories stored yet."
-    return "\n\n".join([f"- {r['memory']}" for r in results.get("results", [])])
+    return "\n\n".join([f"- {r['memory']}" for r in items])
 
 @mcp.tool()
 def delete_memory(memory_id: str) -> str:

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -36,23 +36,23 @@ mem0_config = {
 memory = Memory.from_config(mem0_config)
 mcp = FastMCP("opencode-mem")
 
+def _extract_results(results) -> list:
+    if isinstance(results, list):
+        return results
+    if isinstance(results, dict):
+        return results.get("results", [])
+    return []
+
 @mcp.tool()
 def save_memory(content: str, user_id: str = "jweber") -> str:
     """Save something to persistent memory."""
-    result = memory.add(content, user_id=user_id)
+    result = memory.add(content, filters={"user_id": user_id})
     return f"Saved: {result}"
-
-def _extract_results(results) -> list:
-    if isinstance(results, dict):
-        return results.get("results", [])
-    if isinstance(results, list):
-        return results
-    return []
 
 @mcp.tool()
 def search_memory(query: str, user_id: str = "jweber", limit: int = 5) -> str:
     """Search persistent memory for relevant context."""
-    results = memory.search(query, user_id=user_id, limit=limit)
+    results = memory.search(query, filters={"user_id": user_id}, limit=limit)
     items = _extract_results(results)
     if not items:
         return "No relevant memories found."
@@ -61,7 +61,7 @@ def search_memory(query: str, user_id: str = "jweber", limit: int = 5) -> str:
 @mcp.tool()
 def list_memories(user_id: str = "jweber") -> str:
     """List all stored memories."""
-    results = memory.get_all(user_id=user_id)
+    results = memory.get_all(filters={"user_id": user_id})
     items = _extract_results(results)
     if not items:
         return "No memories stored yet."


### PR DESCRIPTION
Fixes to get the mem0 MCP server working with Ollama and mem0 v2.

## Changes
- Switch from `ollama` provider to `openai` provider pointing at Ollama's OpenAI-compatible endpoint (`localhost:11434/v1`) — avoids mem0's broken `_ensure_model_exists` auto-pull on startup
- Fix embedder model name: `text-embedding-nomic-embed-text-v1.5` → `nomic-embed-text` (Ollama's name)
- Fix mem0 v2 API: `user_id` param replaced with `filters={"user_id": ...}` on `add`, `search`, and `get_all`
- Make result parsing robust for both list and dict returns across mem0 versions

https://claude.ai/code/session_01QuL74USABxM1iem7u9eNy5