### PR TITLE
fix: Add threading.RLock to SessionStore for thread-safe session access (#255)

### DIFF
--- a/calibrator/session.py
+++ b/calibrator/session.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import math
+import threading
 import uuid
 from dataclasses import asdict, replace as dc_replace
 from datetime import datetime, timedelta, timezone
@@ -1602,6 +1603,7 @@ class SessionStore:
         watched_session_id_getter: Callable[[], Optional[str]],
     ) -> None:
         self.sessions: Dict[str, Dict[str, Any]] = {}
+        self._lock = threading.RLock()
         self._session_dir_getter = session_dir_getter
         self._ttl_getter = ttl_getter
         self._watched_session_id_getter = watched_session_id_getter
@@ -1648,72 +1650,78 @@ class SessionStore:
         self, *, current_time: Optional[datetime] = None
     ) -> List[str]:
         active_time = current_time or now()
-        expired_ids = [
-            sid
-            for sid, session in list(self.sessions.items())
-            if self.is_session_expired(session, current_time=active_time)
-        ]
-        for sid in expired_ids:
-            self.sessions.pop(sid, None)
-            self.delete_session_persisted_file(sid)
-        return expired_ids
+        with self._lock:
+            expired_ids = [
+                sid
+                for sid, session in list(self.sessions.items())
+                if self.is_session_expired(session, current_time=active_time)
+            ]
+            for sid in expired_ids:
+                self.sessions.pop(sid, None)
+                self.delete_session_persisted_file(sid)
+            return expired_ids
 
     def save_session(self, sid: str) -> None:
-        if sid not in self.sessions:
-            return
-        try:
-            self.session_dir.mkdir(exist_ok=True)
-            self.touch_session(self.sessions[sid])
-            path = self.session_dir / f"{sid}.json"
-            path.write_text(json.dumps(serialize_session(self.sessions[sid]), indent=2))
-        except Exception:
-            logger.exception("Failed to save session %s to disk", sid)
+        with self._lock:
+            if sid not in self.sessions:
+                return
+            try:
+                self.session_dir.mkdir(exist_ok=True)
+                self.touch_session(self.sessions[sid])
+                path = self.session_dir / f"{sid}.json"
+                path.write_text(json.dumps(serialize_session(self.sessions[sid]), indent=2))
+            except Exception:
+                logger.exception("Failed to save session %s to disk", sid)
 
     def load_sessions(self) -> None:
         if not self.session_dir.exists():
             return
-        for path in self.session_dir.glob("*.json"):
-            try:
-                data = json.loads(path.read_text())
-                sid = data.get("id", path.stem)
-                if sid not in self.sessions and data.get("tv_key") in TV_PROFILES:
-                    session = deserialize_session(data)
-                    if self.is_session_expired(session):
-                        self.delete_session_persisted_file(sid)
-                        continue
-                    self.sessions[sid] = session
-            except Exception:
-                logger.warning(
-                    "Could not load session from %s — file may be corrupt", path
-                )
+        with self._lock:
+            for path in self.session_dir.glob("*.json"):
+                try:
+                    data = json.loads(path.read_text())
+                    sid = data.get("id", path.stem)
+                    if sid not in self.sessions and data.get("tv_key") in TV_PROFILES:
+                        session = deserialize_session(data)
+                        if self.is_session_expired(session):
+                            self.delete_session_persisted_file(sid)
+                            continue
+                        self.sessions[sid] = session
+                except Exception:
+                    logger.warning(
+                        "Could not load session from %s — file may be corrupt", path
+                    )
 
     def get(self, sid: str) -> Dict[str, Any]:
-        self.evict_expired_sessions()
-        if sid not in self.sessions:
-            raise HTTPException(404, "Session not found")
-        session = self.sessions[sid]
-        self.touch_session(session)
-        return session
+        with self._lock:
+            self.evict_expired_sessions()
+            if sid not in self.sessions:
+                raise HTTPException(404, "Session not found")
+            session = self.sessions[sid]
+            self.touch_session(session)
+            return session
 
     def latest_session(self) -> Optional[Dict[str, Any]]:
-        self.evict_expired_sessions()
-        if not self.sessions:
-            return None
-        return max(
-            self.sessions.values(),
-            key=lambda s: s.get("last_accessed_at", s.get("created_at", "")),
-        )
+        with self._lock:
+            self.evict_expired_sessions()
+            if not self.sessions:
+                return None
+            return max(
+                self.sessions.values(),
+                key=lambda s: s.get("last_accessed_at", s.get("created_at", "")),
+            )
 
     def create_session(
         self, tv_key: str, sdr_peak_nits: Optional[float] = None
     ) -> Dict[str, Any]:
-        self.evict_expired_sessions()
-        if tv_key not in TV_PROFILES:
-            raise HTTPException(400, f"Unknown TV profile: {tv_key}")
-        sid = str(uuid.uuid4())[:8]
-        tv = TV_PROFILES[tv_key]
-        created_at = now().isoformat()
-        self.sessions[sid] = {
+        with self._lock:
+            self.evict_expired_sessions()
+            if tv_key not in TV_PROFILES:
+                raise HTTPException(400, f"Unknown TV profile: {tv_key}")
+            sid = str(uuid.uuid4())[:8]
+            tv = TV_PROFILES[tv_key]
+            created_at = now().isoformat()
+            self.sessions[sid] = {
             "id": sid,
             "tv_key": tv_key,
             "tv_name": tv.name,
@@ -1746,12 +1754,13 @@ class SessionStore:
             },
             "repass_count": 0,
         }
