### PR TITLE
Add Readout component for instrument-grade metrics (#293)

### DIFF
--- a/frontend/src/components/Card.jsx
+++ b/frontend/src/components/Card.jsx
@@ -17,3 +17,16 @@ export function StatCard({ value, label, color = '', tooltip }) {
     </div>
   );
 }
+
+export function Readout({ label, value, unit, sub, tone }) {
+  return (
+    <div className={`readout-card${tone ? ` tone-${tone}` : ''}`}>
+      <div className="readout-value">
+        {value}
+        {unit && <span className="readout-unit">{unit}</span>}
+      </div>
+      <div className="readout-label">{label}</div>
+      {sub && <div className="readout-sub">{sub}</div>}
+    </div>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -189,6 +189,23 @@ body {
 .stat-value { font-size: 1.9rem; font-weight: 700; line-height: 1; font-family: var(--mono); font-variant-numeric: tabular-nums; }
 .stat-label { font-size: 0.68rem; color: var(--ink2); margin-top: 5px; text-transform: uppercase; letter-spacing: 0.08em; }
 
+/* ── Readout cards ──────────────────────────────────────────────────────────── */
+.readout-card {
+  background: var(--panel2);
+  border: 1px solid var(--line);
+  border-left: 3px solid var(--line2);
+  border-radius: var(--radius-lg);
+  padding: 16px;
+}
+.readout-card.tone-accent { border-left-color: var(--accent); }
+.readout-card.tone-green  { border-left-color: var(--green); }
+.readout-card.tone-amber  { border-left-color: var(--yellow); }
+.readout-card.tone-red    { border-left-color: var(--red); }
+.readout-value { font-size: 1.9rem; font-weight: 700; line-height: 1; font-family: var(--mono); font-variant-numeric: tabular-nums; }
+.readout-unit  { font-size: 0.9rem; font-weight: 500; font-family: var(--mono); color: var(--ink2); margin-left: 4px; }
+.readout-label { font-size: 0.68rem; color: var(--ink2); margin-top: 5px; text-transform: uppercase; letter-spacing: 0.08em; }
+.readout-sub   { font-size: 0.75rem; color: var(--ink3); margin-top: 6px; }
+
 /* ── Buttons ────────────────────────────────────────────────────────────────── */
 .btn {
   display: inline-flex; align-items: center; gap: 6px;

--- a/frontend/src/pages/WhiteBalance.jsx
+++ b/frontend/src/pages/WhiteBalance.jsx
@@ -1,4 +1,4 @@
-import { Card, StatCard } from '../components/Card';
+import { Card, StatCard, Readout } from '../components/Card';
 import { Button } from '../components/Button';
 import { ActionPlan } from '../components/ActionPlan';
 import { MeasurementTable } from '../components/MeasurementTable';
@@ -7,22 +7,15 @@ import { CIEScatter } from '../charts/CIEScatter';
 import { fmtDe, fmtDateTime } from '../utils/fmt';
 import { QualityGate } from '../components/QualityGate';
 
-function DeMeasCard({ label, measurement, hasFlag }) {
+function wbSub(measurement) {
+  if (!measurement) return null;
   return (
-    <div className={`stat-card ${hasFlag ? 'green-top' : ''}`}>
-      <div className="stat-value"
-        dangerouslySetInnerHTML={{ __html: measurement ? fmtDe(measurement.delta_e) : '—' }}
-      />
-      <div className="stat-label">{label}</div>
-      {measurement && (
-        <div className="text-sm muted mt-2">
-          x={measurement.x?.toFixed(4)} y={measurement.y?.toFixed(4)}
-        </div>
+    <>
+      {(measurement.x != null || measurement.y != null) && (
+        <div>x={measurement.x?.toFixed(4)} y={measurement.y?.toFixed(4)}</div>
       )}
-      {measurement?.timestamp && (
-        <div className="text-sm muted">Measured {fmtDateTime(measurement.timestamp)}</div>
-      )}
-    </div>
+      {measurement.timestamp && <div>Measured {fmtDateTime(measurement.timestamp)}</div>}
+    </>
   );
 }
 
@@ -39,8 +32,18 @@ export function WhiteBalance({ session, onNext, onPrev }) {
       <QualityGate gate={(session.quality_gates || {}).white_balance} />
 
       <div className="two-col" style={{ marginBottom: 16 }}>
-        <DeMeasCard label="80% Gray (Gain)"   measurement={wd.gain_measurement}   hasFlag={wd.has_gain_measurement} />
-        <DeMeasCard label="30% Gray (Offset)" measurement={wd.offset_measurement} hasFlag={wd.has_offset_measurement} />
+        <Readout
+          label="80% Gray (Gain)"
+          value={<span dangerouslySetInnerHTML={{ __html: wd.gain_measurement ? fmtDe(wd.gain_measurement.delta_e) : '—' }} />}
+          tone={wd.has_gain_measurement ? 'green' : null}
+          sub={wbSub(wd.gain_measurement)}
+        />
+        <Readout
+          label="30% Gray (Offset)"
+          value={<span dangerouslySetInnerHTML={{ __html: wd.offset_measurement ? fmtDe(wd.offset_measurement.delta_e) : '—' }} />}
+          tone={wd.has_offset_measurement ? 'green' : null}
+          sub={wbSub(wd.offset_measurement)}
+        />
       </div>
 
       <ActionPlan plan={plan} menuPath={wd.menu_path} />


### PR DESCRIPTION
## Summary

- Adds `Readout({ label, value, unit, sub, tone })` to `frontend/src/components/Card.jsx` — mono value with tabular nums, uppercase micro-label, optional unit suffix, optional sub line, and left-border tone coloring (`red` / `amber` / `green` / `accent`)
- Adds `.readout-card` CSS class and tone variants to `index.css`
- Replaces the local `DeMeasCard` in `WhiteBalance.jsx` with `Readout`; `StatCard` is kept untouched for back-compat

## Test plan

- [ ] White balance page renders both gain and offset readout cards with correct labels and ΔE values
- [ ] Green left border appears when a measurement flag is set (`has_gain_measurement` / `has_offset_measurement`)
- [ ] Sub line shows x/y coords and timestamp when measurement data is present; absent when no measurement
- [ ] `StatCard` still renders correctly on any page that uses it
- [ ] Spot-check `Readout` with each tone value (red, amber, green, accent) and no tone

Closes #293

---
_Generated by [Claude Code](https://claude.ai/code/session_01QeyL7bdCkHsWShWNsevCbm)_