### PR TITLE
feat: first-class OpenRouter support in LLMConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,7 +457,8 @@ are required:
 }
 ```
 
-When `provider` is `openrouter`, requests carry two OpenRouter-specific headers:
+`http_referer` and `app_title` are optional, but recommended: when `provider`
+is `openrouter`, requests carry two OpenRouter-specific headers built from them:
 `HTTP-Referer` (per-app rate-limit attribution; sent only when `http_referer`
 is set) and `X-Title` (display name shown in OpenRouter's usage dashboard,
 defaults to `tv-calibration`). The **Test Connection** probe sends the same

--- a/README.md
+++ b/README.md
@@ -438,6 +438,31 @@ The proxy routes to Claude Sonnet via OpenRouter by default and falls back to a 
 
 See `litellm_config.yaml` for available models and configuration options.
 
+#### Direct OpenRouter (no proxy)
+
+To route through [OpenRouter](https://openrouter.ai) without running a local
+proxy, set `provider` to `openrouter` in the LLM config. The endpoint defaults
+to `https://openrouter.ai/api/v1` automatically, so only `model` and `api_key`
+are required:
+
+```json
+{
+  "llm": {
+    "provider": "openrouter",
+    "model": "anthropic/claude-3-5-sonnet",
+    "api_key": "sk-or-...",
+    "http_referer": "https://github.com/jweber93/tv-calibration",
+    "app_title": "tv-calibration"
+  }
+}
+```
+
+When `provider` is `openrouter`, requests carry two OpenRouter-specific headers:
+`HTTP-Referer` (per-app rate-limit attribution; sent only when `http_referer`
+is set) and `X-Title` (display name shown in OpenRouter's usage dashboard,
+defaults to `tv-calibration`). The **Test Connection** probe sends the same
+headers as real calls, so a passing probe reflects a working configuration.
+
 ### ADB TV Control
 
 For supported TVs, the app can apply color management settings directly over Android Debug Bridge without navigating service menus:

--- a/calcore/llm.py
+++ b/calcore/llm.py
@@ -254,6 +254,33 @@ def resolve_endpoint(endpoint: str) -> str:
     return endpoint
 
 
