### PR TITLE
Bug fixes: CCT float comparison, CMS gate crash, watcher test

### DIFF
--- a/calcore/models.py
+++ b/calcore/models.py
@@ -195,7 +195,9 @@ class Measurement:
     def cct(self) -> Optional[float]:
         if self.Y <= 0 or (self.x == 0.0 and self.y == 0.0):
             return None
-        n = (self.x - 0.3320) / (0.1858 - self.y) if self.y != 0.1858 else 0
+        if math.isclose(self.y, 0.1858, rel_tol=1e-9):
+            return None
+        n = (self.x - 0.3320) / (0.1858 - self.y)
         return 449 * n**3 + 3525 * n**2 + 6823.3 * n + 5520.33
 
     @property

--- a/calibrator/quality.py
+++ b/calibrator/quality.py
@@ -103,17 +103,22 @@ def step_quality(session: Dict[str, Any], tv: Optional[TVProfile]) -> Dict[str, 
                 latest_per_colour[colour] = measurement
         if latest_per_colour:
             de_map = {c: m_to_dict(m, target, signal_range, code_scale)["delta_e"] for c, m in latest_per_colour.items()}
-            worst_de = max(de_map.values())
-            worst_colour = max(de_map, key=de_map.__getitem__)
-            all_present = expected_colours == set(de_map)
-            gates["color_tuner"] = {
-                "passed": all_present and worst_de < QG_CMS_DE_THRESHOLD,
-                "score": round(worst_de, 2),
-                "threshold": QG_CMS_DE_THRESHOLD,
-                "unit": "ΔE",
-                "label": f"All ΔE < {QG_CMS_DE_THRESHOLD:.1f}",
-                "detail": f"Worst: {worst_colour} ΔE {worst_de:.2f}" + ("" if all_present else f" ({len(de_map)}/{len(expected_colours)} colors)"),
-            }
+            # Drop colours whose latest reading was invalid (ΔE is None) before
+            # aggregating; comparing None against floats raises TypeError in
+            # max() and would 500 the whole session view (cf. WB gate above).
+            valid_de_map = {c: de for c, de in de_map.items() if de is not None}
+            if valid_de_map:
+                worst_de = max(valid_de_map.values())
+                worst_colour = max(valid_de_map, key=valid_de_map.__getitem__)
+                all_present = expected_colours == set(valid_de_map)
+                gates["color_tuner"] = {
+                    "passed": all_present and worst_de < QG_CMS_DE_THRESHOLD,
+                    "score": round(worst_de, 2),
+                    "threshold": QG_CMS_DE_THRESHOLD,
+                    "unit": "ΔE",
+                    "label": f"All ΔE < {QG_CMS_DE_THRESHOLD:.1f}",
+                    "detail": f"Worst: {worst_colour} ΔE {worst_de:.2f}" + ("" if all_present else f" ({len(valid_de_map)}/{len(expected_colours)} colors)"),
+                }
 
     for phase, key in (("pre_grayscale", "pre_measurements"), ("post_grayscale", "post_measurements")):
         measurements = session.get(key, [])

--- a/tests/test_colour_science.py
+++ b/tests/test_colour_science.py
@@ -268,3 +268,70 @@ class TestDeltaUv:
         for x, y in [(0.3127, 0.3290), (0.3200, 0.3300), (0.2800, 0.2900)]:
             m = Measurement(x=x, y=y)
             assert abs(m.delta_uv) < 0.05
+
+
+# ---------------------------------------------------------------------------
+# Measurement.cct (Correlated Color Temperature)
+# ---------------------------------------------------------------------------
+
+class TestCCT:
+    def test_normal_cct_calculation(self):
+        """D65 should give a CCT around 6500K."""
+        m = Measurement(x=0.3127, y=0.3290, Y=100.0)
+        assert m.cct is not None
+        assert 6400 < m.cct < 6700
+
+    def test_zero_luminance_returns_none(self):
+        m = Measurement(x=0.3127, y=0.3290, Y=0.0)
+        assert m.cct is None
+
+    def test_zero_chromaticity_returns_none(self):
+        m = Measurement(x=0.0, y=0.0, Y=100.0)
+        assert m.cct is None
+
+    def test_y_near_boundary_returns_none(self):
+        """y values extremely close to 0.1858 should return None to avoid division issues."""
+        m = Measurement(x=0.32, y=0.1858, Y=100.0)
+        assert m.cct is None
+
+    def test_y_slightly_below_boundary(self):
+        """y = 0.1857 should be safe and return a valid CCT."""
+        m = Measurement(x=0.32, y=0.1857, Y=100.0)
+        assert m.cct is not None
+
+    def test_y_slightly_above_boundary(self):
+        """y = 0.1859 should be safe and return a valid CCT."""
+        m = Measurement(x=0.32, y=0.1859, Y=100.0)
+        assert m.cct is not None
+
+    def test_ieee754_precision_edge_case(self):
+        """Test values that could arise from IEEE 754 floating-point arithmetic.
+
+        A value computed as 0.1858 in code might actually be:
+        - 0.18579999999999997 (slightly below)
+        - 0.18580000000000002 (slightly above)
+
+        Both should be handled gracefully by math.isclose().
+        """
+        # Simulate floating-point representation error
+        y_below = 0.18579999999999997
+        y_above = 0.18580000000000002
+
+        m_below = Measurement(x=0.32, y=y_below, Y=100.0)
+        m_above = Measurement(x=0.32, y=y_above, Y=100.0)
+
+        # Both should return None since they're within tolerance of 0.1858
+        assert m_below.cct is None
+        assert m_above.cct is None
+
+    def test_cct_stability_across_range(self):
+        """CCT should produce stable values for typical white points."""
+        test_cases = [
+            (0.3127, 0.3290),  # D65
+            (0.345, 0.359),    # warmer
+            (0.295, 0.315),    # cooler
+        ]
+        for x, y in test_cases:
+            m = Measurement(x=x, y=y, Y=100.0)
+            assert m.cct is not None
+            assert 1000 < m.cct < 25000  # Reasonable CCT range

--- a/tests/test_file_watcher.py
+++ b/tests/test_file_watcher.py
@@ -186,16 +186,25 @@ class TestLifecycle:
             with open(csv_file2, "w") as f:
                 f.write(csv_file_content2)
 
-            # Wait for the watcher to resume and import the new file.
+            # Wait for the watcher to resume and import the new file.  The
+            # pre_grayscale step replaces pre_measurements with the latest ramp
+            # rather than appending, so the list length stays at 1 — the proof
+            # that a second import happened is a second zro_imports entry plus
+            # the new ramp's content replacing the original.
             deadline = time.monotonic() + 3.0
             while time.monotonic() < deadline:
-                if len(session.get("pre_measurements", [])) > 1:
+                if len(session.get("zro_imports", [])) >= 2:
                     break
                 time.sleep(0.1)
 
-            assert len(session["pre_measurements"]) > 1, (
+            assert len(session["zro_imports"]) >= 2, (
                 "Watcher should resume and import after directory is recreated"
             )
+            assert any(
+                (m.get("label") if isinstance(m, dict) else getattr(m, "label", ""))
+                == "White (100%)"
+                for m in session["pre_measurements"]
+            ), "Re-import should replace pre_measurements with the new ramp"
             assert fw._watcher_error is None, (
                 "Error should be cleared once directory reappears"
             )


### PR DESCRIPTION
Bundles several bug fixes found while hardening the calibration core.

## Fixes

### 1. CCT calculation used unsafe exact float equality — Closes #257
`calcore/models.py` guarded the McCamy CCT division with `self.y != 0.1858`, which fails on IEEE-754 precision when `y ≈ 0.1858` and can divide by near-zero. Replaced with `math.isclose(self.y, 0.1858, rel_tol=1e-9)`. Added 8 `TestCCT` cases in `tests/test_colour_science.py` covering the boundary, just-below/just-above, and float-precision edges.

### 2. CMS quality gate crashed the whole session view — Closes #261
The `color_tuner` gate in `calibrator/quality.py` computed `max()` over `m_to_dict(...)["delta_e"]` values, which are `None` for invalid measurements (missing/zero chromaticity, non-finite xyY, non-black patch at 0 nits). `max()` over a float/`None` mix raises `TypeError`, and because `step_quality()` is called unguarded inside `session_view()`, a single bad CMS reading **500s `GET /api/session/{sid}`** and several other endpoints. Now filters out `None` ΔE before aggregating — consistent with the WB and gamma gates — so an invalid colour counts as not-present instead of crashing.

### 3. Watcher resilience test asserted an impossible invariant — Closes #263
`test_polling_survives_transient_missing_dir` asserted `len(pre_measurements) > 1` to prove the watcher resumed after the watched dir vanished and was recreated. But the `pre_grayscale` step **replaces** `pre_measurements` with the latest ramp rather than appending, so the length stays at 1 and the assertion can never pass. The test is skipped whenever `watchdog` is installed, so CI never caught the deterministic failure in the polling fallback. Rewritten to assert the invariants that actually prove a second import (a second `zro_imports` entry + the new ramp replacing the old).

## Not included here
- #262 (`merge_into_session` global cross-bucket dedup empties `wb`/`gamma` buckets) is filed separately — fixing it requires a semantics decision and conflicts with an intentional test (`TestCrossBucketDedup`), so it's left out of this PR.

## Testing
Full suite green: **985 passed**.