### PR TITLE
Redesign Predictive Patch Density + Session Comparison

### DIFF
--- a/frontend/src/pages/ComparisonPage.jsx
+++ b/frontend/src/pages/ComparisonPage.jsx
@@ -199,7 +199,7 @@ export function ComparisonPage({ profiles }) {
             {/* Big improvement delta */}
             {(() => {
               const impD = deltas?.improvement_pct;
-              const impPositive = impD != null && impD > 0;
+              const impPositive = impD > 0;
               return (
                 <>
                   <div style={{ fontSize: '3.5rem', fontWeight: 700, lineHeight: 1, fontFamily: 'var(--mono)', fontVariantNumeric: 'tabular-nums', color: impD == null ? 'var(--ink)' : deltaColor(impD, false), marginBottom: 4 }}>
@@ -215,7 +215,7 @@ export function ComparisonPage({ profiles }) {
             {/* Post-Cal ΔE A → B */}
             <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', maxWidth: 460, margin: '0 auto' }}>
               <div style={{ flex: 1, textAlign: 'right' }}>
-                <div style={{ fontSize: '1.5rem', fontWeight: 700, fontFamily: 'var(--mono)', color: '#e74c3c' }}>
+                <div style={{ fontSize: '1.5rem', fontWeight: 700, fontFamily: 'var(--mono)', color: 'var(--red)' }}>
                   {repA?.post_cal?.avg_de != null ? repA.post_cal.avg_de.toFixed(2) : '—'}
                 </div>
                 <div style={{ fontSize: '0.65rem', letterSpacing: '0.12em', textTransform: 'uppercase', color: 'var(--ink3)', marginTop: 2 }}>
@@ -224,7 +224,7 @@ export function ComparisonPage({ profiles }) {
               </div>
               <div style={{ padding: '0 20px', color: 'var(--ink3)', fontSize: '1.2rem', userSelect: 'none' }}>→</div>
               <div style={{ flex: 1, textAlign: 'left' }}>
-                <div style={{ fontSize: '1.5rem', fontWeight: 700, fontFamily: 'var(--mono)', color: '#22c987' }}>
+                <div style={{ fontSize: '1.5rem', fontWeight: 700, fontFamily: 'var(--mono)', color: 'var(--green)' }}>
                   {repB?.post_cal?.avg_de != null ? repB.post_cal.avg_de.toFixed(2) : '—'}
                 </div>
                 <div style={{ fontSize: '0.65rem', letterSpacing: '0.12em', textTransform: 'uppercase', color: 'var(--ink3)', marginTop: 2 }}>
@@ -240,10 +240,10 @@ export function ComparisonPage({ profiles }) {
               <thead>
                 <tr>
                   <th>Metric</th>
-                  <th style={{ textAlign: 'right', color: '#e74c3c' }}>
+                  <th style={{ textAlign: 'right', color: 'var(--red)' }}>
                     Session A <br /><span style={{ color: 'var(--ink3)', fontWeight: 400, textTransform: 'none', letterSpacing: 0 }}>{sessA?.date ? new Date(sessA.date).toLocaleDateString() : ''}</span>
                   </th>
-                  <th style={{ textAlign: 'right', color: '#22c987' }}>
+                  <th style={{ textAlign: 'right', color: 'var(--green)' }}>
                     Session B <br /><span style={{ color: 'var(--ink3)', fontWeight: 400, textTransform: 'none', letterSpacing: 0 }}>{sessB?.date ? new Date(sessB.date).toLocaleDateString() : ''}</span>
                   </th>
                   <th style={{ textAlign: 'right' }}>Δ (B − A)</th>

--- a/frontend/src/pages/ComparisonPage.jsx
+++ b/frontend/src/pages/ComparisonPage.jsx
@@ -190,19 +190,63 @@ export function ComparisonPage({ profiles }) {
             </div>
           )}
 
+          {/* Delta hero */}
+          <div style={{ background: 'var(--panel2)', border: '1px solid var(--line)', borderRadius: 'var(--radius-lg)', padding: '32px 24px 28px', marginBottom: 16, textAlign: 'center' }}>
+            <div style={{ fontSize: '0.65rem', letterSpacing: '0.2em', textTransform: 'uppercase', color: 'var(--ink3)', marginBottom: 10 }}>
+              Session B vs A — Improvement Δ
+            </div>
+
+            {/* Big improvement delta */}
+            {(() => {
+              const impD = deltas?.improvement_pct;
+              const impPositive = impD != null && impD > 0;
+              return (
+                <>
+                  <div style={{ fontSize: '3.5rem', fontWeight: 700, lineHeight: 1, fontFamily: 'var(--mono)', fontVariantNumeric: 'tabular-nums', color: impD == null ? 'var(--ink)' : deltaColor(impD, false), marginBottom: 4 }}>
+                    {impD != null ? `${impPositive ? '+' : ''}${impD.toFixed(1)}%` : '—'}
+                  </div>
+                  <div style={{ fontSize: '0.75rem', color: 'var(--ink2)', marginBottom: 24 }}>
+                    accuracy improvement Δ (B − A)
+                  </div>
+                </>
+              );
+            })()}
+
+            {/* Post-Cal ΔE A → B */}
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', maxWidth: 460, margin: '0 auto' }}>
+              <div style={{ flex: 1, textAlign: 'right' }}>
+                <div style={{ fontSize: '1.5rem', fontWeight: 700, fontFamily: 'var(--mono)', color: '#e74c3c' }}>
+                  {repA?.post_cal?.avg_de != null ? repA.post_cal.avg_de.toFixed(2) : '—'}
+                </div>
+                <div style={{ fontSize: '0.65rem', letterSpacing: '0.12em', textTransform: 'uppercase', color: 'var(--ink3)', marginTop: 2 }}>
+                  Post-Cal ΔE · A
+                </div>
+              </div>
+              <div style={{ padding: '0 20px', color: 'var(--ink3)', fontSize: '1.2rem', userSelect: 'none' }}>→</div>
+              <div style={{ flex: 1, textAlign: 'left' }}>
+                <div style={{ fontSize: '1.5rem', fontWeight: 700, fontFamily: 'var(--mono)', color: '#22c987' }}>
+                  {repB?.post_cal?.avg_de != null ? repB.post_cal.avg_de.toFixed(2) : '—'}
+                </div>
+                <div style={{ fontSize: '0.65rem', letterSpacing: '0.12em', textTransform: 'uppercase', color: 'var(--ink3)', marginTop: 2 }}>
+                  Post-Cal ΔE · B
+                </div>
+              </div>
+            </div>
+          </div>
+
           {/* Key Metrics Table */}
           <Card title="Key Metrics">
-            <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.82rem' }}>
+            <table className="data-table">
               <thead>
-                <tr style={{ borderBottom: '1px solid var(--line)' }}>
-                  <th style={{ textAlign: 'left', padding: '8px 10px', color: 'var(--ink2)', fontWeight: 600, fontSize: '0.7rem', textTransform: 'uppercase', letterSpacing: '0.07em' }}>Metric</th>
-                  <th style={{ textAlign: 'right', padding: '8px 10px', color: '#e74c3c', fontWeight: 600, fontSize: '0.7rem', textTransform: 'uppercase', letterSpacing: '0.07em' }}>
-                    Session A <br /><span style={{ color: 'var(--ink2)', fontWeight: 400, textTransform: 'none', letterSpacing: 0 }}>{sessA?.date ? new Date(sessA.date).toLocaleDateString() : ''}</span>
+                <tr>
+                  <th>Metric</th>
+                  <th style={{ textAlign: 'right', color: '#e74c3c' }}>
+                    Session A <br /><span style={{ color: 'var(--ink3)', fontWeight: 400, textTransform: 'none', letterSpacing: 0 }}>{sessA?.date ? new Date(sessA.date).toLocaleDateString() : ''}</span>
                   </th>
-                  <th style={{ textAlign: 'right', padding: '8px 10px', color: '#22c987', fontWeight: 600, fontSize: '0.7rem', textTransform: 'uppercase', letterSpacing: '0.07em' }}>
-                    Session B <br /><span style={{ color: 'var(--ink2)', fontWeight: 400, textTransform: 'none', letterSpacing: 0 }}>{sessB?.date ? new Date(sessB.date).toLocaleDateString() : ''}</span>
+                  <th style={{ textAlign: 'right', color: '#22c987' }}>
+                    Session B <br /><span style={{ color: 'var(--ink3)', fontWeight: 400, textTransform: 'none', letterSpacing: 0 }}>{sessB?.date ? new Date(sessB.date).toLocaleDateString() : ''}</span>
                   </th>
-                  <th style={{ textAlign: 'right', padding: '8px 10px', color: 'var(--ink2)', fontWeight: 600, fontSize: '0.7rem', textTransform: 'uppercase', letterSpacing: '0.07em' }}>Δ (B − A)</th>
+                  <th style={{ textAlign: 'right' }}>Δ (B − A)</th>
                 </tr>
               </thead>
               <tbody>
@@ -217,11 +261,11 @@ export function ComparisonPage({ profiles }) {
                   { label: 'Peak Luminance', a: repA?.peak_luminance, b: repB?.peak_luminance, d: deltas?.peak_luminance, digits: 1, suffix: ' nits', lowerIsBetter: false },
                   { label: 'Improvement %', a: repA?.improvement_pct, b: repB?.improvement_pct, d: deltas?.improvement_pct, digits: 1, suffix: '%', lowerIsBetter: false },
                 ].map(row => (
-                  <tr key={row.label} style={{ borderBottom: '1px solid var(--line)' }}>
-                    <td style={{ padding: '8px 10px', fontWeight: 500 }}>{row.label}</td>
-                    <td style={{ padding: '8px 10px', textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>{fmtValue(row.a, row.digits || 2, row.suffix || '')}</td>
-                    <td style={{ padding: '8px 10px', textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>{fmtValue(row.b, row.digits || 2, row.suffix || '')}</td>
-                    <td style={{ padding: '8px 10px', textAlign: 'right', fontVariantNumeric: 'tabular-nums', color: deltaColor(row.d, row.lowerIsBetter) }}>{fmtValue(row.d, row.digits || 2, row.suffix || '')}</td>
+                  <tr key={row.label}>
+                    <td style={{ fontFamily: 'inherit', fontWeight: 500 }}>{row.label}</td>
+                    <td style={{ textAlign: 'right' }}>{fmtValue(row.a, row.digits || 2, row.suffix || '')}</td>
+                    <td style={{ textAlign: 'right' }}>{fmtValue(row.b, row.digits || 2, row.suffix || '')}</td>
+                    <td style={{ textAlign: 'right', color: deltaColor(row.d, row.lowerIsBetter), fontWeight: 600 }}>{fmtValue(row.d, row.digits || 2, row.suffix || '')}</td>
                   </tr>
                 ))}
               </tbody>

--- a/frontend/src/pages/SuggestedPatches.jsx
+++ b/frontend/src/pages/SuggestedPatches.jsx
@@ -2,9 +2,13 @@ import { useState, useEffect } from 'react';
 import { Card } from '../components/Card';
 import { Button } from '../components/Button';
 
+const PRIORITY_ORDER = { high: 0, medium: 1, low: 2 };
+const PRIORITY_WEIGHT = { high: 4, medium: 3, low: 2 };
+const PRIORITY_BADGE = { high: 'badge-high', medium: 'badge-medium', low: 'badge-low' };
+
 function priorityColor(priority) {
   if (priority === 'high') return 'var(--red)';
-  if (priority === 'medium') return 'var(--amber, #f59e0b)';
+  if (priority === 'medium') return 'var(--yellow)';
   return 'var(--green)';
 }
 
@@ -18,7 +22,7 @@ export function SuggestedPatches({ session, getSuggestedPatches, runSuggestedPat
   const [error, setError] = useState(null);
   const [running, setRunning] = useState(false);
   const [runResult, setRunResult] = useState(null);
-  const [runError, setRunRunError] = useState(null);
+  const [runError, setRunError] = useState(null);
 
   useEffect(() => {
     if (!session?.id) return;
@@ -46,109 +50,105 @@ export function SuggestedPatches({ session, getSuggestedPatches, runSuggestedPat
   async function handleRun() {
     if (!optimization?.patches?.length) return;
     setRunning(true);
-    setRunRunError(null);
+    setRunError(null);
     setRunResult(null);
     try {
       const result = await runSuggestedPatches(optimization.patches);
       setRunResult(result);
     } catch (err) {
-      setRunRunError(err.message || String(err));
+      setRunError(err.message || String(err));
     } finally {
       setRunning(false);
     }
   }
 
-  return (
-    <div>
-      <Card title="LLM-Optimized Patch Set" id="suggested-patches">
-        {loading && <div className="muted text-sm">Generating optimized patch set...</div>}
-        {error && <div style={{ color: 'var(--red)', fontSize: '0.85rem', marginBottom: 8 }}>Error: {error}</div>}
+  const patches = optimization?.patches || [];
+  const sortedPatches = [...patches]
+    .map((p, i) => ({ ...p, _idx: i }))
+    .sort((a, b) => (PRIORITY_ORDER[a.priority] ?? 1) - (PRIORITY_ORDER[b.priority] ?? 1));
 
-        {optimization && (
+  const counts = patches.reduce((acc, p) => {
+    const key = p.priority || 'low';
+    acc[key] = (acc[key] || 0) + 1;
+    return acc;
+  }, {});
+
+  const confidence = optimization?.confidence != null ? Math.round(optimization.confidence * 100) : null;
+
+  return (
+    <div id="suggested-patches">
+      {/* Decision hero */}
+      <div style={{ background: 'var(--panel2)', border: '1px solid var(--line)', borderRadius: 'var(--radius-lg)', padding: '28px 24px', marginBottom: 16 }}>
+        <div style={{ fontSize: '0.65rem', letterSpacing: '0.2em', textTransform: 'uppercase', color: 'var(--ink3)', marginBottom: 16 }}>
+          Predictive Patch Density
+        </div>
+
+        {loading && (
+          <div className="muted text-sm"><span className="spinner" style={{ marginRight: 8 }} />Generating optimized patch set…</div>
+        )}
+        {error && !loading && (
+          <div className="red text-sm" style={{ padding: '12px 14px', background: 'var(--red-dim)', borderRadius: 'var(--radius)', border: '1px solid var(--line)' }}>
+            {error}
+          </div>
+        )}
+
+        {optimization && !loading && (
           <>
-            <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 12, flexWrap: 'wrap' }}>
-              <span style={{ fontSize: '0.85rem' }}>
-                {optimization.patch_count} patches recommended
-              </span>
-              <span style={{ fontSize: '0.85rem', color: 'var(--ink2)' }}>
-                Confidence: {(optimization.confidence * 100).toFixed(0)}%
-              </span>
-              {optimization.auto_apply && (
-                <span style={{ fontSize: '0.75rem', padding: '2px 8px', background: 'var(--green)', color: '#fff', borderRadius: 4 }}>
-                  Auto-apply ready
-                </span>
-              )}
-              <Button small onClick={loadOptimization}>Refresh</Button>
+            <div style={{ display: 'flex', alignItems: 'flex-start', gap: 28, flexWrap: 'wrap' }}>
+              {/* Confidence */}
+              <div>
+                <div style={{ fontSize: '3rem', fontWeight: 700, lineHeight: 1, fontFamily: 'var(--mono)', fontVariantNumeric: 'tabular-nums', color: confidence != null && confidence >= 70 ? 'var(--green)' : 'var(--ink)' }}>
+                  {confidence != null ? `${confidence}%` : '—'}
+                </div>
+                <div style={{ fontSize: '0.65rem', letterSpacing: '0.12em', textTransform: 'uppercase', color: 'var(--ink3)', marginTop: 6 }}>
+                  Model Confidence
+                </div>
+              </div>
+
+              {/* Patch count */}
+              <div>
+                <div style={{ fontSize: '3rem', fontWeight: 700, lineHeight: 1, fontFamily: 'var(--mono)', fontVariantNumeric: 'tabular-nums', color: 'var(--accent)' }}>
+                  {optimization.patch_count ?? patches.length}
+                </div>
+                <div style={{ fontSize: '0.65rem', letterSpacing: '0.12em', textTransform: 'uppercase', color: 'var(--ink3)', marginTop: 6 }}>
+                  Patches Recommended
+                </div>
+              </div>
+
+              {/* Auto-apply state */}
+              <div style={{ alignSelf: 'center' }}>
+                {optimization.auto_apply ? (
+                  <span className="badge" style={{ background: 'var(--green-dim)', color: 'var(--green)', border: '1px solid rgba(56,210,154,0.35)' }}>
+                    ● AUTO-APPLY READY
+                  </span>
+                ) : (
+                  <span className="badge" style={{ background: 'var(--panel3)', color: 'var(--ink2)', border: '1px solid var(--line)' }}>
+                    REVIEW BEFORE APPLYING
+                  </span>
+                )}
+              </div>
             </div>
 
             {optimization.rationale && (
-              <div className="muted text-sm" style={{ marginBottom: 12, fontStyle: 'italic' }}>
+              <div style={{ marginTop: 20, padding: '12px 16px', background: 'var(--accent-dim)', border: '1px solid rgba(46,199,230,0.25)', borderLeft: '3px solid var(--accent)', borderRadius: 'var(--radius)', fontSize: '0.85rem', lineHeight: 1.55, color: 'var(--ink)' }}>
                 {optimization.rationale}
               </div>
             )}
 
-            <div style={{ overflowX: 'auto' }}>
-              <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.82rem' }}>
-                <thead>
-                  <tr style={{ borderBottom: '2px solid var(--line)' }}>
-                    <th style={{ textAlign: 'left', padding: '6px 8px' }}>#</th>
-                    <th style={{ textAlign: 'left', padding: '6px 8px' }}>Label</th>
-                    <th style={{ textAlign: 'left', padding: '6px 8px' }}>Color</th>
-                    <th style={{ textAlign: 'right', padding: '6px 8px' }}>RGB</th>
-                    <th style={{ textAlign: 'right', padding: '6px 8px' }}>Nits</th>
-                    <th style={{ textAlign: 'center', padding: '6px 8px' }}>Priority</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {optimization.patches.map((p, i) => (
-                    <tr key={i} style={{ borderBottom: '1px solid var(--line)' }}>
-                      <td style={{ padding: '5px 8px', color: 'var(--ink2)' }}>{i + 1}</td>
-                      <td style={{ padding: '5px 8px' }}>
-                        <div>{p.label || `Patch ${i + 1}`}</div>
-                        {p.rationale && (
-                          <div className="muted text-sm" style={{ fontSize: '0.75rem', maxWidth: 300 }}>
-                            {p.rationale}
-                          </div>
-                        )}
-                      </td>
-                      <td style={{ padding: '5px 8px' }}>
-                        <div style={{
-                          width: 20, height: 20, borderRadius: 3,
-                          background: patchColor(p.r, p.g, p.b),
-                          border: '1px solid var(--line)',
-                        }} />
-                      </td>
-                      <td style={{ padding: '5px 8px', fontFamily: 'monospace', textAlign: 'right' }}>
-                        {p.r},{p.g},{p.b}
-                      </td>
-                      <td style={{ padding: '5px 8px', fontFamily: 'monospace', textAlign: 'right' }}>
-                        {p.nits.toFixed(0)}
-                      </td>
-                      <td style={{ padding: '5px 8px', textAlign: 'center' }}>
-                        <span style={{
-                          display: 'inline-block', width: 8, height: 8, borderRadius: '50%',
-                          background: priorityColor(p.priority),
-                        }} title={p.priority} />
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-
-            <div style={{ marginTop: 16, display: 'flex', gap: 8 }}>
-              <Button primary disabled={running || !optimization.patches.length} onClick={handleRun}>
-                {running ? 'Sending to ZRO...' : 'Run These Patches'}
+            <div style={{ marginTop: 20, display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+              <Button primary disabled={running || !patches.length} onClick={handleRun}>
+                {running ? 'Sending to ZRO…' : 'Run These Patches'}
               </Button>
+              <Button onClick={loadOptimization} disabled={loading}>Refresh</Button>
             </div>
 
             {runResult && (
-              <div style={{ marginTop: 12, padding: 10, background: 'var(--panel2)', borderRadius: 6, fontSize: '0.85rem' }}>
+              <div style={{ marginTop: 16, padding: '12px 14px', background: 'var(--panel)', border: '1px solid var(--line)', borderRadius: 'var(--radius)', fontSize: '0.85rem' }}>
                 <div style={{ fontWeight: 600, marginBottom: 4 }}>
                   {runResult.succeeded}/{runResult.accepted} patches measured successfully
                 </div>
                 {runResult.results?.some(r => !r.ok) && (
-                  <div style={{ color: 'var(--red)', fontSize: '0.8rem', marginTop: 4 }}>
+                  <div className="red" style={{ fontSize: '0.8rem', marginTop: 4 }}>
                     Failed: {runResult.results.filter(r => !r.ok).map(r => r.label).join(', ')}
                   </div>
                 )}
@@ -156,7 +156,7 @@ export function SuggestedPatches({ session, getSuggestedPatches, runSuggestedPat
             )}
 
             {runError && (
-              <div style={{ marginTop: 12, padding: 10, background: 'rgba(220,38,38,0.1)', borderRadius: 6, fontSize: '0.85rem', color: 'var(--red)' }}>
+              <div className="red text-sm" style={{ marginTop: 16, padding: '12px 14px', background: 'var(--red-dim)', borderRadius: 'var(--radius)', border: '1px solid var(--line)' }}>
                 {runError}
               </div>
             )}
@@ -168,7 +168,66 @@ export function SuggestedPatches({ session, getSuggestedPatches, runSuggestedPat
             No optimization data available. Click Refresh to generate, or configure the LLM first.
           </div>
         )}
-      </Card>
+      </div>
+
+      {/* Density map */}
+      {optimization && patches.length > 0 && (
+        <Card title="Patch Density Map">
+          <div style={{ display: 'flex', gap: 14, flexWrap: 'wrap', marginBottom: 16 }}>
+            {['high', 'medium', 'low'].filter(k => counts[k]).map(k => (
+              <div key={k} style={{ display: 'flex', alignItems: 'center', gap: 7, fontSize: '0.76rem', color: 'var(--ink2)' }}>
+                <span style={{ width: 10, height: 10, borderRadius: 2, background: priorityColor(k) }} />
+                <span style={{ textTransform: 'capitalize' }}>{k}</span>
+                <span style={{ fontFamily: 'var(--mono)', color: 'var(--ink)' }}>{counts[k]}</span>
+              </div>
+            ))}
+          </div>
+
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+            {sortedPatches.map((p) => {
+              const color = priorityColor(p.priority);
+              const weight = PRIORITY_WEIGHT[p.priority] ?? 2;
+              return (
+                <div
+                  key={p._idx}
+                  style={{
+                    display: 'flex', alignItems: 'center', gap: 14,
+                    background: 'var(--panel2)', border: '1px solid var(--line)',
+                    borderLeft: `${weight}px solid ${color}`,
+                    borderRadius: 'var(--radius-lg)', padding: '12px 16px',
+                  }}
+                >
+                  <div style={{
+                    width: 28, height: 28, borderRadius: 4, flexShrink: 0,
+                    background: patchColor(p.r, p.g, p.b), border: '1px solid var(--line2)',
+                  }} title={`rgb(${p.r}, ${p.g}, ${p.b})`} />
+
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+                      <span style={{ fontWeight: 600, fontSize: '0.86rem' }}>{p.label || `Patch ${p._idx + 1}`}</span>
+                      <span className={`badge ${PRIORITY_BADGE[p.priority] || 'badge-low'}`} style={{ marginLeft: 0 }}>
+                        {(p.priority || 'low').toUpperCase()}
+                      </span>
+                    </div>
+                    {p.rationale && (
+                      <div className="muted" style={{ fontSize: '0.76rem', marginTop: 3 }}>{p.rationale}</div>
+                    )}
+                  </div>
+
+                  <div style={{ textAlign: 'right', flexShrink: 0 }}>
+                    <div style={{ fontFamily: 'var(--mono)', fontSize: '0.8rem', fontVariantNumeric: 'tabular-nums' }}>
+                      {p.r},{p.g},{p.b}
+                    </div>
+                    <div className="muted" style={{ fontFamily: 'var(--mono)', fontSize: '0.74rem', marginTop: 2 }}>
+                      {p.nits != null ? `${p.nits.toFixed(0)} nits` : '—'}
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </Card>
+      )}
 
       <div className="btn-group">
         <Button onClick={onPrev}>← Back</Button>


### PR DESCRIPTION
Closes #299.

Redesigns the two "pro" surfaces that were the least designed in the app.

## Predictive Patch Density (`SuggestedPatches.jsx`)
- **Leads with the decision**: a hero showing `optimization.confidence` (big number), `patch_count`, and an `auto_apply` state badge, with the `rationale` as a callout and the primary **Run These Patches** action up top.
- **Density map instead of a bare table**: patches are grouped/sorted by `priority` (high → red), with a per-priority legend + counts. Priority is now visualized as **weight** — a colored left accent bar (thicker for higher priority) plus a priority badge — rather than a tiny dot. Each row shows the `patchColor(r,g,b)` swatch, RGB (mono), `nits`, and per-patch `rationale`.
- Preserves `getSuggestedPatches(budget)` / `runSuggestedPatches(patches)` and the success/fail `runResult` reporting (also fixed the odd `setRunRunError` setter name).

## Session Comparison (`ComparisonPage.jsx`)
- Adds a **delta hero** above Key Metrics, styled like the new Report (#9): big improvement Δ (`deltas.improvement_pct`, B − A, green/red via `deltaColor`) and a Post-Cal ΔE **A → B** strip.
- Restyles **Key Metrics** onto the shared `data-table` tokens with mono numerics; keeps `deltaColor` semantics and the `tv_mismatch` / `mode_mismatch` banners.
- Keeps the existing header strip (TV + A/B pickers), LLM Analysis, the three overlays (`OverlayGammaChart` / `OverlayDeChart` / `OverlayCIEScatter`), and side-by-side `MeasurementTable`s untouched.

## Acceptance
- All endpoints unchanged: history, compare, delta summary, compare PDF, suggested-patches get/run.
- Mismatch warnings + delta coloring intact; overlays still render with real A/B data.
- No `useSession` / `api/client` signature changes.
- `vite build` succeeds; eslint clean on changed files (only a pre-existing unrelated warning in `Prepare.jsx`).

Note: the "Compare" entry point is left as the header toggle for now (issue lists promoting it to a rail/nav entry as an optional "consider").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ACK8DHABK6DvYJVoFoiyTi)_