### PR TITLE
refactor: extract five-bucket measurement concat into shared helper

### DIFF
--- a/calibrator/utils.py
+++ b/calibrator/utils.py
@@ -88,3 +88,22 @@ def direction_hint(measured_val, target_val, label="") -> str:
     if diff > 0:
         return f"[yellow]↓ Decrease {label}[/yellow]"
     return f"[cyan]↑ Increase {label}[/cyan]"
+
+
+_MEASUREMENT_BUCKETS = (
+    "pre_measurements",
+    "wb_measurements",
+    "gamma_measurements",
+    "cms_measurements",
+    "post_measurements",
+)
+
+
+def get_all_measurements(session: dict) -> list:
+    """Return a flat list of all measurements across every bucket."""
+    result: list = []
+    for key in _MEASUREMENT_BUCKETS:
+        bucket = session.get(key)
+        if bucket:
+            result.extend(bucket)
+    return result

--- a/server.py
+++ b/server.py
@@ -106,6 +106,7 @@ from calibrator.session import (
     validate_peak_luminance as _validate_peak_luminance,
     zro_step_instructions as _zro_step_instructions,
 )
+from calibrator.utils import get_all_measurements as _get_all_measurements
 import calibrator.adb_control as _adb
 
 logger = logging.getLogger(__name__)
@@ -911,13 +912,7 @@ def _maybe_trigger_llm(sid: str, session: Dict[str, Any]) -> None:
         )
         return
 
-    all_measurements = (
-        session.get("pre_measurements", [])
-        + session.get("wb_measurements", [])
-        + session.get("gamma_measurements", [])
-        + session.get("cms_measurements", [])
-        + session.get("post_measurements", [])
-    )
+    all_measurements = _get_all_measurements(session)
     if not all_measurements:
         logger.info("LLM skip  sid=%s reason=no_measurements", sid)
         return
@@ -1191,13 +1186,7 @@ def llm_run(sid: str):
             400, "LLM not configured; POST /api/session/{sid}/llm/configure first."
         )
 
-    all_measurements = (
-        session.get("pre_measurements", [])
-        + session.get("wb_measurements", [])
-        + session.get("gamma_measurements", [])
-        + session.get("cms_measurements", [])
-        + session.get("post_measurements", [])
-    )
+    all_measurements = _get_all_measurements(session)
     if not all_measurements:
         raise HTTPException(
             400, "No measurements in session; import data before running LLM analysis."
@@ -1591,13 +1580,7 @@ def get_suggested_patches(sid: str, budget: int = 30):
 
     session = store.get(sid)
 
-    all_measurements = (
-        session.get("pre_measurements", [])
-        + session.get("wb_measurements", [])
-        + session.get("gamma_measurements", [])
-        + session.get("cms_measurements", [])
-        + session.get("post_measurements", [])
-    )
+    all_measurements = _get_all_measurements(session)
     if not all_measurements:
         raise HTTPException(400, "No measurements in session; import data first.")
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,63 @@
+"""Tests for calibrator/utils.py helpers."""
+
+import pytest
+from calibrator.utils import get_all_measurements
+
+
+class TestGetAllMeasurements:
+    def test_empty_session(self):
+        result = get_all_measurements({})
+        assert result == []
+
+    def test_all_buckets_empty(self):
+        session = {
+            "pre_measurements": [],
+            "wb_measurements": [],
+            "gamma_measurements": [],
+            "cms_measurements": [],
+            "post_measurements": [],
+        }
+        result = get_all_measurements(session)
+        assert result == []
+
+    def test_single_bucket_with_data(self):
+        session = {
+            "pre_measurements": [{"label": "R100"}],
+            "wb_measurements": [],
+            "gamma_measurements": [],
+            "cms_measurements": [],
+            "post_measurements": [],
+        }
+        result = get_all_measurements(session)
+        assert len(result) == 1
+        assert result[0]["label"] == "R100"
+
+    def test_all_buckets_with_data(self):
+        session = {
+            "pre_measurements": [{"label": "p1"}, {"label": "p2"}],
+            "wb_measurements": [{"label": "w1"}],
+            "gamma_measurements": [{"label": "g1"}, {"label": "g2"}, {"label": "g3"}],
+            "cms_measurements": [{"label": "c1"}],
+            "post_measurements": [{"label": "s1"}],
+        }
+        result = get_all_measurements(session)
+        assert len(result) == 8
+        labels = [m["label"] for m in result]
+        assert labels == ["p1", "p2", "w1", "g1", "g2", "g3", "c1", "s1"]
+
+    def test_missing_keys_returns_empty(self):
+        session = {"pre_measurements": [{"label": "x"}]}
+        result = get_all_measurements(session)
+        assert len(result) == 1
+        assert result[0]["label"] == "x"
+
+    def test_none_values_in_buckets(self):
+        session = {
+            "pre_measurements": None,
+            "wb_measurements": [],
+            "gamma_measurements": [],
+            "cms_measurements": [],
+            "post_measurements": [],
+        }
+        result = get_all_measurements(session)
+        assert result == []


### PR DESCRIPTION

## Summary

- Extract the repeated five-bucket concatenation pattern from `server.py` into a shared `get_all_measurements()` helper in `calibrator/utils.py`
- Pattern appeared verbatim at 3 call sites (lines ~914, ~1194, ~1594) — now a single import + function call
- Add unit tests for the new helper covering empty sessions, partial data, missing keys, and None values

## Changes

- `calibrator/utils.py` — add `_MEASUREMENT_BUCKETS` constant and `get_all_measurements()` function
- `server.py` — import helper, replace 3 inline concatenation blocks with `_get_all_measurements(session)`
- `tests/test_utils.py` — new test file with 6 test cases

Closes #239
