### PR TITLE
Remove superseded scaffolding: scrollToCard, header status buttons, dead CSS

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -48,16 +48,6 @@ import { LogsPanel }     from './components/LogsPanel';
 import { AppShell }     from './components/AppShell';
 
 
-function scrollToCard(id) {
-  const el = document.getElementById(id);
-  if (!el) return;
-  el.scrollIntoView({ behavior: 'smooth', block: 'center' });
-  el.classList.remove('card-pulse');
-  void el.offsetWidth;
-  el.classList.add('card-pulse');
-  setTimeout(() => el.classList.remove('card-pulse'), 900);
-}
-
 export default function App() {
   const sess = useSession();
   const { session, profiles, watchStatus, watchDefaultPath, bridgeStatus, bridgeUrl, dogegenStatus, adbStatus, loading,
@@ -120,11 +110,6 @@ export default function App() {
     setShowComparison(prev => !prev);
   }
 
-  const bridgeOk = bridgeStatus?.ok;
-  const bridgeConfigured = bridgeStatus?.configured;
-  const dogegenRunning = dogegenStatus?.running;
-  const dogegenConfigured = dogegenStatus?.configured;
-
   return (
     <div style={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
       {showStartOver && (
@@ -156,21 +141,6 @@ export default function App() {
                 Start Over
               </button>
             </>
-          )}
-          {watchStatus.watching && (
-            <button className="badge badge-watch" onClick={() => scrollToCard('watch-folder')} style={{ cursor: 'pointer', border: 'none', background: 'none', padding: 0 }}>● WATCHING</button>
-          )}
-          {(bridgeOk || bridgeConfigured) && (
-            <button onClick={() => scrollToCard('bridge-card')} style={{ display: 'flex', alignItems: 'center', gap: 5, fontSize: '0.72rem', color: bridgeOk ? 'var(--green)' : 'var(--red)', cursor: 'pointer', background: 'none', border: 'none', padding: 0, fontFamily: 'inherit' }}>
-              <span style={{ width: 8, height: 8, borderRadius: '50%', background: bridgeOk ? 'var(--green)' : 'var(--ink2)', flexShrink: 0 }} />
-              Bridge
-            </button>
-          )}
-          {(dogegenRunning || dogegenConfigured) && (
-            <button onClick={() => scrollToCard('dogegen-card')} style={{ display: 'flex', alignItems: 'center', gap: 5, fontSize: '0.72rem', color: dogegenRunning ? 'var(--green)' : 'var(--red)', cursor: 'pointer', background: 'none', border: 'none', padding: 0, fontFamily: 'inherit' }}>
-              <span style={{ width: 8, height: 8, borderRadius: '50%', background: dogegenRunning ? 'var(--green)' : 'var(--ink2)', flexShrink: 0 }} />
-              Dogegen
-            </button>
           )}
           <button
             onClick={handleToggleComparison}

--- a/frontend/src/components/AppShell.jsx
+++ b/frontend/src/components/AppShell.jsx
@@ -1,10 +1,6 @@
 import { PhaseRail } from './PhaseRail';
 import { InstrumentPanel } from './InstrumentPanel';
 
-const MEASUREMENT_STEPS = new Set([
-  'pre_grayscale', 'luminance', 'white_balance', 'gamma', 'color_tuner', 'post_grayscale',
-]);
-
 export function AppShell({
   session, onJump, children,
   watchStatus, watchDefaultPath,
@@ -15,7 +11,7 @@ export function AppShell({
   onUpload,
   onSaveDogegenConfig, onStartDogegen, onStopDogegen,
 }) {
-  const showInstrument = session != null && MEASUREMENT_STEPS.has(session.step);
+  const showInstrument = session != null;
 
   return (
     <div className="workspace">

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -257,11 +257,6 @@ body {
 .action-icon.check { background: var(--accent-dim); color: var(--accent); }
 .action-summary { font-size: 0.83rem; font-weight: 600; margin-bottom: 3px; }
 .action-reason  { font-size: 0.78rem; color: var(--ink2); }
-.action-card {
-  background: var(--panel2); border: 1px solid var(--line);
-  border-radius: var(--radius-lg); padding: 14px 16px; margin-bottom: 10px;
-  display: flex; align-items: flex-start; gap: 12px;
-}
 .action-body { flex: 1; }
 
 /* ── ZRO cards ───────────────────────────────────────────────────────────────── */
@@ -548,10 +543,4 @@ hr.divider { border: none; border-top: 1px solid var(--line); margin: 16px 0; }
 }
 .ip-upload:hover, .ip-upload.drag-over { border-color: var(--accent); background: var(--accent-dim); color: var(--ink); }
 
-/* ── Card highlight pulse (#42) ─────────────────────────────────────────────── */
-@keyframes cardPulse {
-  0%   { box-shadow: 0 0 0 0   rgba(46,199,230,0.55); }
-  70%  { box-shadow: 0 0 0 8px rgba(46,199,230,0);    }
-  100% { box-shadow: 0 0 0 0   rgba(46,199,230,0);    }
-}
-.card-pulse { animation: cardPulse 0.85s ease-out; }
+


### PR DESCRIPTION
Removes the `scrollToCard` function and three header status buttons that scrolled to `#bridge-card`/`#watch-folder`/`#dogegen-card` (now redundant — status lives in `PhaseRail` + `InstrumentPanel`).

Drops dead CSS: `.action-card`, `.card-pulse`, `@keyframes cardPulse`, and unused `MEASUREMENT_STEPS` const.

Also fixes a behavioral gap: `InstrumentPanel` now renders on all session steps (not just measurement steps) so bridge/dogegen/watch/ADB status is always visible, not only during measurement phases.

Closes #298