+def _build_request(url: str, body: Dict[str, Any], llm: LLMConfig) -> urllib.request.Request:
+    """Build a POST request to an OpenAI-compatible endpoint with provider headers.
+
+    Centralises the shared request-building boilerplate (JSON body, Bearer auth)
+    and injects provider-specific headers so every call site sends identical
+    headers — including the connection probe.  For ``provider == "openrouter"``
+    this adds:
+
+      - ``HTTP-Referer`` — per-app rate-limit attribution (only when set)
+      - ``X-Title`` — display name shown in OpenRouter's usage dashboard
+    """
+    data = json.dumps(body).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=data,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    if llm.api_key:
+        req.add_header("Authorization", f"Bearer {llm.api_key}")
+    if llm.provider == "openrouter":
+        if llm.http_referer:
+            req.add_header("HTTP-Referer", llm.http_referer)
+        req.add_header("X-Title", llm.app_title or "tv-calibration")
+    return req
+
+
 _SYSTEM_PROMPT = (
     "You are an expert Display Calibration Engine. "
     "Identify the highest-dE errors and produce precise hardware adjustment deltas. "
@@ -309,16 +336,7 @@ def call_llm(
         "temperature": 0.0,
     }
 
-    data = json.dumps(body).encode("utf-8")
-    req = urllib.request.Request(
-        url,
-        data=data,
-        headers={"Content-Type": "application/json"},
-        method="POST",
-    )
-    # LiteLLM supports Bearer tokens; pass the key when provided.
-    if llm.api_key:
-        req.add_header("Authorization", f"Bearer {llm.api_key}")
+    req = _build_request(url, body, llm)
 
     try:
         with urllib.request.urlopen(req, timeout=llm.timeout) as resp:
@@ -520,12 +538,7 @@ def query_next_patch_strategy(
         "temperature": 0.0,
     }
 
-    data = json.dumps(body).encode("utf-8")
-    req = urllib.request.Request(
-        url, data=data, headers={"Content-Type": "application/json"}, method="POST"
-    )
-    if llm.api_key:
-        req.add_header("Authorization", f"Bearer {llm.api_key}")
+    req = _build_request(url, body, llm)
 
     try:
         with urllib.request.urlopen(req, timeout=min(llm.timeout, 30.0)) as resp:
@@ -616,12 +629,7 @@ def query_remediation(
         "temperature": 0.0,
     }
 
-    data = json.dumps(body).encode("utf-8")
-    req = urllib.request.Request(
-        url, data=data, headers={"Content-Type": "application/json"}, method="POST"
-    )
-    if llm.api_key:
-        req.add_header("Authorization", f"Bearer {llm.api_key}")
+    req = _build_request(url, body, llm)
 
     try:
         with urllib.request.urlopen(req, timeout=min(llm.timeout, 20.0)) as resp:
@@ -689,12 +697,7 @@ def query_gamut_advice(
         "temperature": 0.2,
     }
 
-    data = json.dumps(body).encode("utf-8")
-    req = urllib.request.Request(
-        url, data=data, headers={"Content-Type": "application/json"}, method="POST"
-    )
-    if llm.api_key:
-        req.add_header("Authorization", f"Bearer {llm.api_key}")
+    req = _build_request(url, body, llm)
 
     try:
         with urllib.request.urlopen(req, timeout=min(llm.timeout, 30.0)) as resp:
@@ -724,24 +727,23 @@ def probe_llm(cfg: Dict[str, Any], timeout: float = 8.0) -> tuple[bool, str]:
     Unlike a bare TCP check, this catches invalid model names, wrong API keys, and
     misconfigured proxies that would otherwise only fail at analysis time.
     """
-    endpoint = cfg.get("endpoint", "")
-    model = cfg.get("model", "")
-    if not endpoint or not model:
+    # Build an LLMConfig so the probe sends the same provider headers
+    # (HTTP-Referer, X-Title) as a real call — otherwise the probe can pass
+    # while real calls fail (e.g. a bad HTTP-Referer hitting a blocklist).
+    from .models import LLMConfig
+
+    llm = LLMConfig.from_dict(cfg)
+    if not llm.endpoint or not llm.model:
         return False, "endpoint and model are required"
 
-    url = resolve_endpoint(endpoint)
+    url = resolve_endpoint(llm.endpoint)
     body = {
-        "model": model,
+        "model": llm.model,
         "messages": [{"role": "user", "content": "hi"}],
         "max_tokens": 1,
         "temperature": 0,
     }
-    data = json.dumps(body).encode("utf-8")
-    req = urllib.request.Request(
-        url, data=data, headers={"Content-Type": "application/json"}, method="POST"
-    )
-    if cfg.get("api_key"):
-        req.add_header("Authorization", f"Bearer {cfg['api_key']}")
+    req = _build_request(url, body, llm)
 
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp:
@@ -826,12 +828,7 @@ def query_delta_summary(
         "temperature": 0.3,
     }
 
-    data = json.dumps(body).encode("utf-8")
-    req = urllib.request.Request(
-        url, data=data, headers={"Content-Type": "application/json"}, method="POST"
-    )
-    if llm.api_key:
-        req.add_header("Authorization", f"Bearer {llm.api_key}")
+    req = _build_request(url, body, llm)
 
     try:
         with urllib.request.urlopen(req, timeout=min(llm.timeout, 45.0)) as resp:
@@ -1010,12 +1007,7 @@ def query_pass_decision(
         "temperature": 0.0,
     }
 
-    data = json.dumps(body).encode("utf-8")
-    req = urllib.request.Request(
-        url, data=data, headers={"Content-Type": "application/json"}, method="POST"
-    )
-    if llm.api_key:
-        req.add_header("Authorization", f"Bearer {llm.api_key}")
+    req = _build_request(url, body, llm)
 
     try:
         with urllib.request.urlopen(req, timeout=min(llm.timeout, 45.0)) as resp:
@@ -1117,12 +1109,7 @@ def query_patch_optimization(
         "temperature": 0.0,
     }
 
-    data = json.dumps(body).encode("utf-8")
-    req = urllib.request.Request(
-        url, data=data, headers={"Content-Type": "application/json"}, method="POST"
-    )
-    if llm.api_key:
-        req.add_header("Authorization", f"Bearer {llm.api_key}")
+    req = _build_request(url, body, llm)
 
     try:
         with urllib.request.urlopen(req, timeout=min(llm.timeout, 60.0)) as resp:

--- a/calcore/llm.py
+++ b/calcore/llm.py
@@ -730,6 +730,8 @@ def probe_llm(cfg: Dict[str, Any], timeout: float = 8.0) -> tuple[bool, str]:
     # Build an LLMConfig so the probe sends the same provider headers
     # (HTTP-Referer, X-Title) as a real call — otherwise the probe can pass
     # while real calls fail (e.g. a bad HTTP-Referer hitting a blocklist).
+    # Imported locally: models.py is only a TYPE_CHECKING import at module
+    # level, and a top-level import here would create a circular dependency.
     from .models import LLMConfig
 
     llm = LLMConfig.from_dict(cfg)

--- a/calcore/models.py
+++ b/calcore/models.py
@@ -47,6 +47,12 @@ class AnalysisConfig:
             raise ValueError(f"code_max must be positive, got {self.code_max}")
 
 
+# Known providers with a fixed default endpoint, used when the user omits one.
+_PROVIDER_ENDPOINTS = {
+    "openrouter": "https://openrouter.ai/api/v1",
+}
+
+
 @dataclass
 class LLMConfig:
     endpoint: str = ""
@@ -54,6 +60,15 @@ class LLMConfig:
     api_key: str = ""
     temperature: float = 0.2
     timeout: float = 120.0
+    provider: str = ""          # "openrouter" | "litellm" | "" (generic)
+    http_referer: str = ""      # sent as HTTP-Referer when provider == "openrouter"
+    app_title: str = "tv-calibration"  # sent as X-Title when provider == "openrouter"
+
+    def __post_init__(self) -> None:
+        self.provider = (self.provider or "").strip().lower()
+        # Auto-fill the endpoint for known providers when the user omits it.
+        if not self.endpoint and self.provider in _PROVIDER_ENDPOINTS:
+            self.endpoint = _PROVIDER_ENDPOINTS[self.provider]
 
     @classmethod
     def from_dict(cls, d: dict, default_timeout: float = 120.0, default_temperature: float = 0.2) -> "LLMConfig":
@@ -63,6 +78,9 @@ class LLMConfig:
             api_key=d.get("api_key", ""),
             temperature=float(d.get("temperature", default_temperature)),
             timeout=float(d.get("timeout", default_timeout)),
+            provider=d.get("provider", ""),
+            http_referer=d.get("http_referer", ""),
+            app_title=d.get("app_title", "tv-calibration"),
         )
 
 

--- a/tests/test_llm_openrouter.py
+++ b/tests/test_llm_openrouter.py
@@ -1,0 +1,172 @@
+"""Tests for first-class OpenRouter support in LLMConfig (#272).
+
+Covers:
+  - LLMConfig.from_dict provider/header parsing + endpoint auto-fill
+  - _build_request provider-specific header injection
+  - probe_llm sending the same headers as a real call
+"""
+
+import unittest
+
+from calcore.llm import _build_request, probe_llm
+from calcore.models import LLMConfig
+
+
+def _headers(req) -> dict:
+    """Return request headers lower-cased for case-insensitive assertions."""
+    return {k.lower(): v for k, v in req.header_items()}
+
+
+class LLMConfigProviderTests(unittest.TestCase):
+    def test_defaults_have_empty_provider(self):
+        cfg = LLMConfig()
+        self.assertEqual(cfg.provider, "")
+        self.assertEqual(cfg.http_referer, "")
+        self.assertEqual(cfg.app_title, "tv-calibration")
+
+    def test_openrouter_autofills_endpoint(self):
+        cfg = LLMConfig(provider="openrouter", model="anthropic/claude-3-5-sonnet")
+        self.assertEqual(cfg.endpoint, "https://openrouter.ai/api/v1")
+
+    def test_explicit_endpoint_is_not_overridden(self):
+        cfg = LLMConfig(provider="openrouter", endpoint="http://localhost:4000/v1")
+        self.assertEqual(cfg.endpoint, "http://localhost:4000/v1")
+
+    def test_provider_is_normalised(self):
+        cfg = LLMConfig(provider="  OpenRouter ")
+        self.assertEqual(cfg.provider, "openrouter")
+        self.assertEqual(cfg.endpoint, "https://openrouter.ai/api/v1")
+
+    def test_unknown_provider_does_not_autofill(self):
+        cfg = LLMConfig(provider="litellm")
+        self.assertEqual(cfg.endpoint, "")
+
+    def test_from_dict_parses_provider_fields(self):
+        cfg = LLMConfig.from_dict(
+            {
+                "provider": "openrouter",
+                "model": "anthropic/claude-3-5-sonnet",
+                "api_key": "sk-or-test",
+                "http_referer": "https://github.com/jweber93/tv-calibration",
+                "app_title": "my-app",
+            }
+        )
+        self.assertEqual(cfg.provider, "openrouter")
+        self.assertEqual(cfg.endpoint, "https://openrouter.ai/api/v1")
+        self.assertEqual(cfg.http_referer, "https://github.com/jweber93/tv-calibration")
+        self.assertEqual(cfg.app_title, "my-app")
+
+    def test_from_dict_defaults_app_title(self):
+        cfg = LLMConfig.from_dict({"provider": "openrouter"})
+        self.assertEqual(cfg.app_title, "tv-calibration")
+
+
+class BuildRequestTests(unittest.TestCase):
+    URL = "https://openrouter.ai/api/v1/chat/completions"
+    BODY = {"model": "m", "messages": []}
+
+    def test_content_type_and_method(self):
+        req = _build_request(self.URL, self.BODY, LLMConfig())
+        self.assertEqual(req.get_method(), "POST")
+        self.assertEqual(_headers(req)["content-type"], "application/json")
+        self.assertEqual(req.full_url, self.URL)
+
+    def test_bearer_auth_when_key_present(self):
+        req = _build_request(self.URL, self.BODY, LLMConfig(api_key="sk-or-test"))
+        self.assertEqual(_headers(req)["authorization"], "Bearer sk-or-test")
+
+    def test_no_auth_header_without_key(self):
+        req = _build_request(self.URL, self.BODY, LLMConfig())
+        self.assertNotIn("authorization", _headers(req))
+
+    def test_openrouter_injects_referer_and_title(self):
+        cfg = LLMConfig(
+            provider="openrouter",
+            api_key="sk-or-test",
+            http_referer="https://example.com",
+            app_title="my-app",
+        )
+        h = _headers(_build_request(self.URL, self.BODY, cfg))
+        self.assertEqual(h["http-referer"], "https://example.com")
+        self.assertEqual(h["x-title"], "my-app")
+
+    def test_openrouter_title_falls_back_when_blank(self):
+        cfg = LLMConfig(provider="openrouter", app_title="")
+        h = _headers(_build_request(self.URL, self.BODY, cfg))
+        self.assertEqual(h["x-title"], "tv-calibration")
+
+    def test_openrouter_omits_referer_when_blank(self):
+        cfg = LLMConfig(provider="openrouter")
+        h = _headers(_build_request(self.URL, self.BODY, cfg))
+        self.assertNotIn("http-referer", h)
+        self.assertIn("x-title", h)
+
+    def test_generic_provider_has_no_openrouter_headers(self):
+        cfg = LLMConfig(api_key="sk-test", http_referer="https://example.com")
+        h = _headers(_build_request(self.URL, self.BODY, cfg))
+        self.assertNotIn("http-referer", h)
+        self.assertNotIn("x-title", h)
+
+
+class ProbeLlmHeaderTests(unittest.TestCase):
+    """probe_llm must send the same headers as a real call so it can't pass
+    while real calls fail (e.g. a bad HTTP-Referer hitting a blocklist)."""
+
+    def test_probe_builds_openrouter_headers(self):
+        captured = {}
+
+        def fake_urlopen(req, timeout=None):
+            captured["req"] = req
+            raise AssertionError("stop before network")
+
+        import calcore.llm as llm_mod
+
+        orig = llm_mod.urllib.request.urlopen
+        llm_mod.urllib.request.urlopen = fake_urlopen
+        try:
+            probe_llm(
+                {
+                    "provider": "openrouter",
+                    "model": "anthropic/claude-3-5-sonnet",
+                    "api_key": "sk-or-test",
+                    "http_referer": "https://example.com",
+                    "app_title": "probe-app",
+                }
+            )
+        finally:
+            llm_mod.urllib.request.urlopen = orig
+
+        h = _headers(captured["req"])
+        self.assertEqual(captured["req"].full_url, "https://openrouter.ai/api/v1/chat/completions")
+        self.assertEqual(h["authorization"], "Bearer sk-or-test")
+        self.assertEqual(h["http-referer"], "https://example.com")
+        self.assertEqual(h["x-title"], "probe-app")
+
+    def test_probe_requires_endpoint_and_model(self):
+        ok, err = probe_llm({"provider": "litellm"})
+        self.assertFalse(ok)
+        self.assertIn("required", err)
+
+    def test_probe_openrouter_autofills_endpoint_for_validation(self):
+        # provider=openrouter + model but no endpoint should pass the
+        # endpoint/model presence check (endpoint is auto-filled).
+        captured = {}
+
+        def fake_urlopen(req, timeout=None):
+            captured["req"] = req
+            raise AssertionError("stop before network")
+
+        import calcore.llm as llm_mod
+
+        orig = llm_mod.urllib.request.urlopen
+        llm_mod.urllib.request.urlopen = fake_urlopen
+        try:
+            probe_llm({"provider": "openrouter", "model": "m"})
+        finally:
+            llm_mod.urllib.request.urlopen = orig
+
+        self.assertIn("req", captured)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_llm_openrouter.py
+++ b/tests/test_llm_openrouter.py
@@ -7,6 +7,7 @@ Covers:
 """
 
 import unittest
+from unittest.mock import patch
 
 from calcore.llm import _build_request, probe_llm
 from calcore.models import LLMConfig
@@ -40,6 +41,10 @@ class LLMConfigProviderTests(unittest.TestCase):
     def test_unknown_provider_does_not_autofill(self):
         cfg = LLMConfig(provider="litellm")
         self.assertEqual(cfg.endpoint, "")
+
+    def test_litellm_provider_keeps_explicit_endpoint(self):
+        cfg = LLMConfig(provider="litellm", endpoint="http://localhost:4000/v1")
+        self.assertEqual(cfg.endpoint, "http://localhost:4000/v1")
 
     def test_from_dict_parses_provider_fields(self):
         cfg = LLMConfig.from_dict(
@@ -119,11 +124,7 @@ class ProbeLlmHeaderTests(unittest.TestCase):
             captured["req"] = req
             raise AssertionError("stop before network")
 
-        import calcore.llm as llm_mod
-
-        orig = llm_mod.urllib.request.urlopen
-        llm_mod.urllib.request.urlopen = fake_urlopen
-        try:
+        with patch("calcore.llm.urllib.request.urlopen", side_effect=fake_urlopen):
             probe_llm(
                 {
                     "provider": "openrouter",
@@ -133,8 +134,6 @@ class ProbeLlmHeaderTests(unittest.TestCase):
                     "app_title": "probe-app",
                 }
             )
-        finally:
-            llm_mod.urllib.request.urlopen = orig
 
         h = _headers(captured["req"])
         self.assertEqual(captured["req"].full_url, "https://openrouter.ai/api/v1/chat/completions")
@@ -156,14 +155,8 @@ class ProbeLlmHeaderTests(unittest.TestCase):
             captured["req"] = req
             raise AssertionError("stop before network")
 
-        import calcore.llm as llm_mod
-
-        orig = llm_mod.urllib.request.urlopen
-        llm_mod.urllib.request.urlopen = fake_urlopen
-        try:
+        with patch("calcore.llm.urllib.request.urlopen", side_effect=fake_urlopen):
             probe_llm({"provider": "openrouter", "model": "m"})
-        finally:
-            llm_mod.urllib.request.urlopen = orig
 
         self.assertIn("req", captured)
 


### PR DESCRIPTION
## Summary

Adds native OpenRouter support to `LLMConfig` so users can route LLM calls through [openrouter.ai](https://openrouter.ai) without a local LiteLLM proxy, and centralises the request-building boilerplate that was duplicated across ~7 call sites.

Closes #272

## Changes

### `calcore/models.py`
- New `LLMConfig` fields: `provider` (`"openrouter"` | `"litellm"` | `""`), `http_referer`, `app_title` (default `"tv-calibration"`).
- `__post_init__` normalises `provider` (trim + lowercase) and auto-fills the endpoint to `https://openrouter.ai/api/v1` when `provider == "openrouter"` and no endpoint is supplied. This runs for both direct construction (cli.py) and `from_dict`.
- `from_dict` parses the three new fields.

### `calcore/llm.py`
- New `_build_request(url, body, llm)` helper centralising the shared `POST` + `Content-Type` + `Bearer` boilerplate. For `provider == "openrouter"` it injects:
  - `HTTP-Referer` — per-app rate-limit attribution (only when `http_referer` is set)
  - `X-Title` — usage-dashboard display name (falls back to `tv-calibration`)
- Refactored all 7 request-building sites onto the helper: `call_llm`, `query_next_patch_strategy`, `query_remediation`, `query_gamut_advice`, `query_delta_summary`, `query_pass_decision`, `query_patch_optimization`.
- `probe_llm` now resolves its raw `dict` through `LLMConfig.from_dict` and uses `_build_request`, so the connection test sends the same headers as a real call (a passing probe can no longer mask a header-related failure such as an `HTTP-Referer` blocklist).

### Tests — `tests/test_llm_openrouter.py`
- `LLMConfig.from_dict` / provider parsing, endpoint auto-fill, provider normalisation, unknown-provider no-op.
- `_build_request` header injection: Bearer auth, OpenRouter `HTTP-Referer`/`X-Title`, blank-title fallback, omitted referer, and that generic providers get no OpenRouter headers.
- `probe_llm` header parity and endpoint/model validation (including the auto-fill path).

### `README.md`
- New "Direct OpenRouter (no proxy)" subsection documenting the config and the two provider headers.

## Scope notes

Per the issue's "Files affected" list, changes are limited to `calcore/models.py`, `calcore/llm.py`, and `tests/`. Server-side config gates (`server.py`) and UI/frontend wiring were left out of scope — the server already routes config through `LLMConfig.from_dict`, so an OpenRouter config that includes an explicit endpoint works today; wiring the provider-only (endpoint-omitted) case through the server's `configured` guards is a natural follow-up.

## Testing

- New `tests/test_llm_openrouter.py`: 17 tests, all passing.
- Full suite: `1069 passed, 2 skipped`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NcE6hvd3z55neveSGexSrU)_