### PR TITLE
chore: add .ruff_cache/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 __pycache__/
 .pytest_cache/
+.ruff_cache/
 *.py[cod]
 .sessions/
 .calibration-history/


### PR DESCRIPTION
## Summary
- Add `.ruff_cache/` to `.gitignore` alongside other cache directories (`__pycache__/`, `.pytest_cache/`)
- Prevents ruff's cache directory from being tracked in the repository