### PR TITLE
Add edge-case tests for comparison endpoint + frontend InstrumentPanel refactor (#277)

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -6,7 +6,7 @@
       "runtimeExecutable": "npm",
       "runtimeArgs": ["run", "dev"],
       "cwd": "frontend",
-      "port": 5174,
+      "port": 5173,
       "autoPort": true
     }
   ]

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -182,7 +182,24 @@ export default function App() {
       </header>
 
       {/* Main content */}
-      <AppShell session={session} onJump={sess.jumpToStep}>
+      <AppShell
+        session={session}
+        onJump={sess.jumpToStep}
+        watchStatus={watchStatus}
+        watchDefaultPath={watchDefaultPath}
+        bridgeStatus={bridgeStatus}
+        bridgeUrl={bridgeUrl}
+        dogegenStatus={dogegenStatus}
+        adbStatus={adbStatus}
+        onMeasure={sess.triggerMeasure}
+        onSaveBridgeUrl={sess.saveBridgeUrl}
+        onStartWatch={sess.startWatch}
+        onStopWatch={sess.stopWatch}
+        onUpload={sess.uploadCsv}
+        onSaveDogegenConfig={sess.saveDogegenConfig}
+        onStartDogegen={sess.startDogegen}
+        onStopDogegen={sess.stopDogegen}
+      >
         {showComparison ? (
           <ComparisonPage profiles={profiles} />
         ) : (

--- a/frontend/src/components/AppShell.jsx
+++ b/frontend/src/components/AppShell.jsx
@@ -1,10 +1,20 @@
 import { PhaseRail } from './PhaseRail';
+import { InstrumentPanel } from './InstrumentPanel';
 
 const MEASUREMENT_STEPS = new Set([
   'pre_grayscale', 'luminance', 'white_balance', 'gamma', 'color_tuner', 'post_grayscale',
 ]);
 
-export function AppShell({ session, onJump, children }) {
+export function AppShell({
+  session, onJump, children,
+  watchStatus, watchDefaultPath,
+  bridgeStatus, bridgeUrl,
+  dogegenStatus, adbStatus,
+  onMeasure, onSaveBridgeUrl,
+  onStartWatch, onStopWatch,
+  onUpload,
+  onSaveDogegenConfig, onStartDogegen, onStopDogegen,
+}) {
   const showInstrument = session != null && MEASUREMENT_STEPS.has(session.step);
 
   return (
@@ -17,7 +27,23 @@ export function AppShell({ session, onJump, children }) {
       </main>
       {showInstrument && (
         <aside className="workspace-instrument">
-          {/* InstrumentPanel — issue #4 */}
+          <InstrumentPanel
+            session={session}
+            watchStatus={watchStatus}
+            watchDefaultPath={watchDefaultPath}
+            bridgeStatus={bridgeStatus}
+            bridgeUrl={bridgeUrl}
+            dogegenStatus={dogegenStatus}
+            adbStatus={adbStatus}
+            onMeasure={onMeasure}
+            onSaveBridgeUrl={onSaveBridgeUrl}
+            onStartWatch={onStartWatch}
+            onStopWatch={onStopWatch}
+            onUpload={onUpload}
+            onSaveDogegenConfig={onSaveDogegenConfig}
+            onStartDogegen={onStartDogegen}
+            onStopDogegen={onStopDogegen}
+          />
         </aside>
       )}
     </div>

--- a/frontend/src/components/InstrumentPanel.jsx
+++ b/frontend/src/components/InstrumentPanel.jsx
@@ -1,0 +1,373 @@
+import { useState, useRef, useEffect } from 'react';
+import { fmtDateTime, measurementTimeSummary } from '../utils/fmt';
+import { Button } from './Button';
+
+function StatusDot({ ok, configured }) {
+  return (
+    <span style={{
+      width: 7, height: 7, borderRadius: '50%', flexShrink: 0, display: 'inline-block',
+      background: ok ? 'var(--green)' : configured ? 'var(--ink3)' : 'var(--ink3)',
+      boxShadow: ok ? '0 0 5px var(--green)' : 'none',
+    }} />
+  );
+}
+
+export function InstrumentPanel({
+  session,
+  watchStatus, watchDefaultPath,
+  bridgeStatus, bridgeUrl,
+  dogegenStatus, adbStatus,
+  onMeasure, onSaveBridgeUrl,
+  onStartWatch, onStopWatch,
+  onUpload,
+  onSaveDogegenConfig, onStartDogegen, onStopDogegen,
+}) {
+  const [measureBusy, setMeasureBusy] = useState(false);
+  const [measureMsg, setMeasureMsg] = useState('');
+
+  const [showBridgeUrl, setShowBridgeUrl] = useState(!bridgeUrl);
+  const [bridgeUrlInput, setBridgeUrlInput] = useState(bridgeUrl || '');
+  useEffect(() => { setBridgeUrlInput(bridgeUrl || ''); }, [bridgeUrl]);
+
+  const [showWatchConfigure, setShowWatchConfigure] = useState(false);
+  const [watchPath, setWatchPath] = useState(watchDefaultPath || '');
+  useEffect(() => {
+    if (watchDefaultPath && !watchStatus?.watching) setWatchPath(watchDefaultPath);
+  }, [watchDefaultPath, watchStatus?.watching]);
+
+  const inputRef = useRef(null);
+  const [uploadBusy, setUploadBusy] = useState(false);
+  const [uploadStatus, setUploadStatus] = useState('');
+  const [dragging, setDragging] = useState(false);
+
+  const [showDogegenSettings, setShowDogegenSettings] = useState(false);
+  const [dogegenPath, setDogegenPath] = useState(dogegenStatus?.path || '');
+  const [dogegenResolveHost, setDogegenResolveHost] = useState(dogegenStatus?.resolve_host || '');
+  const [dogegenWindowPct, setDogegenWindowPct] = useState(dogegenStatus?.window_pct || 10);
+  const [dogegenMaxcll, setDogegenMaxcll] = useState(dogegenStatus?.maxcll || 1000);
+  const [dogegenBusy, setDogegenBusy] = useState(false);
+  const [dogegenMsg, setDogegenMsg] = useState('');
+  useEffect(() => {
+    setDogegenPath(dogegenStatus?.path || '');
+    setDogegenResolveHost(dogegenStatus?.resolve_host || '');
+    setDogegenWindowPct(dogegenStatus?.window_pct || 10);
+    setDogegenMaxcll(dogegenStatus?.maxcll || 1000);
+  }, [dogegenStatus?.path, dogegenStatus?.resolve_host, dogegenStatus?.window_pct, dogegenStatus?.maxcll]);
+
+  const bridgeOk = bridgeStatus?.ok;
+  const dogegenSelected = session?.pattern_generator === 'dogegen';
+  const dogegenRunning = dogegenStatus?.running;
+  const dogegenReady = dogegenStatus?.ready;
+  const dogegenBlocked = dogegenSelected && dogegenRunning && !dogegenReady;
+
+  const ws = watchStatus || {};
+  const watchDotCls = ws.watching ? 'dot-active' : ws.error ? 'dot-error' : 'dot-inactive';
+  const lastImport = ws.last_import;
+  const lastImportMeasured = measurementTimeSummary(lastImport?.measurement_start, lastImport?.measurement_end);
+
+  async function handleMeasure() {
+    setMeasureBusy(true);
+    setMeasureMsg('');
+    try {
+      await onMeasure();
+      setMeasureMsg('Triggered');
+    } catch (e) {
+      setMeasureMsg(`Error: ${e.message}`);
+    } finally {
+      setMeasureBusy(false);
+    }
+  }
+
+  async function handleSaveBridgeUrl() {
+    await onSaveBridgeUrl(bridgeUrlInput);
+    setShowBridgeUrl(false);
+  }
+
+  async function handleFile(file) {
+    if (!file) return;
+    setUploadBusy(true);
+    setUploadStatus('Uploading…');
+    try {
+      const result = await onUpload(file);
+      setUploadStatus(`Imported ${result?.total_rows ?? '?'} rows`);
+    } catch (e) {
+      setUploadStatus(`Error: ${e.message}`);
+    } finally {
+      setUploadBusy(false);
+    }
+  }
+
+  async function handleDogegenStart() {
+    setDogegenBusy(true);
+    setDogegenMsg('');
+    try {
+      await onStartDogegen();
+    } catch (e) {
+      setDogegenMsg(`Error: ${e.message}`);
+    } finally {
+      setDogegenBusy(false);
+    }
+  }
+
+  async function handleDogegenStop() {
+    setDogegenBusy(true);
+    setDogegenMsg('');
+    try {
+      await onStopDogegen();
+    } catch (e) {
+      setDogegenMsg(`Error: ${e.message}`);
+    } finally {
+      setDogegenBusy(false);
+    }
+  }
+
+  async function handleDogegenSave() {
+    setDogegenBusy(true);
+    setDogegenMsg('');
+    try {
+      await onSaveDogegenConfig({
+        path: dogegenPath,
+        resolve_host: dogegenResolveHost,
+        window_pct: Number(dogegenWindowPct),
+        maxcll: Number(dogegenMaxcll),
+      });
+      setShowDogegenSettings(false);
+    } catch (e) {
+      setDogegenMsg(`Error: ${e.message}`);
+    } finally {
+      setDogegenBusy(false);
+    }
+  }
+
+  return (
+    <div className="instrument-panel">
+
+      {/* Measure */}
+      <div className="ip-section">
+        <button
+          className="btn btn-primary"
+          style={{ width: '100%', justifyContent: 'center', fontSize: '0.88rem', padding: '10px 0' }}
+          disabled={!bridgeOk || measureBusy || dogegenBlocked}
+          onClick={handleMeasure}
+        >
+          {measureBusy ? <span className="spinner" /> : 'Measure'}
+        </button>
+        {measureMsg && <div className="text-sm muted mt-2">{measureMsg}</div>}
+        {dogegenBlocked && (
+          <div className="text-sm muted mt-2">Waiting for Dogegen to warm up</div>
+        )}
+        {!bridgeOk && !dogegenBlocked && (
+          <div className="text-sm muted mt-2">Bridge offline — configure URL below</div>
+        )}
+      </div>
+
+      {/* Signal Chain */}
+      <div className="ip-section">
+        <div className="ip-label">Signal Chain</div>
+
+        {/* ZRO Bridge */}
+        <div className="ip-chain-row">
+          <StatusDot ok={bridgeOk} configured={bridgeStatus?.configured} />
+          <span className="text-sm" style={{ flex: 1 }}>
+            ZRO Bridge&nbsp;
+            {bridgeOk
+              ? <span className="green">connected</span>
+              : <span className="muted">offline</span>
+            }
+          </span>
+          <button className="btn btn-sm" onClick={() => setShowBridgeUrl(s => !s)}>
+            {showBridgeUrl ? 'Hide' : 'URL'}
+          </button>
+        </div>
+        {showBridgeUrl && (
+          <div className="ip-settings-body">
+            <div className="text-sm muted" style={{ marginBottom: 6 }}>ZRO Bridge URL</div>
+            <div className="bridge-url-row">
+              <input
+                type="text"
+                value={bridgeUrlInput}
+                onChange={e => setBridgeUrlInput(e.target.value)}
+                placeholder="http://localhost:7070"
+              />
+              <Button small onClick={handleSaveBridgeUrl}>Save</Button>
+            </div>
+          </div>
+        )}
+
+        {/* Dogegen */}
+        {dogegenSelected && (
+          <div style={{ marginTop: 10 }}>
+            <div className="ip-chain-row">
+              <StatusDot ok={dogegenRunning} configured={dogegenStatus?.configured} />
+              <span className="text-sm" style={{ flex: 1 }}>
+                Dogegen&nbsp;
+                {dogegenRunning
+                  ? <span className="green">running</span>
+                  : dogegenStatus?.configured
+                    ? <span className="muted">ready</span>
+                    : <span className="muted">not configured</span>
+                }
+              </span>
+              <button className="btn btn-sm" onClick={() => setShowDogegenSettings(s => !s)}>
+                {showDogegenSettings ? 'Hide' : 'Settings'}
+              </button>
+            </div>
+            <div className="ip-chain-row" style={{ marginTop: 6, paddingLeft: 14, gap: 6 }}>
+              <Button small primary={!dogegenRunning} disabled={dogegenBusy} onClick={handleDogegenStart}>
+                {dogegenRunning ? 'Running' : 'Start'}
+              </Button>
+              <Button small disabled={dogegenBusy || !dogegenRunning} onClick={handleDogegenStop}>Stop</Button>
+            </div>
+            {showDogegenSettings && (
+              <div className="ip-settings-body">
+                <div className="text-sm muted" style={{ marginBottom: 4 }}>Executable path</div>
+                <div className="bridge-url-row" style={{ marginBottom: 8 }}>
+                  <input
+                    type="text"
+                    value={dogegenPath}
+                    onChange={e => setDogegenPath(e.target.value)}
+                    placeholder="C:\...\Dogegen.exe"
+                  />
+                </div>
+                <div className="text-sm muted" style={{ marginBottom: 4 }}>Resolve host</div>
+                <div className="bridge-url-row" style={{ marginBottom: 8 }}>
+                  <input
+                    type="text"
+                    value={dogegenResolveHost}
+                    onChange={e => setDogegenResolveHost(e.target.value)}
+                    placeholder="127.0.0.1"
+                  />
+                </div>
+                <div style={{ display: 'flex', gap: 8, alignItems: 'center', marginBottom: 8 }}>
+                  <input
+                    type="number"
+                    min={1} max={100}
+                    value={dogegenWindowPct}
+                    onChange={e => setDogegenWindowPct(Number(e.target.value))}
+                    style={{ width: 60, padding: '4px 6px', background: 'var(--bg)', border: '1px solid var(--line2)', borderRadius: 'var(--radius)', color: 'var(--ink)', fontSize: '0.79rem' }}
+                  />
+                  <span className="text-sm muted">Window %</span>
+                  <input
+                    type="number"
+                    min={1}
+                    value={dogegenMaxcll}
+                    onChange={e => setDogegenMaxcll(Number(e.target.value))}
+                    style={{ width: 80, padding: '4px 6px', background: 'var(--bg)', border: '1px solid var(--line2)', borderRadius: 'var(--radius)', color: 'var(--ink)', fontSize: '0.79rem' }}
+                  />
+                  <span className="text-sm muted">MaxCLL</span>
+                </div>
+                <Button small onClick={handleDogegenSave} disabled={dogegenBusy}>Save</Button>
+              </div>
+            )}
+            {dogegenMsg && <div className="text-sm muted mt-2">{dogegenMsg}</div>}
+          </div>
+        )}
+
+        {/* ADB */}
+        {adbStatus && (
+          <div className="ip-chain-row" style={{ marginTop: 10 }}>
+            <StatusDot ok={adbStatus.connected} configured />
+            <span className="text-sm" style={{ flex: 1 }}>
+              ADB&nbsp;
+              {adbStatus.connected
+                ? <span className="green">connected</span>
+                : <span className="muted">disconnected</span>
+              }
+            </span>
+          </div>
+        )}
+      </div>
+
+      {/* Last Import */}
+      {lastImport && (
+        <div className="ip-section">
+          <div className="ip-label">Last Import</div>
+          <div style={{ fontSize: '0.78rem', fontFamily: 'var(--mono)', color: 'var(--ink)', wordBreak: 'break-all' }}>
+            {lastImport.file || 'auto-import'}
+          </div>
+          <div className="text-sm muted" style={{ marginTop: 3 }}>{fmtDateTime(lastImport.timestamp)}</div>
+          {lastImportMeasured && (
+            <div className="text-sm muted">Measurement: {lastImportMeasured}</div>
+          )}
+        </div>
+      )}
+
+      {/* Watch */}
+      <div className="ip-section">
+        <div className="ip-label">Auto-Watch</div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 7 }}>
+          <span className={`watch-status-dot ${watchDotCls}`} />
+          <span className="text-sm" style={{ flex: 1 }}>
+            {ws.watching
+              ? <span className="green">Watching</span>
+              : ws.error
+                ? <span className="red" style={{ fontSize: '0.78rem' }}>{ws.error}</span>
+                : <span className="muted">Not watching</span>
+            }
+          </span>
+          {ws.watching && (
+            <button className="btn btn-sm" onClick={onStopWatch}>Stop</button>
+          )}
+        </div>
+        {ws.watching && ws.path && (
+          <div className="muted" style={{ fontSize: '0.72rem', fontFamily: 'var(--mono)', marginTop: 4, wordBreak: 'break-all' }}>
+            {ws.path}
+          </div>
+        )}
+        <button
+          style={{ background: 'none', border: 'none', padding: '6px 0 0', cursor: 'pointer', color: 'var(--ink2)', fontFamily: 'inherit', fontSize: '0.78rem', display: 'flex', alignItems: 'center', gap: 4 }}
+          onClick={() => setShowWatchConfigure(o => !o)}
+        >
+          {showWatchConfigure ? '▾' : '▸'} Configure
+        </button>
+        {showWatchConfigure && (
+          <div className="ip-settings-body" style={{ marginTop: 6 }}>
+            <div className="text-sm muted" style={{ marginBottom: 6 }}>
+              Path or folder to watch for ZRO CSV exports
+            </div>
+            <div className="watch-row">
+              <input
+                type="text"
+                value={watchPath}
+                onChange={e => setWatchPath(e.target.value)}
+                placeholder="C:\Users\...\ColourSpaceMeasurementLog.csv"
+              />
+              {ws.watching
+                ? <button className="btn btn-sm" onClick={onStopWatch}>Stop</button>
+                : <button className="btn btn-primary btn-sm" onClick={() => onStartWatch(watchPath)}>Watch</button>
+              }
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Upload */}
+      <div className="ip-section">
+        <div
+          className={`ip-upload ${dragging ? 'drag-over' : ''}`}
+          onClick={() => inputRef.current?.click()}
+          onDragOver={e => { e.preventDefault(); setDragging(true); }}
+          onDragLeave={() => setDragging(false)}
+          onDrop={e => { e.preventDefault(); setDragging(false); handleFile(e.dataTransfer.files[0]); }}
+        >
+          <span>📂</span>
+          <span className="text-sm">Drop CSV or browse</span>
+        </div>
+        <input
+          ref={inputRef}
+          type="file"
+          accept=".csv,.tsv,.txt"
+          style={{ display: 'none' }}
+          onChange={e => handleFile(e.target.files[0])}
+        />
+        {uploadStatus && (
+          <div className="text-sm muted mt-2">
+            {uploadBusy && <span className="spinner" style={{ marginRight: 6 }} />}
+            {uploadStatus}
+          </div>
+        )}
+      </div>
+
+    </div>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -488,6 +488,49 @@ hr.divider { border: none; border-top: 1px solid var(--line); margin: 16px 0; }
   box-shadow: 0 4px 12px rgba(0,0,0,0.4);
 }
 
+/* ── InstrumentPanel (#291) ─────────────────────────────────────────────────── */
+.instrument-panel {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+.ip-section {
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--line);
+}
+.ip-section:last-child { border-bottom: none; }
+.ip-label {
+  font-size: 0.62rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--ink3);
+  margin-bottom: 10px;
+}
+.ip-chain-row { display: flex; align-items: center; gap: 7px; }
+.ip-settings-body {
+  background: var(--panel2);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 10px;
+  margin-top: 8px;
+}
+.ip-upload {
+  border: 1px dashed var(--line2);
+  border-radius: var(--radius);
+  padding: 10px 14px;
+  text-align: center;
+  cursor: pointer;
+  color: var(--ink2);
+  transition: all 0.2s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+}
+.ip-upload:hover, .ip-upload.drag-over { border-color: var(--accent); background: var(--accent-dim); color: var(--ink); }
+
 /* ── Card highlight pulse (#42) ─────────────────────────────────────────────── */
 @keyframes cardPulse {
   0%   { box-shadow: 0 0 0 0   rgba(46,199,230,0.55); }

--- a/frontend/src/pages/ColorTuner.jsx
+++ b/frontend/src/pages/ColorTuner.jsx
@@ -1,9 +1,6 @@
 import { Card } from '../components/Card';
 import { Button } from '../components/Button';
 import { MeasurementTable } from '../components/MeasurementTable';
-import { UploadZone } from '../components/UploadZone';
-import { WatchFolder } from '../components/WatchFolder';
-import { BridgeCard } from '../components/BridgeCard';
 import { ZroInstructions } from '../components/ZroInstructions';
 import { fmtDe, dirIcon } from '../utils/fmt';
 import { QualityGate } from '../components/QualityGate';
@@ -71,7 +68,7 @@ function ActionPlanWithAdb({ plan, title, adbStatus, onAdbApply }) {
   );
 }
 
-export function ColorTuner({ session, watchStatus, watchDefaultPath, bridgeStatus, bridgeUrl, dogegenStatus, adbStatus, onUpload, onStartWatch, onStopWatch, onSaveBridgeUrl, onMeasure, onAdbApply, onAdbReset, onAdbDeploy, onRefreshAdb, onNext, onPrev }) {
+export function ColorTuner({ session, adbStatus, onAdbApply, onAdbReset, onAdbDeploy, onRefreshAdb, onNext, onPrev }) {
   const cd = session.cms_data || {};
   const plan = cd.control_plan || [];
   const meas = cd.measurements || [];
@@ -133,19 +130,6 @@ export function ColorTuner({ session, watchStatus, watchDefaultPath, bridgeStatu
           </div>
         </Card>
       </AdbErrorBoundary>
-
-      <Card title="ZRO Bridge" id="bridge-card">
-        <BridgeCard bridgeStatus={bridgeStatus} bridgeUrl={bridgeUrl} session={session} dogegenStatus={dogegenStatus} onSaveUrl={onSaveBridgeUrl} onMeasure={onMeasure} />
-      </Card>
-
-      <div className="two-col">
-        <Card title="Auto-Watch Path" id="watch-folder">
-          <WatchFolder watchStatus={watchStatus} defaultPath={watchStatus.path || watchDefaultPath} onStart={onStartWatch} onStop={onStopWatch} />
-        </Card>
-        <Card title="Import ZRO CSV">
-          <UploadZone onUpload={onUpload} />
-        </Card>
-      </div>
 
       <div className="btn-group">
         <Button onClick={onPrev}>← Back</Button>

--- a/frontend/src/pages/Gamma.jsx
+++ b/frontend/src/pages/Gamma.jsx
@@ -2,14 +2,11 @@ import { Card } from '../components/Card';
 import { Button } from '../components/Button';
 import { ActionPlan } from '../components/ActionPlan';
 import { MeasurementTable } from '../components/MeasurementTable';
-import { UploadZone } from '../components/UploadZone';
-import { WatchFolder } from '../components/WatchFolder';
-import { BridgeCard } from '../components/BridgeCard';
 import { ZroInstructions } from '../components/ZroInstructions';
 import { GammaChart } from '../charts/GammaChart';
 import { QualityGate } from '../components/QualityGate';
 
-export function Gamma({ session, watchStatus, watchDefaultPath, bridgeStatus, bridgeUrl, dogegenStatus, onUpload, onStartWatch, onStopWatch, onSaveBridgeUrl, onMeasure, onSetGammaWorkflow, onNext, onPrev }) {
+export function Gamma({ session, onSetGammaWorkflow, onNext, onPrev }) {
   const gd = session.gamma_data || {};
   const plan      = gd.control_plan || [];
   const meas      = gd.measurements || [];
@@ -58,19 +55,6 @@ export function Gamma({ session, watchStatus, watchDefaultPath, bridgeStatus, br
           </ul>
         </Card>
       )}
-
-      <Card title="ZRO Bridge" id="bridge-card">
-        <BridgeCard bridgeStatus={bridgeStatus} bridgeUrl={bridgeUrl} session={session} dogegenStatus={dogegenStatus} onSaveUrl={onSaveBridgeUrl} onMeasure={onMeasure} />
-      </Card>
-
-      <div className="two-col">
-        <Card title="Auto-Watch Path" id="watch-folder">
-          <WatchFolder watchStatus={watchStatus} defaultPath={watchStatus.path || watchDefaultPath} onStart={onStartWatch} onStop={onStopWatch} />
-        </Card>
-        <Card title="Import ZRO CSV">
-          <UploadZone onUpload={onUpload} />
-        </Card>
-      </div>
 
       <div className="btn-group">
         <Button onClick={onPrev}>← Back</Button>

--- a/frontend/src/pages/Luminance.jsx
+++ b/frontend/src/pages/Luminance.jsx
@@ -2,9 +2,6 @@ import { useState } from 'react';
 import { Card, StatCard } from '../components/Card';
 import { Button } from '../components/Button';
 import { ActionPlan } from '../components/ActionPlan';
-import { UploadZone } from '../components/UploadZone';
-import { WatchFolder } from '../components/WatchFolder';
-import { BridgeCard } from '../components/BridgeCard';
 import { ZroInstructions } from '../components/ZroInstructions';
 import { fmtDateTime, fmtNits } from '../utils/fmt';
 import { QualityGate } from '../components/QualityGate';
@@ -94,7 +91,7 @@ function AdbPictureControls({ adbStatus, onAdbSetPicture, onAdbGetPicture, onDep
   );
 }
 
-export function Luminance({ session, watchStatus, watchDefaultPath, bridgeStatus, bridgeUrl, adbStatus, dogegenStatus, onUpload, onStartWatch, onStopWatch, onSaveBridgeUrl, onMeasure, onAdbSetPicture, onAdbGetPicture, onAdbDeploy, onRefreshAdb, onNext, onPrev }) {
+export function Luminance({ session, adbStatus, onAdbSetPicture, onAdbGetPicture, onAdbDeploy, onRefreshAdb, onNext, onPrev }) {
   const ld = session.luminance_data || {};
   const plan     = ld.control_plan || [];
   const readings = ld.readings || [];
@@ -134,19 +131,6 @@ export function Luminance({ session, watchStatus, watchDefaultPath, bridgeStatus
           />
         </AdbErrorBoundary>
       )}
-
-      <Card title="ZRO Bridge" id="bridge-card">
-        <BridgeCard bridgeStatus={bridgeStatus} bridgeUrl={bridgeUrl} session={session} dogegenStatus={dogegenStatus} onSaveUrl={onSaveBridgeUrl} onMeasure={onMeasure} />
-      </Card>
-
-      <div className="two-col">
-        <Card title="Auto-Watch Path" id="watch-folder">
-          <WatchFolder watchStatus={watchStatus} defaultPath={watchStatus.path || watchDefaultPath} onStart={onStartWatch} onStop={onStopWatch} />
-        </Card>
-        <Card title="Import ZRO CSV">
-          <UploadZone onUpload={onUpload} />
-        </Card>
-      </div>
 
       {readings.length > 0 && (
         <Card title="Luminance History">

--- a/frontend/src/pages/PostGrayscale.jsx
+++ b/frontend/src/pages/PostGrayscale.jsx
@@ -1,14 +1,11 @@
 import { Card } from '../components/Card';
 import { Button } from '../components/Button';
 import { MeasurementTable } from '../components/MeasurementTable';
-import { UploadZone } from '../components/UploadZone';
-import { WatchFolder } from '../components/WatchFolder';
-import { BridgeCard } from '../components/BridgeCard';
 import { ZroInstructions } from '../components/ZroInstructions';
 import { DeChart } from '../charts/DeChart';
 import { QualityGate } from '../components/QualityGate';
 
-export function PostGrayscale({ session, watchStatus, watchDefaultPath, bridgeStatus, bridgeUrl, dogegenStatus, onUpload, onStartWatch, onStopWatch, onSaveBridgeUrl, onMeasure, onNext, onPrev }) {
+export function PostGrayscale({ session, onNext, onPrev }) {
   const gd = session.grayscale_data || {};
   const done  = gd.done || 0;
   const total = gd.total || 11;
@@ -19,18 +16,6 @@ export function PostGrayscale({ session, watchStatus, watchDefaultPath, bridgeSt
     <>
       <ZroInstructions instructions={session.zro_instructions} />
       <QualityGate gate={(session.quality_gates || {}).post_grayscale} />
-
-      <Card title="ZRO Bridge" id="bridge-card">
-        <BridgeCard bridgeStatus={bridgeStatus} bridgeUrl={bridgeUrl} session={session} dogegenStatus={dogegenStatus} onSaveUrl={onSaveBridgeUrl} onMeasure={onMeasure} />
-      </Card>
-
-      <Card title="Auto-Watch Path" id="watch-folder">
-        <WatchFolder watchStatus={watchStatus} defaultPath={watchStatus.path || watchDefaultPath} onStart={onStartWatch} onStop={onStopWatch} />
-      </Card>
-
-      <Card title="Import ZRO CSV">
-        <UploadZone onUpload={onUpload} />
-      </Card>
 
       <Card title="Post-Calibration Grayscale Progress">
         <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 12 }}>

--- a/frontend/src/pages/PreGrayscale.jsx
+++ b/frontend/src/pages/PreGrayscale.jsx
@@ -2,14 +2,10 @@ import { Card } from '../components/Card';
 import { Button } from '../components/Button';
 import { MeasurementTable } from '../components/MeasurementTable';
 import { ImportLog } from '../components/ImportLog';
-import { UploadZone } from '../components/UploadZone';
-import { WatchFolder } from '../components/WatchFolder';
-import { BridgeCard } from '../components/BridgeCard';
-import { DogegenCard } from '../components/DogegenCard';
 import { ZroInstructions } from '../components/ZroInstructions';
 import { DeChart } from '../charts/DeChart';
 
-export function PreGrayscale({ session, watchStatus, watchDefaultPath, bridgeStatus, bridgeUrl, dogegenStatus, onUpload, onStartWatch, onStopWatch, onSaveBridgeUrl, onSaveDogegenConfig, onStartDogegen, onStopDogegen, onMeasure, onNext, onPrev }) {
+export function PreGrayscale({ session, onNext, onPrev }) {
   const gd = session.grayscale_data || {};
   const done  = gd.done || 0;
   const total = gd.total || 11;
@@ -19,37 +15,6 @@ export function PreGrayscale({ session, watchStatus, watchDefaultPath, bridgeSta
   return (
     <>
       <ZroInstructions instructions={session.zro_instructions} />
-
-      <Card title="ZRO Bridge" id="bridge-card">
-        <BridgeCard
-          bridgeStatus={bridgeStatus} bridgeUrl={bridgeUrl}
-          session={session} dogegenStatus={dogegenStatus}
-          onSaveUrl={onSaveBridgeUrl} onMeasure={onMeasure}
-        />
-      </Card>
-
-      {session.pattern_generator === 'dogegen' && (
-        <Card title="Dogegen Companion" id="dogegen-card">
-          <DogegenCard
-            dogegenStatus={dogegenStatus}
-            session={session}
-            onSaveConfig={onSaveDogegenConfig}
-            onStart={onStartDogegen}
-            onStop={onStopDogegen}
-          />
-        </Card>
-      )}
-
-      <Card title="Auto-Watch Path" id="watch-folder">
-        <WatchFolder
-          watchStatus={watchStatus} defaultPath={watchStatus.path || watchDefaultPath}
-          onStart={onStartWatch} onStop={onStopWatch}
-        />
-      </Card>
-
-      <Card title="Import ZRO CSV">
-        <UploadZone onUpload={onUpload} />
-      </Card>
 
       <Card title="Pre-Calibration Grayscale Progress">
         <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 12 }}>

--- a/frontend/src/pages/WhiteBalance.jsx
+++ b/frontend/src/pages/WhiteBalance.jsx
@@ -2,9 +2,6 @@ import { Card, StatCard } from '../components/Card';
 import { Button } from '../components/Button';
 import { ActionPlan } from '../components/ActionPlan';
 import { MeasurementTable } from '../components/MeasurementTable';
-import { UploadZone } from '../components/UploadZone';
-import { WatchFolder } from '../components/WatchFolder';
-import { BridgeCard } from '../components/BridgeCard';
 import { ZroInstructions } from '../components/ZroInstructions';
 import { CIEScatter } from '../charts/CIEScatter';
 import { fmtDe, fmtDateTime } from '../utils/fmt';
@@ -29,7 +26,7 @@ function DeMeasCard({ label, measurement, hasFlag }) {
   );
 }
 
-export function WhiteBalance({ session, watchStatus, watchDefaultPath, bridgeStatus, bridgeUrl, dogegenStatus, onUpload, onStartWatch, onStopWatch, onSaveBridgeUrl, onMeasure, onNext, onPrev }) {
+export function WhiteBalance({ session, onNext, onPrev }) {
   const wd = session.wb_data || {};
   const plan   = wd.control_plan || [];
   const hints  = wd.hints || null;
@@ -71,19 +68,6 @@ export function WhiteBalance({ session, watchStatus, watchDefaultPath, bridgeSta
           </div>
         </Card>
       )}
-
-      <Card title="ZRO Bridge" id="bridge-card">
-        <BridgeCard bridgeStatus={bridgeStatus} bridgeUrl={bridgeUrl} session={session} dogegenStatus={dogegenStatus} onSaveUrl={onSaveBridgeUrl} onMeasure={onMeasure} />
-      </Card>
-
-      <div className="two-col">
-        <Card title="Auto-Watch Path" id="watch-folder">
-          <WatchFolder watchStatus={watchStatus} defaultPath={watchStatus.path || watchDefaultPath} onStart={onStartWatch} onStop={onStopWatch} />
-        </Card>
-        <Card title="Import ZRO CSV">
-          <UploadZone onUpload={onUpload} />
-        </Card>
-      </div>
 
       <Card title="Menu Path">
         <div className="text-sm accent">{wd.menu_path || ''}</div>

--- a/tests/test_delta_report.py
+++ b/tests/test_delta_report.py
@@ -187,6 +187,158 @@ class TestComparisonPayloadSessionIds:
         assert data["session_id_a"] == sid_a
         assert data["session_id_b"] == sid_b
 
+
+# ── Edge-case comparison tests (issue #277) ───────────────────────────────────
+
+class TestComparisonEdgeCases:
+    def test_comparison_session_a_no_pre_cal(self, client):
+        sid_a = _make_session_with_measurements(client)
+        sid_b = _make_session_with_measurements(client)
+        _sessions[sid_a]["pre_measurements"] = []
+
+        result = comparison_payload(_sessions[sid_a], _sessions[sid_b])
+        deltas = result["deltas"]
+
+        assert deltas["pre_cal_avg_de"] is None
+        assert deltas["pre_cal_max_de"] is None
+        assert result["session_a"]["report"]["pre_cal"]["avg_de"] is None
+
+    def test_comparison_session_b_no_post_cal(self, client):
+        sid_a = _make_session_with_measurements(client)
+        sid_b = _make_session_with_measurements(client)
+        _sessions[sid_b]["post_measurements"] = []
+
+        result = comparison_payload(_sessions[sid_a], _sessions[sid_b])
+        deltas = result["deltas"]
+
+        assert deltas["post_cal_avg_de"] is None
+        assert deltas["post_cal_max_de"] is None
+        assert result["session_b"]["report"]["post_cal"]["avg_de"] is None
+
+    def test_comparison_both_sessions_zero_delta_e(self, client):
+        from calibrator.reports import report_payload
+        from calibrator.utils import stimulus_pct_from_code_value
+
+        sid = _make_session_with_measurements(client)
+        sess = _sessions[sid]
+        target = sess["target"]
+        signal_range = sess.get("signal_range", "full")
+
+        perfect_measurements = [
+            Measurement(
+                x=target.white_point_xy[0],
+                y=target.white_point_xy[1],
+                Y=target.peak_luminance_nits * (stimulus_pct_from_code_value(pct * 2, signal_range) / 100.0) ** target.gamma,
+                X=0.0, Z=0.0,
+                label=f"{pct}% Gray",
+                stimulus_rgb=(pct * 2, pct * 2, pct * 2),
+            )
+            for pct in [10, 20, 30, 40, 50, 60, 70, 80, 90, 100]
+        ]
+        sess["pre_measurements"] = perfect_measurements
+        sess["post_measurements"] = perfect_measurements
+
+        report = report_payload(sess)
+        assert report["pre_cal"]["avg_de"] == 0.0
+        assert report["improvement_pct"] is None
+
+        result = comparison_payload(sess, sess)
+        assert result["deltas"]["improvement_pct"] is None
+
+    def test_comparison_one_session_empty_one_complete(self, client):
+        sid_a = _make_session_with_measurements(client)
+        sid_b = _make_session_with_measurements(client)
+        _sessions[sid_a]["pre_measurements"] = []
+        _sessions[sid_a]["post_measurements"] = []
+
+        result = comparison_payload(_sessions[sid_a], _sessions[sid_b])
+        deltas = result["deltas"]
+
+        assert deltas["pre_cal_avg_de"] is None
+        assert deltas["post_cal_avg_de"] is None
+        assert deltas["pre_cal_max_de"] is None
+        assert deltas["post_cal_max_de"] is None
+
+    def test_comparison_only_invalid_measurements(self, client):
+        sid_a = _make_session_with_measurements(client)
+        sid_b = _make_session_with_measurements(client)
+
+        invalid_measurements = [
+            Measurement(
+                x=float("nan"), y=float("nan"),
+                Y=float("nan"),
+                X=float("nan"),
+                Z=float("nan"),
+                label="Invalid",
+                stimulus_rgb=(128, 128, 128),
+            )
+        ]
+        _sessions[sid_a]["pre_measurements"] = invalid_measurements
+        _sessions[sid_a]["post_measurements"] = invalid_measurements
+
+        result = comparison_payload(_sessions[sid_a], _sessions[sid_b])
+        report_a = result["session_a"]["report"]
+
+        assert report_a["pre_cal"]["avg_de"] is None
+        assert report_a["pre_cal"]["invalid_count"] == 1
+        assert report_a["improvement_pct"] is None
+
+
+class TestReportPayloadEdgeCases:
+    def test_report_payload_empty_measurements_no_crash(self, client):
+        from calibrator.reports import report_payload
+        sid = _make_session_with_measurements(client)
+        sess = _sessions[sid]
+        sess["pre_measurements"] = []
+        sess["post_measurements"] = []
+        sess["wb_measurements"] = []
+        sess["gamma_measurements"] = []
+        sess["cms_measurements"] = []
+
+        result = report_payload(sess)
+
+        assert result["pre_cal"]["avg_de"] is None
+        assert result["pre_cal"]["max_de"] is None
+        assert result["pre_cal"]["measurements"] == []
+        assert result["post_cal"]["avg_de"] is None
+        assert result["improvement_pct"] is None
+        assert result["white_balance"]["avg_de"] is None
+        assert result["color_tuner"]["avg_de"] is None
+        assert result["gamma"]["avg_gamma"] is None
+
+    def test_report_payload_pre_zero_post_nonzero_improvement_none(self, client):
+        from calibrator.reports import report_payload
+        from calibrator.utils import stimulus_pct_from_code_value
+
+        sid = _make_session_with_measurements(client)
+        sess = _sessions[sid]
+        target = sess["target"]
+        signal_range = sess.get("signal_range", "full")
+
+        perfect = Measurement(
+            x=target.white_point_xy[0],
+            y=target.white_point_xy[1],
+            Y=target.peak_luminance_nits * (stimulus_pct_from_code_value(100, signal_range) / 100.0) ** target.gamma,
+            X=0.0, Z=0.0,
+            label="50% Gray",
+            stimulus_rgb=(100, 100, 100),
+        )
+        slightly_off = Measurement(
+            x=target.white_point_xy[0] + 0.01,
+            y=target.white_point_xy[1] + 0.01,
+            Y=target.peak_luminance_nits * (stimulus_pct_from_code_value(102, signal_range) / 100.0) ** target.gamma,
+            X=0.0, Z=0.0,
+            label="51% Gray",
+            stimulus_rgb=(102, 102, 102),
+        )
+
+        sess["pre_measurements"] = [perfect]
+        sess["post_measurements"] = [slightly_off]
+
+        result = report_payload(sess)
+        assert result["pre_cal"]["avg_de"] == 0.0
+        assert result["improvement_pct"] is None
+
 # ── GET /api/report/compare ────────────────────────────────────────────────────
 
 class TestCompareEndpoint:

--- a/tests/test_delta_report.py
+++ b/tests/test_delta_report.py
@@ -397,6 +397,19 @@ class TestCompareEndpoint:
         data = resp.json()
         assert data["summary"] is None
 
+    def test_compare_empty_session_returns_200_with_none_deltas(self, client):
+        sid_a = _make_session_with_measurements(client)
+        sid_b = _make_session_with_measurements(client)
+        _sessions[sid_a]["pre_measurements"] = []
+        _sessions[sid_a]["post_measurements"] = []
+
+        resp = client.get(f"/api/report/compare?a={sid_a}&b={sid_b}")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["deltas"]["pre_cal_avg_de"] is None
+        assert data["deltas"]["post_cal_avg_de"] is None
+        assert data["session_a"]["report"]["pre_cal"]["avg_de"] is None
+
 
 # ── GET /api/session/{sid}/suggested-patches ──────────────────────────────────
 


### PR DESCRIPTION
Closes #277

## Summary

Two changes in this branch:

### 1. Edge-case tests for comparison/report payloads (issue #277)

Adds 8 tests to `tests/test_delta_report.py` covering untested scenarios in `calibrator/reports.py`:

**`TestComparisonEdgeCases`:**
- Session A has no pre_cal measurements → delta is `None`
- Session B has no post_cal measurements → delta is `None`
- Both sessions have zero ΔE → improvement is `None` (guards division-by-zero)
- One session empty, one complete → all deltas are `None`
- Session with only invalid (NaN) measurements → stats are `None`, `invalid_count` is correct

**`TestReportPayloadEdgeCases`:**
- Empty measurements across all buckets → all stats are `None`, no crash
- Pre-cal avg_de exactly 0.0 → improvement guard prevents division, returns `None`

**`TestCompareEndpoint` (integration):**
- `GET /api/report/compare` with empty session → 200 with `None` deltas

### 2. Frontend InstrumentPanel refactor (pre-existing on branch)

Extracts BridgeCard, WatchFolder, UploadZone, DogegenCard from 6 page components into a shared `InstrumentPanel` sidebar component. This reduces duplication across PreGrayscale, PostGrayscale, WhiteBalance, Gamma, Luminance, and ColorTuner pages.

Frontend cleanup tracked in #308.

## Verification

All 35 tests pass (`pytest tests/test_delta_report.py`).