### PR TITLE
[Bug] Fix debounce race allowing duplicate CSV imports (#267)

### DIFF
--- a/calibrator/file_watcher.py
+++ b/calibrator/file_watcher.py
@@ -359,7 +359,13 @@ class _ZROHandler(FileSystemEventHandler):
             self._importing.discard(src_path)
 
     def _do_import_file(self, src_path: str) -> None:
-        """Inner import logic — called from ``_import_file`` under the ``_importing`` guard."""
+        """Inner import logic — called from ``_import_file`` under the ``_importing`` guard.
+
+        Split out so ``_import_file`` can wrap this in ``try/finally`` and
+        guarantee ``_importing.discard(src_path)`` on every exit path (success,
+        error, or PermissionError retry).  Calling this directly would bypass
+        the cleanup.
+        """
         global _last_import, _watcher_error, _last_attempt
 
         # ── mtime dedup ───────────────────────────────────────────────────

--- a/calibrator/file_watcher.py
+++ b/calibrator/file_watcher.py
@@ -28,7 +28,7 @@ import queue
 import threading
 import time
 from datetime import datetime, timezone
-from typing import Callable, Dict, List, Optional
+from typing import Callable, Dict, List, Optional, Set
 
 try:
     from watchdog.events import FileSystemEvent, FileSystemEventHandler
@@ -280,6 +280,8 @@ class _ZROHandler(FileSystemEventHandler):
         self._timers: Dict[str, threading.Timer] = {}
         # path → mtime already imported
         self._imported: Dict[str, float] = {}
+        # paths currently being imported (prevents concurrent timers)
+        self._importing: Set[str] = set()
         self._timer_lock = threading.Lock()
         self._stopped = False
 
@@ -318,6 +320,11 @@ class _ZROHandler(FileSystemEventHandler):
         with self._timer_lock:
             if self._stopped:
                 return
+            # Skip scheduling if an import is already in-flight for this path.
+            # The in-flight import will handle the file; a new write event after
+            # it completes will trigger a fresh timer with an updated mtime.
+            if src_path in self._importing:
+                return
             # Cancel any pending timer for this path.
             existing = self._timers.get(src_path)
             if existing is not None:
@@ -339,13 +346,21 @@ class _ZROHandler(FileSystemEventHandler):
 
     def _import_file(self, src_path: str) -> None:
         """Called by the debounce timer — run the actual import."""
-        global _last_import, _watcher_error, _last_attempt
-
         if self._stopped:
             return
 
         with self._timer_lock:
             self._timers.pop(src_path, None)
+            self._importing.add(src_path)
+
+        try:
+            self._do_import_file(src_path)
+        finally:
+            self._importing.discard(src_path)
+
+    def _do_import_file(self, src_path: str) -> None:
+        """Inner import logic — called from ``_import_file`` under the ``_importing`` guard."""
+        global _last_import, _watcher_error, _last_attempt
 
         # ── mtime dedup ───────────────────────────────────────────────────
         try:
@@ -363,6 +378,8 @@ class _ZROHandler(FileSystemEventHandler):
                         "status": "locked",
                         "detail": str(exc),
                     }
+                with self._timer_lock:
+                    self._importing.discard(src_path)
                 self._schedule_timer(src_path, LOCKED_FILE_RETRY_SECONDS)
                 return
             logger.warning("OSError accessing mtime for %s: %s", src_path, exc)
@@ -421,6 +438,7 @@ class _ZROHandler(FileSystemEventHandler):
             # Release the optimistic claim so the retry timer can proceed.
             with self._timer_lock:
                 self._imported.pop(src_path, None)
+                self._importing.discard(src_path)
             self._schedule_timer(src_path, LOCKED_FILE_RETRY_SECONDS)
             return
         except Exception as exc:

--- a/tests/test_file_watcher.py
+++ b/tests/test_file_watcher.py
@@ -373,6 +373,45 @@ class TestDebounce:
 
         assert session["pre_measurements"] == []
 
