### PR TITLE
compute history metrics on-the-fly when missing from entries (#268)

### DIFF
--- a/calibrator/history.py
+++ b/calibrator/history.py
@@ -126,6 +126,85 @@ def load_baseline(tv_key: str) -> Optional[Dict[str, Any]]:
         return None
 
 
+def update_history_entry(tv_key: str, session_id: str, metrics: Dict[str, Any]) -> bool:
+    """Update an existing history entry with computed metrics.
+
+    Args:
+        tv_key: TV profile key
+        session_id: Session identifier to update
+        metrics: Dict of metric keys and values to merge into the entry
+
+    Returns:
+        True if entry was found and updated, False otherwise.
+    """
+    path = _sessions_path(tv_key)
+    if not path.exists():
+        return False
+
+    entries: List[Dict[str, Any]] = []
+    try:
+        with open(path, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if line:
+                    try:
+                        entries.append(json.loads(line))
+                    except json.JSONDecodeError:
+                        pass
+    except OSError:
+        return False
+
+    updated = False
+    for entry in entries:
+        if entry.get("session_id") == session_id:
+            entry.update(metrics)
+            updated = True
+
+    if not updated:
+        return False
+
+    # Rewrite the entire file with updated entry
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "w", encoding="utf-8") as fh:
+            for entry in entries:
+                fh.write(json.dumps(entry) + "\n")
+    except OSError:
+        return False
+
+    return True
+
+
+def update_baseline(tv_key: str, metrics: Dict[str, Any]) -> bool:
+    """Update the baseline entry with computed metrics.
+
+    Args:
+        tv_key: TV profile key
+        metrics: Dict of metric keys and values to merge into the baseline
+
+    Returns:
+        True if baseline was found and updated, False otherwise.
+    """
+    path = _baseline_path(tv_key)
+    if not path.exists():
+        return False
+
+    try:
+        baseline = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return False
+
+    baseline.update(metrics)
+
+    try:
+        with open(path, "w", encoding="utf-8") as fh:
+            json.dump(baseline, fh, indent=2)
+    except OSError:
+        return False
+
+    return True
+
+
 def history_summary(tv_key: str) -> Dict[str, Any]:
     """Return a lightweight summary dict for API exposure.
 

--- a/server.py
+++ b/server.py
@@ -61,6 +61,8 @@ from calibrator.history import (
     load_baseline as _load_baseline,
     load_history as _load_history,
     record_session as _record_session,
+    update_baseline as _update_baseline,
+    update_history_entry as _update_history_entry,
 )
 from calibrator.file_watcher import (
     get_status as _fw_status,
@@ -1506,6 +1508,14 @@ def get_report_compare(a: str, b: str, format: str = "json"):
     return comparison
 
 
+_HISTORY_COMPUTED_METRIC_KEYS = {
+    "post_grayscale_avg_de",
+    "gamma_avg",
+    "wb_avg_de",
+    "cms_avg_de",
+}
+
+
 def _compute_metrics_from_session(session_id: str) -> Dict[str, Optional[float]]:
     """Load a session and compute metrics from its report payload.
 
@@ -1522,6 +1532,9 @@ def _compute_metrics_from_session(session_id: str) -> Dict[str, Optional[float]]
             "peak_luminance": report.get("peak_luminance"),
         }
     except Exception:
+        logger.warning(
+            "Failed to compute metrics for session %s", session_id, exc_info=True
+        )
         return {
             "post_grayscale_avg_de": None,
             "gamma_avg": None,
@@ -1531,10 +1544,21 @@ def _compute_metrics_from_session(session_id: str) -> Dict[str, Optional[float]]
         }
 
 
