### PR TITLE
perf: replace O(n) guard with try/except in _llm_unsubscribe

### DIFF
--- a/server.py
+++ b/server.py
@@ -638,8 +638,10 @@ def _llm_subscribe(sid: str) -> "queue.Queue[Dict[str, Any]]":
 def _llm_unsubscribe(sid: str, q: "queue.Queue[Dict[str, Any]]") -> None:
     with _llm_queues_lock:
         listeners = _llm_queues.get(sid, [])
-        if q in listeners:
+        try:
             listeners.remove(q)
+        except ValueError:
+            pass
         if not listeners:
             _llm_queues.pop(sid, None)
 


### PR DESCRIPTION
## Summary

- Replace two O(n) list operations (`if q in listeners` + `listeners.remove(q)`) with a single `try/except ValueError` pass
- Reduces `_llm_unsubscribe` from two linear scans to one, matching the idiomatic Python EAFP pattern
- Behavior is identical: if `q` is not in the list, no error is raised; if the list becomes empty, the `sid` key is removed from `_llm_queues`

Closes #242