### PR TITLE
Validate required adjustment fields in parse_adjustment_plan

### DIFF
--- a/calcore/llm.py
+++ b/calcore/llm.py
@@ -134,6 +134,18 @@ def parse_adjustment_plan(text: str) -> Optional[AdjustmentPlan]:
     if not isinstance(adjustments, list) or not next_step:
         return None
 
+    required_fields: set = {"menu", "setting", "to", "scope"}
+    for adj in adjustments:
+        if not isinstance(adj, dict) or not required_fields.issubset(adj.keys()):
+            logger.warning("parse_adjustment_plan: adjustment missing required key(s)")
+            return None
+        for field in required_fields:
+            if adj[field] is None:
+                logger.warning(
+                    "parse_adjustment_plan: required field '%s' is null", field
+                )
+                return None
+
     try:
         return AdjustmentPlan(
             adjustments=adjustments,

--- a/frontend/src/components/LlmInsightCard.jsx
+++ b/frontend/src/components/LlmInsightCard.jsx
@@ -31,10 +31,10 @@ function AdjustmentRow({ adj }) {
     <div style={{ padding: '8px 0', borderBottom: '1px solid var(--border-subtle, rgba(255,255,255,0.06))' }}>
       <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, flexWrap: 'wrap' }}>
         <span style={{ fontWeight: 600, fontSize: '0.83rem', color: 'var(--ink)' }}>
-          {adj.setting}
+          {adj.setting ?? '?'}
         </span>
         <span style={{ fontSize: '0.75rem', color: 'var(--ink2)' }}>
-          {adj.menu}
+          {adj.menu ?? '?'}
         </span>
         <span style={{
           marginLeft: 'auto',

--- a/tests/test_calcore/test_calcore.py
+++ b/tests/test_calcore/test_calcore.py
@@ -474,9 +474,7 @@ class LlmResponseEdgeCasesTests(unittest.TestCase):
             }
         )
         result = parse_adjustment_plan(data)
-        self.assertIsNotNone(result)
-        self.assertEqual(len(result.adjustments), 1)
-        self.assertEqual(result.adjustments[0].get("menu"), "White Balance")
+        self.assertIsNone(result)
 
     def test_parse_adjustment_plan_valid_json_string(self):
         invalid = '{"adjustments": [], "next_step": "verify", "confidence": 0.5}'

--- a/tests/test_llm_parse.py
+++ b/tests/test_llm_parse.py
@@ -195,6 +195,101 @@ class ParseAdjustmentPlanFenceTests(unittest.TestCase):
         self.assertIsNotNone(result)
         self.assertEqual(result.adjustments, [])
 
+    # ── per-adjustment field validation (#315) ─────────────────────────────
+
+    def _make_adj(self, **overrides):
+        base = {
+            "menu": "White Balance",
+            "setting": "B-Gain",
+            "from": 0,
+            "to": -3,
+            "scope": "global",
+            "reason": "Blue push above D65 locus.",
+        }
+        base.update(overrides)
+        return base
+
+    def _plan_with_adjustments(self, adjustments):
+        return json.dumps(
+            {
+                "adjustments": adjustments,
+                "next_step": "rerun_grayscale",
+                "confidence": 0.85,
+            }
+        )
+
+    def test_adjustment_missing_menu_returns_none(self):
+        """Adjustment without 'menu' field is rejected."""
+        adj = self._make_adj()
+        del adj["menu"]
+        payload = self._plan_with_adjustments([adj])
+        self.assertIsNone(parse_adjustment_plan(payload))
+
+    def test_adjustment_missing_setting_returns_none(self):
+        """Adjustment without 'setting' field is rejected."""
+        adj = self._make_adj()
+        del adj["setting"]
+        payload = self._plan_with_adjustments([adj])
+        self.assertIsNone(parse_adjustment_plan(payload))
+
+    def test_adjustment_missing_to_returns_none(self):
+        """Adjustment without 'to' field is rejected."""
+        adj = self._make_adj()
+        del adj["to"]
+        payload = self._plan_with_adjustments([adj])
+        self.assertIsNone(parse_adjustment_plan(payload))
+
+    def test_adjustment_missing_scope_returns_none(self):
+        """Adjustment without 'scope' field is rejected."""
+        adj = self._make_adj()
+        del adj["scope"]
+        payload = self._plan_with_adjustments([adj])
+        self.assertIsNone(parse_adjustment_plan(payload))
+
+    def test_adjustment_with_optional_fields_omitted_is_valid(self):
+        """Adjustment missing optional fields 'from' and 'reason' is still valid."""
+        adj = self._make_adj()
+        del adj["from"]
+        del adj["reason"]
+        payload = self._plan_with_adjustments([adj])
+        result = parse_adjustment_plan(payload)
+        self.assertIsNotNone(result)
+        self.assertEqual(len(result.adjustments), 1)
+
+    def test_adjustment_with_extra_fields_is_valid(self):
+        """Adjustment with extra fields beyond required is still valid."""
+        adj = self._make_adj()
+        adj["colour"] = "Red"
+        adj["priority"] = "high"
+        payload = self._plan_with_adjustments([adj])
+        result = parse_adjustment_plan(payload)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.adjustments[0]["colour"], "Red")
+
+    def test_adjustment_not_a_dict_returns_none(self):
+        """Non-dict adjustment item is rejected."""
+        payload = self._plan_with_adjustments(["not_a_dict"])
+        self.assertIsNone(parse_adjustment_plan(payload))
+
+    def test_mixed_valid_and_invalid_adjustments_returns_none(self):
+        """Plan with one valid and one invalid adjustment is rejected."""
+        good = self._make_adj()
+        bad = {"menu": "Color", "setting": "Red Gain"}  # missing 'to' and 'scope'
+        payload = self._plan_with_adjustments([good, bad])
+        self.assertIsNone(parse_adjustment_plan(payload))
+
+    def test_null_adjustment_in_list_returns_none(self):
+        """Adjustment list containing None is rejected."""
+        payload = self._plan_with_adjustments([None])
+        self.assertIsNone(parse_adjustment_plan(payload))
+
+    def test_adjustment_null_required_field_returns_none(self):
+        """Adjustment with null value for a required field is rejected."""
+        adj = self._make_adj(to=None)
+        adj["to"] = None
+        payload = self._plan_with_adjustments([adj])
+        self.assertIsNone(parse_adjustment_plan(payload))
+
 
 # ── pytest-style parametrized tests ────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Parse-time validation for individual adjustment dicts in `parse_adjustment_plan()`. Each adjustment must now contain the required fields `menu`, `setting`, `to`, `scope`; optional fields `from` and `reason` are still permitted.

## Changes

1. **`calcore/llm.py`** — Added per-adjustment field validation in `parse_adjustment_plan()` (`llm.py:137-145`). Each dict in the `adjustments` list is checked for the required field set `{menu, setting, to, scope}`. Non-dict items or missing fields return `None`.

2. **`tests/test_llm_parse.py`** — Added 7 test cases covering:
   - Missing each required field individually
   - Optional fields (`from`, `reason`) omitted → still valid
   - Extra fields → still valid
   - Non-dict items → rejected
   - Mixed valid/invalid adjustments → rejected
   - `None` in adjustment list → rejected

3. **`tests/test_calcore/test_calcore.py`** — Updated `test_parse_adjustment_plan_adjustment_missing_fields` to expect `None` (was asserting the old buggy behavior).

4. **`frontend/src/components/LlmInsightCard.jsx`** — Guarded `adj.setting` and `adj.menu` rendering with fallback to `'?'` to avoid displaying `undefined` text.

Closes #315
