### PR TITLE
strip credentials from LLM endpoint URLs before logging

### DIFF
--- a/server.py
+++ b/server.py
@@ -22,6 +22,7 @@ from contextlib import asynccontextmanager, suppress as context_suppress
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
+from urllib.parse import urlparse
 
 import httpx
 
@@ -707,11 +708,13 @@ def _run_llm_background(
     session_step_history: Optional[List[Dict[str, Any]]] = None,
     tv_settings: Optional[TVSettings] = None,
 ) -> None:
+    _parsed_ep = urlparse(llm_cfg.endpoint)
+    _safe_endpoint = f"{_parsed_ep.scheme}://{_parsed_ep.hostname or ''}{_parsed_ep.path}"
     logger.info(
         "LLM run started  sid=%s phase=%s endpoint=%s model=%s",
         sid,
         phase,
-        llm_cfg.endpoint,
+        _safe_endpoint,
         llm_cfg.model,
     )
     _llm_broadcast(
@@ -826,7 +829,11 @@ def _maybe_trigger_llm(sid: str, session: Dict[str, Any]) -> None:
     endpoint = llm_cfg_dict.get("endpoint", "")
     model = llm_cfg_dict.get("model", "")
     if not (endpoint and model):
-        endpoint_repr = endpoint.split("?")[0] if endpoint else ""
+        if endpoint:
+            _rep = urlparse(endpoint)
+            endpoint_repr = f"{_rep.scheme}://{_rep.hostname or ''}{_rep.path}"
+        else:
+            endpoint_repr = ""
         logger.info(
             "LLM skip  sid=%s reason=not_configured endpoint=%r model=%r",
             sid,


### PR DESCRIPTION
Sanitize LLM endpoint URLs before logging to prevent credentials from appearing in plaintext log output.

- Added `from urllib.parse import urlparse` import to server.py
- `_run_llm_background()`: Sanitize `llm_cfg.endpoint` before logging — strips `user:pass@` fragment using urlparse
- `_maybe_trigger_llm()`: Replaced `endpoint.split("?")[0]` with urlparse-based sanitization that also strips credentials

All 136 existing tests pass.

Closes #238