+    def test_importing_flag_prevents_scheduling_duplicate_timer(self, tmp_path):
+        """_importing guard in _schedule_timer skips scheduling while import runs."""
+        import threading
+
+        session = _make_session()
+        handler = fw._ZROHandler(lambda: session, lambda: None)
+        csv_file = tmp_path / "race.csv"
+        csv_file.write_text(MINIMAL_ZRO_CSV)
+
+        gate = threading.Event()
+
+        def slow_import(src_path):
+            gate.wait(timeout=5.0)
+
+        with patch.object(handler, "_do_import_file", side_effect=slow_import):
+            t1 = threading.Thread(target=handler._import_file, args=(str(csv_file),))
+            t1.start()
+
+            # Wait until the import is in-flight.
+            deadline = time.monotonic() + 2.0
+            while str(csv_file) not in handler._importing:
+                time.sleep(0.01)
+                if time.monotonic() > deadline:
+                    pytest.fail("Timed out waiting for _importing flag")
+
+            # _schedule_timer should be a no-op while _importing is set.
+            handler._schedule_timer(str(csv_file), fw.DEBOUNCE_SECONDS)
+
+            gate.set()
+            t1.join(timeout=5.0)
+
+        # No timer should have been created (was skipped because _importing).
+        assert str(csv_file) not in handler._timers, (
+            "_schedule_timer should not create a timer while _importing is set"
+        )
+        assert str(csv_file) not in handler._importing, (
+            "_importing flag should be cleared after import completes"
+        )
+
 
 class TestDuplicateSuppression:
     def test_same_mtime_not_reimported(self, tmp_path):

--- a/tests/test_file_watcher.py
+++ b/tests/test_file_watcher.py
@@ -412,6 +412,39 @@ class TestDebounce:
             "_importing flag should be cleared after import completes"
         )
 
+    def test_schedule_timer_works_after_guard_clears(self, tmp_path):
+        """_schedule_timer creates a timer once _importing is cleared."""
+        import threading
+
+        session = _make_session()
+        handler = fw._ZROHandler(lambda: session, lambda: None)
+        csv_file = tmp_path / "guard-clear.csv"
+        csv_file.write_text(MINIMAL_ZRO_CSV)
+
+        gate = threading.Event()
+
+        def slow_import(src_path):
+            gate.wait(timeout=5.0)
+
+        with patch.object(handler, "_do_import_file", side_effect=slow_import):
+            t1 = threading.Thread(target=handler._import_file, args=(str(csv_file),))
+            t1.start()
+
+            deadline = time.monotonic() + 2.0
+            while str(csv_file) not in handler._importing:
+                time.sleep(0.01)
+                if time.monotonic() > deadline:
+                    pytest.fail("Timed out waiting for _importing flag")
+
+            gate.set()
+            t1.join(timeout=5.0)
+
+        # Guard is clear — _schedule_timer should now create a timer.
+        handler._schedule_timer(str(csv_file), fw.DEBOUNCE_SECONDS)
+        assert str(csv_file) in handler._timers, (
+            "_schedule_timer should create a timer once _importing is cleared"
+        )
+
 
 class TestDuplicateSuppression:
     def test_same_mtime_not_reimported(self, tmp_path):


### PR DESCRIPTION
## Summary

Adds a per-path `_importing` guard to prevent duplicate CSV imports when ZRO writes in rapid increments on Windows.

## Root Cause

The TOCTOU gap between `_schedule_timer` creating a new timer and `_import_file` setting `self._imported[src_path]` allowed a second timer to fire and re-import the same data before the first import completed its optimistic mtime claim.

## Fix

- `_importing: Set[str]` tracks paths with an in-flight import
- `_schedule_timer` skips scheduling if `src_path in _importing`
- `_import_file` wraps `_do_import_file` in `try/finally` so `_importing.discard(src_path)` runs on every exit path (success, error, PermissionError retry)

## Test

Added `test_importing_flag_prevents_scheduling_duplicate_timer` that verifies `_schedule_timer` is a no-op while `_importing` is set.

## Verification

- All 37 existing tests pass (33 in `test_file_watcher.py`, 4 in `test_file_watcher_resilience.py`)
- New test passes

Closes #267