-        return self.sessions[sid]
+            return self.sessions[sid]
 
     def delete(self, sid: str) -> None:
-        self.get(sid)
-        self.sessions.pop(sid, None)
-        self.delete_session_persisted_file(sid)
+        with self._lock:
+            self.get(sid)
+            self.sessions.pop(sid, None)
+            self.delete_session_persisted_file(sid)
 
     def select_mode(
         self, sid: str, mode: str, sdr_peak_nits: Optional[float] = None

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,7 +1,16 @@
-"""Tests for calibrator/session.py deserialization functions."""
+"""Tests for calibrator/session.py deserialization and thread-safety."""
+
+import threading
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
-from calibrator.session import deserialize_session, deserialize_measurement
+from calibrator.session import (
+    SessionStore,
+    deserialize_session,
+    deserialize_measurement,
+)
 
 
 class TestDeserializeMeasurement:
@@ -176,3 +185,117 @@ class TestDeserializeSession:
         sess = deserialize_session(data)
         assert sess["pre_measurements"] == []
         assert sess["wb_measurements"] == []
+
+
+class TestSessionStoreThreadSafety:
+    """Verify that SessionStore serializes concurrent access to self.sessions."""
+
+    @pytest.fixture
+    def store(self, tmp_path):
+        return SessionStore(
+            session_dir_getter=lambda: tmp_path,
+            ttl_getter=lambda: timedelta(days=7),
+            watched_session_id_getter=lambda: None,
+        )
+
+    def test_concurrent_create_and_get(self, store):
+        """create_session and get should not corrupt state under concurrent access."""
+        errors = []
+
+        def create_sessions(n):
+            for _ in range(n):
+                try:
+                    s = store.create_session("u8g")
+                    store.get(s["id"])
+                except Exception as e:
+                    errors.append(e)
+
+        threads = [threading.Thread(target=create_sessions, args=(50,)) for _ in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors, f"Errors during concurrent access: {errors}"
+        # Every session created should be retrievable
+        assert len(store.sessions) == 400
+
+    def test_concurrent_get_and_evict(self, store):
+        """get() calling evict_expired_sessions() must not race with manual eviction."""
+        # Seed with sessions that will expire
+        store.create_session("u8g")
+        store.create_session("u8g")
+
+        barrier = threading.Barrier(2)
+        errors = []
+
+        def getter():
+            try:
+                barrier.wait()
+                for _ in range(100):
+                    for sid in list(store.sessions.keys()):
+                        try:
+                            store.get(sid)
+                        except Exception:
+                            pass  # 404 is fine if evicted
+            except Exception as e:
+                errors.append(e)
+
+        def evictor():
+            try:
+                barrier.wait()
+                for _ in range(100):
+                    store.evict_expired_sessions()
+            except Exception as e:
+                errors.append(e)
+
+        t1 = threading.Thread(target=getter)
+        t2 = threading.Thread(target=evictor)
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+
+        assert not errors, f"Errors during concurrent get/evict: {errors}"
+
+    def test_concurrent_delete_and_get(self, store):
+        """delete() must not race with get() causing dict-modify-during-iteration."""
+        for _ in range(50):
+            store.create_session("u8g")
+
+        sids = list(store.sessions.keys())
+        errors = []
+
+        def deleter():
+            try:
+                for sid in sids[:25]:
+                    store.delete(sid)
+            except Exception as e:
+                errors.append(e)
+
+        def getter():
+            try:
+                for sid in sids[25:]:
+                    try:
+                        store.get(sid)
+                    except Exception:
+                        pass
+            except Exception as e:
+                errors.append(e)
+
+        t1 = threading.Thread(target=deleter)
+        t2 = threading.Thread(target=getter)
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+
+        assert not errors, f"Errors during concurrent delete/get: {errors}"
+        assert len(store.sessions) == 25
+
+    def test_rlock_is_reentrant(self, store):
+        """RLock must allow nested acquisition (e.g. get -> evict_expired_sessions)."""
+        store.create_session("u8g")
+        # get() calls evict_expired_sessions() internally — should not deadlock
+        session = store.get(list(store.sessions.keys())[0])
+        assert session is not None


### PR DESCRIPTION
## Summary
- Adds `threading.RLock` to `SessionStore.__init__`
- Wraps all `self.sessions` reads/writes in `with self._lock:`
- Uses `RLock` (not `Lock`) to support reentrant calls like `get()` -> `evict_expired_sessions()`, `create_session()` -> `evict_expired_sessions()`, `delete()` -> `get()`

## Affected methods
- `evict_expired_sessions()`, `save_session()`, `load_sessions()`, `get()`, `latest_session()`, `create_session()`, `delete()`

## Testing
- Added 4 concurrency tests in `TestSessionStoreThreadSafety`:
  - `test_concurrent_create_and_get` — 8 threads, 50 sessions each
  - `test_concurrent_get_and_evict` — get racing with manual eviction
  - `test_concurrent_delete_and_get` — delete racing with get
  - `test_rlock_is_reentrant` — verifies no deadlock on nested acquisition
- All 59 existing session tests continue to pass

Closes #255