### PR TITLE
GuidanceHero: rebuild ActionPlan as hero, unify with ActionPlanWithAdb (#292)

### DIFF
--- a/frontend/src/components/ActionPlan.jsx
+++ b/frontend/src/components/ActionPlan.jsx
@@ -1,22 +1,105 @@
 import { dirClass, dirIcon } from '../utils/fmt';
+import { Button } from './Button';
 
-export function ActionPlan({ plan, title }) {
+export function ActionPlan({ plan, menuPath, adbStatus, onApply }) {
   if (!plan?.length) return null;
+  const ready = adbStatus?.connected && adbStatus?.cms_tool_deployed && !!onApply;
+  const applyableSteps = ready ? plan.filter(s => s.direction !== 'hold' && s.amount) : [];
+  const maxAmount = Math.max(...plan.map(s => s.amount || 0), 1);
+
   return (
     <div className="card mb-0">
-      <div className="card-title">{title}</div>
-      {plan.map((a, i) => (
-        <div className="action-card" key={i}>
-          <div className={`action-icon ${dirClass(a.direction)}`}>{dirIcon(a.direction)}</div>
-          <div className="action-body">
-            <div className="action-summary">
-              {a.summary}
-              {a.priority && <span className={`badge badge-${a.priority}`}>{a.priority}</span>}
-            </div>
-            <div className="action-reason">{a.reason}</div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 16 }}>
+        <div style={{ flex: 1 }}>
+          <div style={{ fontSize: '1rem', fontWeight: 700, color: 'var(--ink)', lineHeight: 1.2 }}>
+            What to Adjust
           </div>
+          {menuPath && (
+            <div style={{ fontSize: '0.73rem', color: 'var(--ink2)', fontFamily: 'var(--mono)', marginTop: 3 }}>
+              {menuPath}
+            </div>
+          )}
         </div>
-      ))}
+        {applyableSteps.length > 0 && (
+          <Button
+            small
+            onClick={() => applyableSteps.forEach(s => onApply(s.control, s.amount, s.direction))}
+          >
+            Apply all
+          </Button>
+        )}
+      </div>
+
+      {plan.map((step, i) => {
+        const isHold = step.direction === 'hold';
+        const canApply = ready && step.amount && !isHold;
+        const pct = step.amount ? Math.min((step.amount / maxAmount) * 100, 100) : 0;
+        const barColor =
+          step.direction === 'up' ? 'var(--green)' :
+          step.direction === 'down' ? 'var(--red)' :
+          'var(--yellow)';
+
+        return (
+          <div
+            key={i}
+            style={{
+              display: 'flex',
+              alignItems: 'flex-start',
+              gap: 14,
+              padding: '12px 0',
+              borderBottom: i < plan.length - 1 ? '1px solid var(--line)' : 'none',
+            }}
+          >
+            <div
+              className={`action-icon ${dirClass(step.direction)}`}
+              style={{ width: 38, height: 38, fontSize: '1.25rem', flexShrink: 0, marginTop: 1 }}
+            >
+              {dirIcon(step.direction)}
+            </div>
+
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 4 }}>
+                {step.control && (
+                  <code style={{ fontFamily: 'var(--mono)', fontSize: '0.82rem', color: 'var(--accent)', fontWeight: 600 }}>
+                    {step.control}
+                  </code>
+                )}
+                {step.priority && (
+                  <span className={`badge badge-${step.priority}`}>{step.priority}</span>
+                )}
+                {canApply && (
+                  <div style={{ marginLeft: 'auto' }}>
+                    <Button small onClick={() => onApply(step.control, step.amount, step.direction)}>
+                      Apply
+                    </Button>
+                  </div>
+                )}
+              </div>
+
+              <div style={{ fontSize: '0.84rem', fontWeight: 500, color: 'var(--ink)', marginBottom: 3 }}>
+                {step.summary}
+              </div>
+
+              {step.reason && (
+                <div className="action-reason" style={{ marginBottom: step.amount != null ? 8 : 0 }}>
+                  {step.reason}
+                </div>
+              )}
+
+              {step.amount != null && (
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                  <div style={{ flex: 1, height: 4, background: 'var(--panel3)', borderRadius: 2, overflow: 'hidden' }}>
+                    <div style={{ width: `${pct}%`, height: '100%', background: barColor, borderRadius: 2 }} />
+                  </div>
+                  <span style={{ fontSize: '0.72rem', color: 'var(--ink2)', fontFamily: 'var(--mono)', minWidth: 20, textAlign: 'right' }}>
+                    {step.amount}
+                  </span>
+                </div>
+              )}
+            </div>
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/frontend/src/components/ActionPlan.jsx
+++ b/frontend/src/components/ActionPlan.jsx
@@ -4,7 +4,7 @@ import { Button } from './Button';
 export function ActionPlan({ plan, menuPath, adbStatus, onApply }) {
   if (!plan?.length) return null;
   const ready = adbStatus?.connected && adbStatus?.cms_tool_deployed && !!onApply;
-  const applyableSteps = ready ? plan.filter(s => s.direction !== 'hold' && s.amount) : [];
+  const applicableSteps = ready ? plan.filter(s => s.direction !== 'hold' && s.amount) : [];
   const maxAmount = Math.max(...plan.map(s => s.amount || 0), 1);
 
   return (
@@ -20,10 +20,10 @@ export function ActionPlan({ plan, menuPath, adbStatus, onApply }) {
             </div>
           )}
         </div>
-        {applyableSteps.length > 0 && (
+        {applicableSteps.length > 0 && (
           <Button
             small
-            onClick={() => applyableSteps.forEach(s => onApply(s.control, s.amount, s.direction))}
+            onClick={() => applicableSteps.forEach(s => onApply(s.control, s.amount, s.direction))}
           >
             Apply all
           </Button>
@@ -53,6 +53,7 @@ export function ActionPlan({ plan, menuPath, adbStatus, onApply }) {
             <div
               className={`action-icon ${dirClass(step.direction)}`}
               style={{ width: 38, height: 38, fontSize: '1.25rem', flexShrink: 0, marginTop: 1 }}
+              aria-label={step.direction === 'up' ? 'increase' : step.direction === 'down' ? 'decrease' : step.direction === 'hold' ? 'hold' : 'ok'}
             >
               {dirIcon(step.direction)}
             </div>

--- a/frontend/src/pages/ColorTuner.jsx
+++ b/frontend/src/pages/ColorTuner.jsx
@@ -1,8 +1,9 @@
 import { Card } from '../components/Card';
 import { Button } from '../components/Button';
+import { ActionPlan } from '../components/ActionPlan';
 import { MeasurementTable } from '../components/MeasurementTable';
 import { ZroInstructions } from '../components/ZroInstructions';
-import { fmtDe, dirIcon } from '../utils/fmt';
+import { fmtDe } from '../utils/fmt';
 import { QualityGate } from '../components/QualityGate';
 import { AdbErrorBoundary } from '../components/AdbErrorBoundary';
 
@@ -37,45 +38,12 @@ function AdbStatusPanel({ adbStatus, onDeploy, onRefresh }) {
   );
 }
 
-function ActionPlanWithAdb({ plan, title, adbStatus, onAdbApply }) {
-  if (!plan?.length) return null;
-  const ready = adbStatus?.connected && adbStatus?.cms_tool_deployed;
-
-  return (
-    <Card title={title}>
-      {plan.map((step, i) => {
-        const isHold = step.direction === 'hold';
-        return (
-          <div key={i} style={{ display: 'flex', alignItems: 'flex-start', gap: 10, padding: '8px 0', borderBottom: '1px solid var(--line)' }}>
-            <span style={{ fontSize: '1rem', width: 20, textAlign: 'center', flexShrink: 0 }}>
-              {dirIcon(step.direction)}
-            </span>
-            <div style={{ flex: 1 }}>
-              <div style={{ fontWeight: 600, fontSize: '0.85rem' }}>
-                {step.summary}
-                {!isHold && ready && step.amount && (
-                  <Button small onClick={() => onAdbApply(step.control, step.amount, step.direction)} style={{ marginLeft: 8 }}>
-                    Apply
-                  </Button>
-                )}
-              </div>
-              <div className="muted text-sm">{step.reason || ''}</div>
-            </div>
-          </div>
-        );
-      })}
-    </Card>
-  );
-}
-
 export function ColorTuner({ session, adbStatus, onAdbApply, onAdbReset, onAdbDeploy, onRefreshAdb, onNext, onPrev }) {
   const cd = session.cms_data || {};
   const plan = cd.control_plan || [];
   const meas = cd.measurements || [];
   const lastMeasLabel  = meas.length ? meas[meas.length - 1].label : '';
   const activeColour   = lastMeasLabel.replace(/ 100%$/, '');
-
-  const ready = adbStatus?.connected && adbStatus?.cms_tool_deployed;
 
   return (
     <>
@@ -102,11 +70,11 @@ export function ColorTuner({ session, adbStatus, onAdbApply, onAdbReset, onAdbDe
       </Card>
 
       {cd.latest_hint && (
-        <ActionPlanWithAdb
+        <ActionPlan
           plan={plan}
-          title={`${lastMeasLabel || 'Latest'} — Control Plan (${cd.menu_path || ''})`}
+          menuPath={cd.menu_path}
           adbStatus={adbStatus}
-          onAdbApply={(control, amount, direction) => {
+          onApply={(control, amount, direction) => {
             const delta = direction === 'up' ? amount : -amount;
             onAdbApply(activeColour, control, delta);
           }}

--- a/frontend/src/pages/ColorTuner.jsx
+++ b/frontend/src/pages/ColorTuner.jsx
@@ -91,7 +91,7 @@ export function ColorTuner({ session, adbStatus, onAdbApply, onAdbReset, onAdbDe
         <Card title="Programmatic Control (ADB)">
           <AdbStatusPanel adbStatus={adbStatus} onDeploy={onAdbDeploy} onRefresh={onRefreshAdb} />
           <div style={{ marginTop: 10 }}>
-            <Button small disabled={!ready} onClick={onAdbReset}>
+            <Button small disabled={!(adbStatus?.connected && adbStatus?.cms_tool_deployed)} onClick={onAdbReset}>
               Reset All CMS to 0
             </Button>
             <span className="muted text-sm" style={{ marginLeft: 8 }}>Calls setColorTunerReset() on the TV</span>

--- a/frontend/src/pages/Gamma.jsx
+++ b/frontend/src/pages/Gamma.jsx
@@ -33,7 +33,7 @@ export function Gamma({ session, onSetGammaWorkflow, onNext, onPrev }) {
         </Card>
       )}
 
-      <ActionPlan plan={plan} title={`Gamma Control Plan (${gd.menu_path || ''})`} />
+      <ActionPlan plan={plan} menuPath={gd.menu_path} />
 
       {gd.gamma_note && (
         <Card title="Note">

--- a/frontend/src/pages/Luminance.jsx
+++ b/frontend/src/pages/Luminance.jsx
@@ -118,7 +118,7 @@ export function Luminance({ session, adbStatus, onAdbSetPicture, onAdbGetPicture
         <StatCard value={readings.length} label="Readings" color="accent" />
       </div>
 
-      <ActionPlan plan={plan} title="Backlight Control Plan" />
+      <ActionPlan plan={plan} />
 
       {onAdbSetPicture && (
         <AdbErrorBoundary>

--- a/frontend/src/pages/WhiteBalance.jsx
+++ b/frontend/src/pages/WhiteBalance.jsx
@@ -43,7 +43,7 @@ export function WhiteBalance({ session, onNext, onPrev }) {
         <DeMeasCard label="30% Gray (Offset)" measurement={wd.offset_measurement} hasFlag={wd.has_offset_measurement} />
       </div>
 
-      <ActionPlan plan={plan} title={`WB Control Plan (${wd.menu_path || ''})`} />
+      <ActionPlan plan={plan} menuPath={wd.menu_path} />
 
       {hints && (
         <Card title="White Point Analysis">


### PR DESCRIPTION
## Summary

- **Rebuilds `ActionPlan` as a hero component**: static "What to Adjust" heading + optional `menuPath` in mono, large (38px) direction glyph per row, control name in accent mono, summary text, proportional magnitude bar from `amount`, and inline "Apply" + header-level "Apply all" buttons when ADB is connected and `cms_tool_deployed`
- **Deletes `ActionPlanWithAdb`** from `ColorTuner.jsx` — the unified component now serves WB, Luminance, Gamma, and Color Tuner via optional `adbStatus` + `onApply` props
- **Updates all call sites**: WB, Gamma, and Luminance pass `menuPath` separately instead of embedding it in the old `title` string; Color Tuner wires `onApply` to `onAdbApply(colour, control, delta)` as before

## Behavioral notes

- WB / Luminance / Gamma: no change in runtime behavior — `adbStatus`/`onApply` are not passed so the Apply buttons don't appear and the component renders identically to before (minus the old card-title label)
- Color Tuner: `onApply(colour, control, delta)` call signature preserved; "Apply all" applies every non-hold step with an `amount` in sequence
- `amount` magnitude bar scales relative to the max `amount` in the plan; zero/hold steps show no bar

## Test plan

- [ ] WB page renders "What to Adjust" hero with `menu_path` in mono; no Apply buttons visible (no ADB props passed)
- [ ] Gamma page same
- [ ] Luminance page renders without `menuPath` (no menu path for backlight)
- [ ] Color Tuner shows hero with Apply / Apply all when `adbStatus.connected && adbStatus.cms_tool_deployed`; Apply calls `onAdbApply(colour, control, delta)` correctly
- [ ] `ActionPlanWithAdb` no longer exists in `ColorTuner.jsx`

Closes #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)