### PR TITLE
Add logging to silent except Exception handlers (#235)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import json
 import math
+import logging
 import os
 import time
 from dataclasses import asdict
@@ -23,6 +24,9 @@ from calcore import (
 )
 from calcore.llm import hash_summary, query_delta_summary
 from calcore.models import Summary
+
+
+logger = logging.getLogger(__name__)
 
 
 def format_num(v: Optional[float], digits: int = 3) -> str:
@@ -165,7 +169,8 @@ def load_state(path: Path, default_cfg: AnalysisConfig) -> SessionState:
             ),
             llm=LLMConfig.from_dict(llm_raw, default_timeout=120.0),
         )
-    except Exception:
+    except Exception as exc:
+        logger.warning("Failed to load session state from %s; starting fresh", path, exc_info=True)
         return SessionState(config=default_cfg)
 
 

--- a/server.py
+++ b/server.py
@@ -390,6 +390,7 @@ def _load_prefs() -> None:
     try:
         saved = json.loads(_PREFS_PATH.read_text(encoding="utf-8"))
     except Exception:
+        logger.warning("Failed to parse .prefs.json; using defaults", exc_info=True)
         return
     for key in ("dogegen", "bridge_url", "watch_folder", "llm", "session_defaults"):
         if key in saved:
@@ -813,6 +814,7 @@ def _run_llm_background(
                 if hist:
                     history_block = _build_history_block(hist, baseline)
             except Exception:
+                logger.warning("Failed to load LLM history for tv_key=%s", tv_key, exc_info=True)
                 pass  # history is advisory; never block the main LLM call
 
         # Inject TV settings schema when the TV model is known (#99)
@@ -966,16 +968,19 @@ def create_session(req: CreateSessionReq):
         try:
             session = store.set_signal_range(sid, sd["signal_range"])
         except Exception:
+            logger.warning("Failed to apply default signal_range for sid=%s", sid, exc_info=True)
             pass
     if sd.get("code_scale"):
         try:
             session = store.set_code_scale(sid, sd["code_scale"])
         except Exception:
+            logger.warning("Failed to apply default code_scale for sid=%s", sid, exc_info=True)
             pass
     if sd.get("pattern_generator"):
         try:
             session = store.set_pattern_generator(sid, sd["pattern_generator"])
         except Exception:
+            logger.warning("Failed to apply default pattern_generator for sid=%s", sid, exc_info=True)
             pass
     llm = _prefs.get("llm", {})
     if llm.get("endpoint") or llm.get("model"):
@@ -1416,6 +1421,7 @@ def get_report(sid: str):
             session["_history_recorded"] = True
             store.save_session(sid)
         except Exception:
+            logger.warning("Failed to record calibration history for sid=%s", sid, exc_info=True)
             pass  # history recording is non-critical
     return report
 


### PR DESCRIPTION
## Summary

- Replaced 7 `except Exception: pass` blocks with `logger.warning(..., exc_info=True)` so swallowed errors are visible in logs
- Added `logging` import and logger to `cli.py` (was missing entirely)
- 6 changes in `server.py`, 1 change in `cli.py`

## Affected Handlers

| File | Handler | What's now logged |
|------|---------|-------------------|
| `server.py` | `_load_prefs()` | `.prefs.json` parse failure → use defaults |
| `server.py` | `_run_llm_background()` | LLM history load failure for tv_key |
| `server.py` | `create_session()` | Failed default: signal_range, code_scale, pattern_generator |
| `server.py` | `get_report()` | History recording failure for sid |
| `cli.py` | `load_state()` | Session state deserialization failure → start fresh |

## Testing

- All existing tests pass (`pytest`, 76.86% coverage)
- No behavioral change — additive logging only

Closes #235