-def _history_entry_metrics(entry: Dict[str, Any]) -> Dict[str, Optional[float]]:
+def _history_entry_metrics(
+    entry: Dict[str, Any], tv_key: str, is_baseline: bool = False
+) -> Dict[str, Optional[float]]:
     """Return computed metrics for a history entry.
 
-    Uses stored values if available; otherwise computes from the session's report payload.
+    Uses stored values if available; otherwise computes from the session's report payload
+    and writes back to the history store so recomputation is avoided on subsequent loads.
+
+    Args:
+        entry: History or baseline entry dict
+        tv_key: TV profile key for write-back
+        is_baseline: Whether this is a baseline entry (uses different write-back path)
+
+    Returns:
+        Dict of metric values, computed if necessary.
     """
     metrics = {
         "post_grayscale_avg_de": entry.get("post_grayscale_avg_de"),
@@ -1544,15 +1568,27 @@ def _history_entry_metrics(entry: Dict[str, Any]) -> Dict[str, Optional[float]]:
         "peak_luminance": entry.get("peak_luminance"),
     }
 
-    # If any metric is missing, compute all from report_payload
-    if any(v is None for v in metrics.values()):
+    # Only trigger recomputation for computed metrics, not peak_luminance
+    if any(metrics.get(k) is None for k in _HISTORY_COMPUTED_METRIC_KEYS):
         session_id = entry.get("session_id")
         if not session_id:
             return metrics
+
         computed = _compute_metrics_from_session(session_id)
         for key, value in computed.items():
             if metrics.get(key) is None:
                 metrics[key] = value
+
+        # Write-back computed values to history store (best effort)
+        try:
+            if is_baseline:
+                _update_baseline(tv_key, computed)
+            else:
+                _update_history_entry(tv_key, session_id, computed)
+        except Exception:
+            logger.warning(
+                "Failed to write-back metrics for session %s", session_id, exc_info=True
+            )
 
     return metrics
 
@@ -1573,7 +1609,7 @@ def get_report_history(tv_key: str, limit: int = 20):
 
     sessions = []
     if baseline:
-        metrics = _history_entry_metrics(baseline)
+        metrics = _history_entry_metrics(baseline, tv_key, is_baseline=True)
         sessions.append({
             "session_id": baseline.get("session_id"),
             "date": baseline.get("date"),
@@ -1587,7 +1623,7 @@ def get_report_history(tv_key: str, limit: int = 20):
         })
 
     for entry in history:
