### PR TITLE
fix(session): scope grayscale clear to current step only (#271)

### DIFF
--- a/calibrator/session.py
+++ b/calibrator/session.py
@@ -1112,6 +1112,15 @@ def bucket_map_for_session_step(
     return bucket_map
 
 
+def _gray_bucket_for_step(session_step):
+    """Return the grayscale session bucket that the current step writes to."""
+    if session_step == "pre_grayscale":
+        return "pre_measurements"
+    if session_step == "post_grayscale":
+        return "post_measurements"
+    return None
+
+
 def latest_gamma_pass(
     measurements: List[Measurement],
     levels: Tuple[int, ...] = GAMMA_TRACKING_LEVELS,
@@ -2058,8 +2067,9 @@ class SessionStore:
         bucket_map = bucket_map_for_session_step(result, session.get("step"))
         step_warnings = warnings_for_session_step(result, session.get("step"))
         counts: Dict[str, int] = {}
+        target_gray_bucket = _gray_bucket_for_step(session.get("step"))
         for key, meas_dicts in bucket_map.items():
-            if key in ("pre_measurements", "post_measurements") and meas_dicts:
+            if key == target_gray_bucket and meas_dicts:
                 session[key] = []
             for item in meas_dicts:
                 session[key].append(deserialize_measurement(item))
@@ -2107,8 +2117,9 @@ class SessionStore:
         bucket_map = patches_to_session_buckets(patches, session["target"], session.get("step"))
         step_warnings = []
         counts: Dict[str, int] = {}
+        target_gray_bucket = _gray_bucket_for_step(session.get("step"))
         for key, meas_dicts in bucket_map.items():
-            if key in ("pre_measurements", "post_measurements") and meas_dicts:
+            if key == target_gray_bucket and meas_dicts:
                 session[key] = []
             for item in meas_dicts:
                 session[key].append(deserialize_measurement(item))

--- a/tests/test_zro_import.py
+++ b/tests/test_zro_import.py
@@ -846,3 +846,47 @@ class TestMergeDedupAgainstExistingSession:
         _upload(client, session_id, FULL_CSV)
         session = client.get(f"/api/session/{session_id}").json()
         assert len(session["zro_imports"]) == 2
+
+
+def test_pre_grayscale_import_does_not_clear_post_measurements(self, client, session_id):
+        """Importing on pre_grayscale must not wipe existing post_measurements.
+
+        Regression: issue #271 — import_zro_bytes() unconditionally cleared
+        both pre_measurements and post_measurements whenever any grayscale
+        bucket in the import result was non-empty.  If the user imported
+        post-cal data first (or the session already had it from a prior
+        workflow), importing pre-cal grayscale would blank post_measurements.
+        """
+        # Manually set step to post_grayscale and seed post_measurements
+        _sessions[session_id]["step"] = "post_grayscale"
+        _upload(client, session_id, CLEAN_GRAYSCALE_CSV)
+        session_before = client.get(f"/api/session/{session_id}").json()
+        assert len(session_before["post_measurements"]) == 11
+
+        # Switch back to pre_grayscale and import pre-cal grayscale
+        _sessions[session_id]["step"] = "pre_grayscale"
+        _upload(client, session_id, CLEAN_GRAYSCALE_CSV)
+        session_after = client.get(f"/api/session/{session_id}").json()
+        assert len(session_after["pre_measurements"]) == 11
+        # post_measurements must be untouched
+        assert len(session_after["post_measurements"]) == 11
+
+
+def test_post_grayscale_import_does_not_clear_pre_measurements(self, client, session_id):
+        """Importing on post_grayscale must not wipe existing pre_measurements.
+
+        Symmetric case from issue #271 — the previous test covers pre→post;
+        this one ensures post→pre is also safe.
+        """
+        # Seed pre_measurements (session starts on pre_grayscale)
+        _upload(client, session_id, CLEAN_GRAYSCALE_CSV)
+        session_before = client.get(f"/api/session/{session_id}").json()
+        assert len(session_before["pre_measurements"]) == 11
+
+        # Switch to post_grayscale and import post-cal grayscale
+        _sessions[session_id]["step"] = "post_grayscale"
+        _upload(client, session_id, CLEAN_GRAYSCALE_CSV)
+        session_after = client.get(f"/api/session/{session_id}").json()
+        assert len(session_after["post_measurements"]) == 11
+        # pre_measurements must be untouched
+        assert len(session_after["pre_measurements"]) == 11

--- a/tests/test_zro_import.py
+++ b/tests/test_zro_import.py
@@ -848,7 +848,14 @@ class TestMergeDedupAgainstExistingSession:
         assert len(session["zro_imports"]) == 2
 
 
-def test_pre_grayscale_import_does_not_clear_post_measurements(self, client, session_id):
+# ── Grayscale bucket isolation tests (issue #271) ──────────────────────────
+
+
+class TestGrayscaleBucketIsolation:
+    """Regression tests for issue #271: import must not clear the other
+    step's grayscale bucket."""
+
+    def test_pre_grayscale_import_does_not_clear_post_measurements(self, client, session_id):
         """Importing on pre_grayscale must not wipe existing post_measurements.
 
         Regression: issue #271 — import_zro_bytes() unconditionally cleared
@@ -860,19 +867,16 @@ def test_pre_grayscale_import_does_not_clear_post_measurements(self, client, ses
         # Manually set step to post_grayscale and seed post_measurements
         _sessions[session_id]["step"] = "post_grayscale"
         _upload(client, session_id, CLEAN_GRAYSCALE_CSV)
-        session_before = client.get(f"/api/session/{session_id}").json()
-        assert len(session_before["post_measurements"]) == 11
+        assert len(_sessions[session_id]["post_measurements"]) == 11
 
         # Switch back to pre_grayscale and import pre-cal grayscale
         _sessions[session_id]["step"] = "pre_grayscale"
         _upload(client, session_id, CLEAN_GRAYSCALE_CSV)
-        session_after = client.get(f"/api/session/{session_id}").json()
-        assert len(session_after["pre_measurements"]) == 11
+        assert len(_sessions[session_id]["pre_measurements"]) == 11
         # post_measurements must be untouched
-        assert len(session_after["post_measurements"]) == 11
+        assert len(_sessions[session_id]["post_measurements"]) == 11
 
-
-def test_post_grayscale_import_does_not_clear_pre_measurements(self, client, session_id):
+    def test_post_grayscale_import_does_not_clear_pre_measurements(self, client, session_id):
         """Importing on post_grayscale must not wipe existing pre_measurements.
 
         Symmetric case from issue #271 — the previous test covers pre→post;
@@ -880,13 +884,11 @@ def test_post_grayscale_import_does_not_clear_pre_measurements(self, client, ses
         """
         # Seed pre_measurements (session starts on pre_grayscale)
         _upload(client, session_id, CLEAN_GRAYSCALE_CSV)
-        session_before = client.get(f"/api/session/{session_id}").json()
-        assert len(session_before["pre_measurements"]) == 11
+        assert len(_sessions[session_id]["pre_measurements"]) == 11
 
         # Switch to post_grayscale and import post-cal grayscale
         _sessions[session_id]["step"] = "post_grayscale"
         _upload(client, session_id, CLEAN_GRAYSCALE_CSV)
-        session_after = client.get(f"/api/session/{session_id}").json()
-        assert len(session_after["post_measurements"]) == 11
+        assert len(_sessions[session_id]["post_measurements"]) == 11
         # pre_measurements must be untouched
-        assert len(session_after["pre_measurements"]) == 11
+        assert len(_sessions[session_id]["pre_measurements"]) == 11


### PR DESCRIPTION
## Summary
- `import_zro_bytes()` and `import_generic_bytes()` cleared both `pre_measurements` and `post_measurements` whenever any grayscale bucket was non-empty in the import
- Added `_gray_bucket_for_step()` helper; clearing now targets only the bucket matching the current session step
- Added regression tests for both pre->post and post->pre scenarios

## Test Plan
- [ ] `test_pre_grayscale_import_does_not_clear_post_measurements` passes
- [ ] `test_post_grayscale_import_does_not_clear_pre_measurements` passes
- [ ] Existing `test_zro_import.py` tests continue to pass

Closes #271