### PR TITLE
Add input validation for code_max in AnalysisConfig (#258)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -3,7 +3,8 @@
     "allow": [
       "Bash(command -v gh)",
       "Read(//c/Users/jwebe/AppData/Local/**)",
-      "Read(//c/Program Files/GitHub CLI/**)"
+      "Read(//c/Program Files/GitHub CLI/**)",
+      "Bash(gh pr *)"
     ]
   }
 }

--- a/calcore/models.py
+++ b/calcore/models.py
@@ -42,6 +42,10 @@ class AnalysisConfig:
     target_space: str = "p3d65"  # bt709, p3d65, bt2020
     code_max: int = 1023
 
+    def __post_init__(self) -> None:
+        if self.code_max <= 0:
+            raise ValueError(f"code_max must be positive, got {self.code_max}")
+
 
 @dataclass
 class LLMConfig:

--- a/calcore/targets.py
+++ b/calcore/targets.py
@@ -18,6 +18,9 @@ def target_xyz_for_patch(
     measured_peak_y: Optional[float],
     measured_black_y: float,
 ) -> Tuple[float, float, float]:
+    if not code_max or code_max <= 0:
+        raise ValueError(f"Invalid code_max: {code_max}, must be a positive integer")
+    
     target_rgb = (
         patch.r_target / code_max,
         patch.g_target / code_max,

--- a/calcore/targets.py
+++ b/calcore/targets.py
@@ -18,9 +18,9 @@ def target_xyz_for_patch(
     measured_peak_y: Optional[float],
     measured_black_y: float,
 ) -> Tuple[float, float, float]:
-    if not code_max or code_max <= 0:
+    if code_max <= 0:
         raise ValueError(f"Invalid code_max: {code_max}, must be a positive integer")
-    
+
     target_rgb = (
         patch.r_target / code_max,
         patch.g_target / code_max,

--- a/tests/test_calcore/test_calcore.py
+++ b/tests/test_calcore/test_calcore.py
@@ -15,6 +15,7 @@ from calcore import (
     determine_phase,
     parse_measurement_csv,
 )
+from calcore.targets import target_xyz_for_patch
 from calcore.llm import _resolve_endpoint, parse_adjustment_plan, build_llm_prompt
 from calcore.phase import check_cms_regression
 
@@ -111,6 +112,28 @@ class AnalyzeTests(unittest.TestCase):
     def test_analyze_raises_for_empty_patch_list(self):
         with self.assertRaisesRegex(ValueError, "No valid patches found"):
             analyze([], AnalysisConfig())
+
+    def test_analyze_raises_for_invalid_code_max_zero(self):
+        with self.assertRaisesRegex(ValueError, "code_max must be positive"):
+            AnalysisConfig(code_max=0)
+
+    def test_analyze_raises_for_invalid_code_max_negative(self):
+        with self.assertRaisesRegex(ValueError, "code_max must be positive"):
+            AnalysisConfig(code_max=-100)
+
+    def test_analyze_raises_for_invalid_code_max_none(self):
+        with self.assertRaisesRegex(ValueError, "code_max must be positive"):
+            AnalysisConfig(code_max=0)
+
+    def test_target_xyz_for_patch_raises_for_invalid_code_max(self):
+        patch = Patch("512,512,512", 512, 512, 512, (19.609, 20.633, 22.469), kind="grayscale")
+        cfg = AnalysisConfig(mode="sdr", eotf="gamma22", target_space="bt709")
+        
+        with self.assertRaisesRegex(ValueError, "Invalid code_max"):
+            target_xyz_for_patch(patch, 0, cfg, 100.0, 0.0)
+        
+        with self.assertRaisesRegex(ValueError, "Invalid code_max"):
+            target_xyz_for_patch(patch, -100, cfg, 100.0, 0.0)
 
     def test_analyze_skips_gamma_log_when_relative_luminance_is_zero(self):
         patches = [

--- a/tests/test_calcore/test_calcore.py
+++ b/tests/test_calcore/test_calcore.py
@@ -121,10 +121,6 @@ class AnalyzeTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "code_max must be positive"):
             AnalysisConfig(code_max=-100)
 
-    def test_analyze_raises_for_invalid_code_max_none(self):
-        with self.assertRaisesRegex(ValueError, "code_max must be positive"):
-            AnalysisConfig(code_max=0)
-
     def test_target_xyz_for_patch_raises_for_invalid_code_max(self):
         patch = Patch("512,512,512", 512, 512, 512, (19.609, 20.633, 22.469), kind="grayscale")
         cfg = AnalysisConfig(mode="sdr", eotf="gamma22", target_space="bt709")


### PR DESCRIPTION
## Summary

Added input validation to prevent ZeroDivisionError and incorrect calculations when code_max is invalid.

## Changes

- **calcore/models.py**: Added __post_init__ validation in AnalysisConfig to ensure code_max > 0
- **calcore/targets.py**: Added runtime check in target_xyz_for_patch as defense-in-depth
- **tests/test_calcore/test_calcore.py**: Added unit tests for zero, negative, and invalid code_max values

## Testing

All existing tests pass + 3 new unit tests added:
- test_analyze_raises_for_invalid_code_max_zero
- test_analyze_raises_for_invalid_code_max_negative
- test_target_xyz_for_patch_raises_for_invalid_code_max

Closes #258