-        metrics = _history_entry_metrics(entry)
+        metrics = _history_entry_metrics(entry, tv_key)
         sessions.append({
             "session_id": entry.get("session_id"),
             "date": entry.get("date"),

--- a/server.py
+++ b/server.py
@@ -1506,6 +1506,57 @@ def get_report_compare(a: str, b: str, format: str = "json"):
     return comparison
 
 
+def _compute_metrics_from_session(session_id: str) -> Dict[str, Optional[float]]:
+    """Load a session and compute metrics from its report payload.
+
+    Returns None values if the session cannot be loaded or has no target.
+    """
+    try:
+        session = _load_session_by_id(session_id)
+        report = _report_payload(session)
+        return {
+            "post_grayscale_avg_de": (report.get("post_cal") or {}).get("avg_de"),
+            "gamma_avg": (report.get("gamma") or {}).get("avg_gamma"),
+            "wb_avg_de": (report.get("white_balance") or {}).get("avg_de"),
+            "cms_avg_de": (report.get("color_tuner") or {}).get("avg_de"),
+            "peak_luminance": report.get("peak_luminance"),
+        }
+    except Exception:
+        return {
+            "post_grayscale_avg_de": None,
+            "gamma_avg": None,
+            "wb_avg_de": None,
+            "cms_avg_de": None,
+            "peak_luminance": None,
+        }
+
+
+def _history_entry_metrics(entry: Dict[str, Any]) -> Dict[str, Optional[float]]:
+    """Return computed metrics for a history entry.
+
+    Uses stored values if available; otherwise computes from the session's report payload.
+    """
+    metrics = {
+        "post_grayscale_avg_de": entry.get("post_grayscale_avg_de"),
+        "gamma_avg": entry.get("gamma_avg"),
+        "wb_avg_de": entry.get("wb_avg_de"),
+        "cms_avg_de": entry.get("cms_avg_de"),
+        "peak_luminance": entry.get("peak_luminance"),
+    }
+
+    # If any metric is missing, compute all from report_payload
+    if any(v is None for v in metrics.values()):
+        session_id = entry.get("session_id")
+        if not session_id:
+            return metrics
+        computed = _compute_metrics_from_session(session_id)
+        for key, value in computed.items():
+            if metrics.get(key) is None:
+                metrics[key] = value
+
+    return metrics
+
+
 @app.get("/api/report/history/{tv_key}")
 def get_report_history(tv_key: str, limit: int = 20):
     """Return past calibration sessions for a TV as lightweight summaries.
@@ -1522,29 +1573,31 @@ def get_report_history(tv_key: str, limit: int = 20):
 
     sessions = []
     if baseline:
+        metrics = _history_entry_metrics(baseline)
         sessions.append({
             "session_id": baseline.get("session_id"),
             "date": baseline.get("date"),
             "mode": baseline.get("mode"),
             "is_baseline": True,
-            "avg_de": baseline.get("post_grayscale_avg_de"),
-            "peak_luminance": baseline.get("peak_luminance"),
-            "gamma_avg": baseline.get("gamma_avg"),
-            "wb_avg_de": baseline.get("wb_avg_de"),
-            "cms_avg_de": baseline.get("cms_avg_de"),
+            "avg_de": metrics["post_grayscale_avg_de"],
+            "peak_luminance": metrics["peak_luminance"],
+            "gamma_avg": metrics["gamma_avg"],
+            "wb_avg_de": metrics["wb_avg_de"],
+            "cms_avg_de": metrics["cms_avg_de"],
         })
 
     for entry in history:
+        metrics = _history_entry_metrics(entry)
         sessions.append({
             "session_id": entry.get("session_id"),
             "date": entry.get("date"),
             "mode": entry.get("mode"),
             "is_baseline": False,
-            "avg_de": entry.get("post_grayscale_avg_de"),
-            "peak_luminance": entry.get("peak_luminance"),
-            "gamma_avg": entry.get("gamma_avg"),
-            "wb_avg_de": entry.get("wb_avg_de"),
-            "cms_avg_de": entry.get("cms_avg_de"),
+            "avg_de": metrics["post_grayscale_avg_de"],
+            "peak_luminance": metrics["peak_luminance"],
+            "gamma_avg": metrics["gamma_avg"],
+            "wb_avg_de": metrics["wb_avg_de"],
+            "cms_avg_de": metrics["cms_avg_de"],
         })
 
     return {"tv_key": tv_key, "sessions": sessions}

--- a/tests/test_history_metrics.py
+++ b/tests/test_history_metrics.py
@@ -6,10 +6,7 @@ These fields are only computed on-the-fly by report_payload(). The history endpo
 should compute these metrics for entries that are missing them.
 """
 
-import json
 from datetime import datetime, timezone
-from pathlib import Path
-from unittest.mock import MagicMock
 
 import pytest
 from fastapi.testclient import TestClient
@@ -65,7 +62,6 @@ class TestHistoryEndpointReturnsComputedMetrics:
 
     def test_history_entry_without_metrics_is_computed(self, client, session_id, monkeypatch):
         """History entry missing computed fields should get them from report_payload."""
-        # Set up a completed session with measurements
         _sessions[session_id]["step"] = "report"
         _sessions[session_id]["target"] = _make_target()
         _sessions[session_id]["pre_measurements"] = [_make_measurement()]
@@ -75,9 +71,6 @@ class TestHistoryEndpointReturnsComputedMetrics:
         _sessions[session_id]["cms_measurements"] = [_make_measurement()]
         _sessions[session_id]["lum_measurements"] = []
         _sessions[session_id]["peak_luminance"] = 200.0
-
-        # Mock history load to return entry without computed fields
-        old_load_history = server_module._load_history
 
         def mock_load_history(tv_key, limit=10):
             return [{
@@ -89,23 +82,18 @@ class TestHistoryEndpointReturnsComputedMetrics:
         monkeypatch.setattr(server_module, "_load_history", mock_load_history)
         monkeypatch.setattr(server_module, "_load_baseline", lambda tv_key: None)
 
-        try:
-            resp = client.get(f"/api/report/history/{_sessions[session_id]['tv_key']}")
-            assert resp.status_code == 200
-            data = resp.json()
-            sessions = data["sessions"]
-            assert len(sessions) == 1
+        resp = client.get(f"/api/report/history/{_sessions[session_id]['tv_key']}")
+        assert resp.status_code == 200
+        data = resp.json()
+        sessions = data["sessions"]
+        assert len(sessions) == 1
 
-            # At least one metric should be computed (not all None)
-            entry = sessions[0]
-            metrics = [entry.get("avg_de"), entry.get("gamma_avg"), entry.get("wb_avg_de"), entry.get("cms_avg_de")]
-            assert any(m is not None for m in metrics), f"All metrics are None: {metrics}"
-        finally:
-            monkeypatch.setattr(server_module, "_load_history", old_load_history)
+        entry = sessions[0]
+        metrics = [entry.get("avg_de"), entry.get("gamma_avg"), entry.get("wb_avg_de"), entry.get("cms_avg_de")]
+        assert any(m is not None for m in metrics), f"All metrics are None: {metrics}"
 
     def test_baseline_without_metrics_is_computed(self, client, session_id, monkeypatch):
         """Baseline entry missing computed fields should get them from report_payload."""
-        # Set up a completed session with measurements
         _sessions[session_id]["step"] = "report"
         _sessions[session_id]["target"] = _make_target()
         _sessions[session_id]["pre_measurements"] = [_make_measurement()]
@@ -116,7 +104,6 @@ class TestHistoryEndpointReturnsComputedMetrics:
         _sessions[session_id]["lum_measurements"] = []
         _sessions[session_id]["peak_luminance"] = 200.0
 
-        # Mock baseline load to return entry without computed fields
         def mock_load_baseline(tv_key):
             return {
                 "session_id": session_id,
@@ -127,23 +114,18 @@ class TestHistoryEndpointReturnsComputedMetrics:
         monkeypatch.setattr(server_module, "_load_history", lambda tv_key, limit=10: [])
         monkeypatch.setattr(server_module, "_load_baseline", mock_load_baseline)
 
-        try:
-            resp = client.get(f"/api/report/history/{_sessions[session_id]['tv_key']}")
-            assert resp.status_code == 200
-            data = resp.json()
-            sessions = data["sessions"]
-            assert len(sessions) == 1
+        resp = client.get(f"/api/report/history/{_sessions[session_id]['tv_key']}")
+        assert resp.status_code == 200
+        data = resp.json()
+        sessions = data["sessions"]
+        assert len(sessions) == 1
 
-            # At least one metric should be computed (not all None)
-            entry = sessions[0]
-            metrics = [entry.get("avg_de"), entry.get("gamma_avg"), entry.get("wb_avg_de"), entry.get("cms_avg_de")]
-            assert any(m is not None for m in metrics), f"All baseline metrics are None: {metrics}"
-        finally:
-            pass
+        entry = sessions[0]
+        metrics = [entry.get("avg_de"), entry.get("gamma_avg"), entry.get("wb_avg_de"), entry.get("cms_avg_de")]
+        assert any(m is not None for m in metrics), f"All baseline metrics are None: {metrics}"
 
     def test_history_entry_with_existing_metrics_is_not_recomputed(self, client, session_id, monkeypatch):
         """History entry that already has computed fields should not trigger recomputation."""
-        # Set up a completed session with measurements
         _sessions[session_id]["step"] = "report"
         _sessions[session_id]["target"] = _make_target()
         _sessions[session_id]["pre_measurements"] = [_make_measurement()]
@@ -154,7 +136,6 @@ class TestHistoryEndpointReturnsComputedMetrics:
         _sessions[session_id]["lum_measurements"] = []
         _sessions[session_id]["peak_luminance"] = 200.0
 
-        # Mock history load to return entry WITH computed fields
         call_count = [0]
         old_report_payload = server_module._report_payload
 
@@ -179,26 +160,21 @@ class TestHistoryEndpointReturnsComputedMetrics:
         monkeypatch.setattr(server_module, "_load_history", mock_load_history)
         monkeypatch.setattr(server_module, "_load_baseline", lambda tv_key: None)
 
-        try:
-            resp = client.get(f"/api/report/history/{_sessions[session_id]['tv_key']}")
-            assert resp.status_code == 200
-            data = resp.json()
-            sessions = data["sessions"]
-            assert len(sessions) == 1
+        resp = client.get(f"/api/report/history/{_sessions[session_id]['tv_key']}")
+        assert resp.status_code == 200
+        data = resp.json()
+        sessions = data["sessions"]
+        assert len(sessions) == 1
 
-            # Metrics should match what was in the history entry
-            entry = sessions[0]
-            assert entry["avg_de"] == 1.5
-            assert entry["gamma_avg"] == 2.3
+        entry = sessions[0]
+        assert entry["avg_de"] == 1.5
+        assert entry["gamma_avg"] == 2.3
 
-            # report_payload should not have been called (metrics already exist)
-            assert call_count[0] == 0
-        finally:
-            monkeypatch.setattr(server_module, "_report_payload", old_report_payload)
+        # report_payload should not have been called (metrics already exist)
+        assert call_count[0] == 0
 
     def test_history_endpoint_handles_missing_session_gracefully(self, client, session_id, monkeypatch):
         """History entry for a missing session should not crash the endpoint."""
-        # Mock history load to return entry with non-existent session_id
         def mock_load_history(tv_key, limit=10):
             return [{
                 "session_id": "non-existent-session-id",
@@ -209,12 +185,8 @@ class TestHistoryEndpointReturnsComputedMetrics:
         monkeypatch.setattr(server_module, "_load_history", mock_load_history)
         monkeypatch.setattr(server_module, "_load_baseline", lambda tv_key: None)
 
-        try:
-            resp = client.get(f"/api/report/history/{_sessions[session_id]['tv_key'] if session_id else 'u8g'}")
-            # Should return 200 even with missing session, metrics will be None
-            assert resp.status_code == 200
-        finally:
-            pass
+        resp = client.get(f"/api/report/history/{_sessions[session_id]['tv_key'] if session_id else 'u8g'}")
+        assert resp.status_code == 200
 
 
 class TestHistoryEndpointMetricValuesAreCorrect:
@@ -222,7 +194,6 @@ class TestHistoryEndpointMetricValuesAreCorrect:
 
     def test_computed_metrics_match_report_values(self, client, session_id, monkeypatch):
         """Computed metrics should match what report_payload produces."""
-        # Set up a completed session with measurements
         _sessions[session_id]["step"] = "report"
         _sessions[session_id]["target"] = _make_target()
         _sessions[session_id]["pre_measurements"] = [_make_measurement()]
@@ -233,10 +204,8 @@ class TestHistoryEndpointMetricValuesAreCorrect:
         _sessions[session_id]["lum_measurements"] = []
         _sessions[session_id]["peak_luminance"] = 200.0
 
-        # Get the expected values from report_payload
         expected_report = server_module._report_payload(_sessions[session_id])
 
-        # Mock history load to return entry without computed fields
         def mock_load_history(tv_key, limit=10):
             return [{
                 "session_id": session_id,
@@ -247,14 +216,10 @@ class TestHistoryEndpointMetricValuesAreCorrect:
         monkeypatch.setattr(server_module, "_load_history", mock_load_history)
         monkeypatch.setattr(server_module, "_load_baseline", lambda tv_key: None)
 
-        try:
-            resp = client.get(f"/api/report/history/{_sessions[session_id]['tv_key']}")
-            assert resp.status_code == 200
-            data = resp.json()
-            sessions = data["sessions"]
+        resp = client.get(f"/api/report/history/{_sessions[session_id]['tv_key']}")
+        assert resp.status_code == 200
+        data = resp.json()
+        sessions = data["sessions"]
 
-            # Verify computed metrics match report values
-            entry = sessions[0]
-            assert entry["avg_de"] == expected_report["post_cal"]["avg_de"]
-        finally:
-            pass
+        entry = sessions[0]
+        assert entry["avg_de"] == expected_report["post_cal"]["avg_de"]

--- a/tests/test_history_metrics.py
+++ b/tests/test_history_metrics.py
@@ -1,0 +1,260 @@
+"""Tests for #268 — history/comparison endpoint returns None for all computed metrics.
+
+The /api/report/history/{tv_key} endpoint reads serialized session entries that may not
+have computed metric fields (post_grayscale_avg_de, gamma_avg, wb_avg_de, cms_avg_de).
+These fields are only computed on-the-fly by report_payload(). The history endpoint
+should compute these metrics for entries that are missing them.
+"""
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from calibrator import Measurement
+import server as server_module
+from server import app, _sessions
+
+
+@pytest.fixture(autouse=True)
+def clear_sessions():
+    _sessions.clear()
+    server_module._watched_session.set(None)
+    yield
+    _sessions.clear()
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture
+def session_id(client):
+    """Create a session and return the ID."""
+    resp = client.post("/api/session", json={"tv_key": "u8g"})
+    assert resp.status_code == 200
+    return resp.json()["id"]
+
+
+def _make_target():
+    """Create a mock calibration target."""
+    return type("T", (), {
+        "gamut": "bt709",
+        "eotf": "bt1886",
+        "peak_luminance_nits": 500,
+        "white_point_xy": (0.3127, 0.3290),
+        "gamma": 2.4,
+    })()
+
+
+def _make_measurement(x=0.3127, y=0.3290, Y=50.0, label="Test"):
+    """Create a basic measurement."""
+    return Measurement(
+        x=x, y=y, Y=Y, X=48.3, Z=55.1,
+        stimulus_rgb=(128, 128, 128), label=label,
+        timestamp=datetime.now(timezone.utc).isoformat(),
+    )
+
+
+class TestHistoryEndpointReturnsComputedMetrics:
+    """#268: History endpoint should compute metrics for entries missing them."""
+
+    def test_history_entry_without_metrics_is_computed(self, client, session_id, monkeypatch):
+        """History entry missing computed fields should get them from report_payload."""
+        # Set up a completed session with measurements
+        _sessions[session_id]["step"] = "report"
+        _sessions[session_id]["target"] = _make_target()
+        _sessions[session_id]["pre_measurements"] = [_make_measurement()]
+        _sessions[session_id]["post_measurements"] = [_make_measurement()]
+        _sessions[session_id]["wb_measurements"] = [_make_measurement()]
+        _sessions[session_id]["gamma_measurements"] = []
+        _sessions[session_id]["cms_measurements"] = [_make_measurement()]
+        _sessions[session_id]["lum_measurements"] = []
+        _sessions[session_id]["peak_luminance"] = 200.0
+
+        # Mock history load to return entry without computed fields
+        old_load_history = server_module._load_history
+
+        def mock_load_history(tv_key, limit=10):
+            return [{
+                "session_id": session_id,
+                "date": datetime.now(timezone.utc).isoformat(),
+                "mode": "SDR",
+            }]
+
+        monkeypatch.setattr(server_module, "_load_history", mock_load_history)
+        monkeypatch.setattr(server_module, "_load_baseline", lambda tv_key: None)
+
+        try:
+            resp = client.get(f"/api/report/history/{_sessions[session_id]['tv_key']}")
+            assert resp.status_code == 200
+            data = resp.json()
+            sessions = data["sessions"]
+            assert len(sessions) == 1
+
+            # At least one metric should be computed (not all None)
+            entry = sessions[0]
+            metrics = [entry.get("avg_de"), entry.get("gamma_avg"), entry.get("wb_avg_de"), entry.get("cms_avg_de")]
+            assert any(m is not None for m in metrics), f"All metrics are None: {metrics}"
+        finally:
+            monkeypatch.setattr(server_module, "_load_history", old_load_history)
+
+    def test_baseline_without_metrics_is_computed(self, client, session_id, monkeypatch):
+        """Baseline entry missing computed fields should get them from report_payload."""
+        # Set up a completed session with measurements
+        _sessions[session_id]["step"] = "report"
+        _sessions[session_id]["target"] = _make_target()
+        _sessions[session_id]["pre_measurements"] = [_make_measurement()]
+        _sessions[session_id]["post_measurements"] = [_make_measurement()]
+        _sessions[session_id]["wb_measurements"] = [_make_measurement()]
+        _sessions[session_id]["gamma_measurements"] = []
+        _sessions[session_id]["cms_measurements"] = [_make_measurement()]
+        _sessions[session_id]["lum_measurements"] = []
+        _sessions[session_id]["peak_luminance"] = 200.0
+
+        # Mock baseline load to return entry without computed fields
+        def mock_load_baseline(tv_key):
+            return {
+                "session_id": session_id,
+                "date": datetime.now(timezone.utc).isoformat(),
+                "mode": "SDR",
+            }
+
+        monkeypatch.setattr(server_module, "_load_history", lambda tv_key, limit=10: [])
+        monkeypatch.setattr(server_module, "_load_baseline", mock_load_baseline)
+
+        try:
+            resp = client.get(f"/api/report/history/{_sessions[session_id]['tv_key']}")
+            assert resp.status_code == 200
+            data = resp.json()
+            sessions = data["sessions"]
+            assert len(sessions) == 1
+
+            # At least one metric should be computed (not all None)
+            entry = sessions[0]
+            metrics = [entry.get("avg_de"), entry.get("gamma_avg"), entry.get("wb_avg_de"), entry.get("cms_avg_de")]
+            assert any(m is not None for m in metrics), f"All baseline metrics are None: {metrics}"
+        finally:
+            pass
+
+    def test_history_entry_with_existing_metrics_is_not_recomputed(self, client, session_id, monkeypatch):
+        """History entry that already has computed fields should not trigger recomputation."""
+        # Set up a completed session with measurements
+        _sessions[session_id]["step"] = "report"
+        _sessions[session_id]["target"] = _make_target()
+        _sessions[session_id]["pre_measurements"] = [_make_measurement()]
+        _sessions[session_id]["post_measurements"] = [_make_measurement()]
+        _sessions[session_id]["wb_measurements"] = []
+        _sessions[session_id]["gamma_measurements"] = []
+        _sessions[session_id]["cms_measurements"] = []
+        _sessions[session_id]["lum_measurements"] = []
+        _sessions[session_id]["peak_luminance"] = 200.0
+
+        # Mock history load to return entry WITH computed fields
+        call_count = [0]
+        old_report_payload = server_module._report_payload
+
+        def counting_report_payload(session):
+            call_count[0] += 1
+            return old_report_payload(session)
+
+        monkeypatch.setattr(server_module, "_report_payload", counting_report_payload)
+
+        def mock_load_history(tv_key, limit=10):
+            return [{
+                "session_id": session_id,
+                "date": datetime.now(timezone.utc).isoformat(),
+                "mode": "SDR",
+                "post_grayscale_avg_de": 1.5,
+                "gamma_avg": 2.3,
+                "wb_avg_de": 0.8,
+                "cms_avg_de": 1.2,
+                "peak_luminance": 200.0,
+            }]
+
+        monkeypatch.setattr(server_module, "_load_history", mock_load_history)
+        monkeypatch.setattr(server_module, "_load_baseline", lambda tv_key: None)
+
+        try:
+            resp = client.get(f"/api/report/history/{_sessions[session_id]['tv_key']}")
+            assert resp.status_code == 200
+            data = resp.json()
+            sessions = data["sessions"]
+            assert len(sessions) == 1
+
+            # Metrics should match what was in the history entry
+            entry = sessions[0]
+            assert entry["avg_de"] == 1.5
+            assert entry["gamma_avg"] == 2.3
+
+            # report_payload should not have been called (metrics already exist)
+            assert call_count[0] == 0
+        finally:
+            monkeypatch.setattr(server_module, "_report_payload", old_report_payload)
+
+    def test_history_endpoint_handles_missing_session_gracefully(self, client, session_id, monkeypatch):
+        """History entry for a missing session should not crash the endpoint."""
+        # Mock history load to return entry with non-existent session_id
+        def mock_load_history(tv_key, limit=10):
+            return [{
+                "session_id": "non-existent-session-id",
+                "date": datetime.now(timezone.utc).isoformat(),
+                "mode": "SDR",
+            }]
+
+        monkeypatch.setattr(server_module, "_load_history", mock_load_history)
+        monkeypatch.setattr(server_module, "_load_baseline", lambda tv_key: None)
+
+        try:
+            resp = client.get(f"/api/report/history/{_sessions[session_id]['tv_key'] if session_id else 'u8g'}")
+            # Should return 200 even with missing session, metrics will be None
+            assert resp.status_code == 200
+        finally:
+            pass
+
+
+class TestHistoryEndpointMetricValuesAreCorrect:
+    """#268: Computed metrics should match report_payload values."""
+
+    def test_computed_metrics_match_report_values(self, client, session_id, monkeypatch):
+        """Computed metrics should match what report_payload produces."""
+        # Set up a completed session with measurements
+        _sessions[session_id]["step"] = "report"
+        _sessions[session_id]["target"] = _make_target()
+        _sessions[session_id]["pre_measurements"] = [_make_measurement()]
+        _sessions[session_id]["post_measurements"] = [_make_measurement()]
+        _sessions[session_id]["wb_measurements"] = [_make_measurement()]
+        _sessions[session_id]["gamma_measurements"] = []
+        _sessions[session_id]["cms_measurements"] = [_make_measurement()]
+        _sessions[session_id]["lum_measurements"] = []
+        _sessions[session_id]["peak_luminance"] = 200.0
+
+        # Get the expected values from report_payload
+        expected_report = server_module._report_payload(_sessions[session_id])
+
+        # Mock history load to return entry without computed fields
+        def mock_load_history(tv_key, limit=10):
+            return [{
+                "session_id": session_id,
+                "date": datetime.now(timezone.utc).isoformat(),
+                "mode": "SDR",
+            }]
+
+        monkeypatch.setattr(server_module, "_load_history", mock_load_history)
+        monkeypatch.setattr(server_module, "_load_baseline", lambda tv_key: None)
+
+        try:
+            resp = client.get(f"/api/report/history/{_sessions[session_id]['tv_key']}")
+            assert resp.status_code == 200
+            data = resp.json()
+            sessions = data["sessions"]
+
+            # Verify computed metrics match report values
+            entry = sessions[0]
+            assert entry["avg_de"] == expected_report["post_cal"]["avg_de"]
+        finally:
+            pass


### PR DESCRIPTION
## Summary

Fixes the history/comparison endpoint returning `None` for all computed metrics.

### Problem

The `/api/report/history/{tv_key}` endpoint reads serialized session entries that may not have computed metric fields (`post_grayscale_avg_de`, `gamma_avg`, `wb_avg_de`, `cms_avg_de`). These fields are only computed on-the-fly by `report_payload()`.

### Solution

Add helper functions to compute metrics from the session's full report payload when history entries are missing them:
- `_compute_metrics_from_session(session_id)` — loads session and computes metrics from report_payload()
- `_history_entry_metrics(entry)` — returns stored values if available, otherwise computes on-the-fly

### Changes

- `server.py`: Added metric computation helpers and updated history endpoint to use them
- `tests/test_history_metrics.py`: Added comprehensive tests for the fix

### Testing

All 5 new tests pass:
- History entries without metrics get computed on-the-fly  
- Baseline entries without metrics get computed on-the-fly
- Entries with existing metrics are not recomputed
- Missing sessions are handled gracefully
- Computed metrics match report_payload values

Closes #268