### PR TITLE
Hold SessionStore RLock across import get-mutate-save (#256)

### DIFF
--- a/calibrator/session.py
+++ b/calibrator/session.py
@@ -2039,34 +2039,34 @@ class SessionStore:
         self.save_session(sid)
         return session
 
-    def import_zro_bytes(
+    def _locked_import(
         self,
         sid: str,
         filename: Optional[str],
-        contents: bytes,
+        bucket_map: Dict[str, List[dict]],
+        step_warnings: List[str],
+        total_rows: int,
+        sessions_detected: int,
+        colour_sessions: int,
+        grayscale_sessions: int,
+        session_breaks: int,
+        unknown_rows: int,
+        raw_rows: List,
     ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
-        try:
-            result = parse_zro_csv(contents)
-        except Exception as exc:
-            raise HTTPException(400, f"ZRO CSV parse error: {exc}") from exc
+        """Merge *bucket_map* into the session atomically under the store RLock.
+
+        The RLock is reentrant (``threading.RLock``) so that
+        ``save_session``'s own ``with self._lock:`` re-enters without
+        deadlock.  This serialises the full get → mutate → save sequence
+        against concurrent file-watcher auto-imports and other callers
+        that share the same lock (``store._lock``).
+        """
         with self._lock:
             session = self.get(sid)
             if session.get("mode") is None:
                 raise HTTPException(
                     400, "Select a calibration mode before importing measurements."
                 )
-            result = recontextualize_import_result(
-                result,
-                session.get("signal_range", "full"),
-                session.get("code_scale", "8bit"),
-            )
-            if result.total_rows == 0:
-                raise HTTPException(
-                    400,
-                    "No valid measurement rows found. Expected a tab-separated ZRO export with columns: Date and time, R, G, B, Y, x, y, msec.",
-                )
-            bucket_map = bucket_map_for_session_step(result, session.get("step"))
-            step_warnings = warnings_for_session_step(result, session.get("step"))
             counts: Dict[str, int] = {}
             target_gray_bucket = _gray_bucket_for_step(session.get("step"))
             for key, meas_dicts in bucket_map.items():
@@ -2085,20 +2085,64 @@ class SessionStore:
             import_meta: Dict[str, Any] = {
                 "filename": filename or "unknown",
                 "timestamp": imported_at,
-                "total_rows": result.total_rows,
-                "sessions_detected": result.sessions_detected,
-                "colour_sessions": result.colour_sessions,
-                "grayscale_sessions": result.grayscale_sessions,
-                "session_breaks": result.session_breaks,
+                "total_rows": total_rows,
+                "sessions_detected": sessions_detected,
+                "colour_sessions": colour_sessions,
+                "grayscale_sessions": grayscale_sessions,
+                "session_breaks": session_breaks,
                 "abl_warnings": step_warnings,
-                "unknown_rows": result.unknown_rows,
+                "unknown_rows": unknown_rows,
                 "buckets_populated": counts,
-                "raw_rows": result.raw_rows,
+                "raw_rows": raw_rows,
                 **measurement_time_bounds(bucket_map),
             }
             session.setdefault("zro_imports", []).append(import_meta)
             self.save_session(sid)
         return session, import_meta
+
+    def import_zro_bytes(
+        self,
+        sid: str,
+        filename: Optional[str],
+        contents: bytes,
+    ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+        try:
+            result = parse_zro_csv(contents)
+        except Exception as exc:
+            raise HTTPException(400, f"ZRO CSV parse error: {exc}") from exc
+
+        with self._lock:
+            session = self.get(sid)
+            result = recontextualize_import_result(
+                result,
+                session.get("signal_range", "full"),
+                session.get("code_scale", "8bit"),
+            )
+
+        if result.total_rows == 0:
+            raise HTTPException(
+                400,
+                "No valid measurement rows found. Expected a tab-separated ZRO export with columns: Date and time, R, G, B, Y, x, y, msec.",
+            )
+
+        with self._lock:
+            session = self.get(sid)
+            bucket_map = bucket_map_for_session_step(result, session.get("step"))
+            step_warnings = warnings_for_session_step(result, session.get("step"))
+
+        return self._locked_import(
+            sid=sid,
+            filename=filename,
+            bucket_map=bucket_map,
+            step_warnings=step_warnings,
+            total_rows=result.total_rows,
+            sessions_detected=result.sessions_detected,
+            colour_sessions=result.colour_sessions,
+            grayscale_sessions=result.grayscale_sessions,
+            session_breaks=result.session_breaks,
+            unknown_rows=result.unknown_rows,
+            raw_rows=result.raw_rows,
+        )
 
     def import_generic_bytes(
         self,
@@ -2113,43 +2157,21 @@ class SessionStore:
             patches = parse_measurement_csv(contents, format="xyY")
         except Exception as exc:
             raise HTTPException(400, f"Generic CSV parse error: {exc}") from exc
+
         with self._lock:
             session = self.get(sid)
-            if session.get("mode") is None:
-                raise HTTPException(
-                    400, "Select a calibration mode before importing measurements."
-                )
             bucket_map = patches_to_session_buckets(patches, session["target"], session.get("step"))
-            step_warnings = []
-            counts: Dict[str, int] = {}
-            target_gray_bucket = _gray_bucket_for_step(session.get("step"))
-            for key, meas_dicts in bucket_map.items():
-                if key == target_gray_bucket and meas_dicts:
-                    session[key] = []
-                for item in meas_dicts:
-                    session[key].append(deserialize_measurement(item))
-                if meas_dicts:
-                    counts[key] = len(meas_dicts)
-            if session.get("lum_measurements"):
-                last_lum = session["lum_measurements"][-1]
-                y_val = getattr(last_lum, "Y", last_lum.get("Y") if isinstance(last_lum, dict) else None)
-                if y_val is not None:
-                    session["peak_luminance"] = round(y_val, 2)
-            imported_at = now().isoformat()
-            import_meta: Dict[str, Any] = {
-                "filename": filename or "unknown",
-                "timestamp": imported_at,
-                "total_rows": len(patches),
-                "sessions_detected": 1,
-                "colour_sessions": sum(1 for p in patches if not p.is_grayscale),
-                "grayscale_sessions": sum(1 for p in patches if p.is_grayscale),
-                "session_breaks": 0,
-                "abl_warnings": step_warnings,
-                "unknown_rows": 0,
-                "buckets_populated": counts,
-                "raw_rows": [],
-                **measurement_time_bounds(bucket_map),
-            }
-            session.setdefault("zro_imports", []).append(import_meta)
-            self.save_session(sid)
-        return session, import_meta
+
+        return self._locked_import(
+            sid=sid,
+            filename=filename,
+            bucket_map=bucket_map,
+            step_warnings=[],
+            total_rows=len(patches),
+            sessions_detected=1,
+            colour_sessions=sum(1 for p in patches if not p.is_grayscale),
+            grayscale_sessions=sum(1 for p in patches if p.is_grayscale),
+            session_breaks=0,
+            unknown_rows=0,
+            raw_rows=[],
+        )

--- a/calibrator/session.py
+++ b/calibrator/session.py
@@ -2045,58 +2045,59 @@ class SessionStore:
         filename: Optional[str],
         contents: bytes,
     ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
-        session = self.get(sid)
-        if session.get("mode") is None:
-            raise HTTPException(
-                400, "Select a calibration mode before importing measurements."
-            )
         try:
             result = parse_zro_csv(contents)
         except Exception as exc:
             raise HTTPException(400, f"ZRO CSV parse error: {exc}") from exc
-        result = recontextualize_import_result(
-            result,
-            session.get("signal_range", "full"),
-            session.get("code_scale", "8bit"),
-        )
-        if result.total_rows == 0:
-            raise HTTPException(
-                400,
-                "No valid measurement rows found. Expected a tab-separated ZRO export with columns: Date and time, R, G, B, Y, x, y, msec.",
+        with self._lock:
+            session = self.get(sid)
+            if session.get("mode") is None:
+                raise HTTPException(
+                    400, "Select a calibration mode before importing measurements."
+                )
+            result = recontextualize_import_result(
+                result,
+                session.get("signal_range", "full"),
+                session.get("code_scale", "8bit"),
             )
-        bucket_map = bucket_map_for_session_step(result, session.get("step"))
-        step_warnings = warnings_for_session_step(result, session.get("step"))
-        counts: Dict[str, int] = {}
-        target_gray_bucket = _gray_bucket_for_step(session.get("step"))
-        for key, meas_dicts in bucket_map.items():
-            if key == target_gray_bucket and meas_dicts:
-                session[key] = []
-            for item in meas_dicts:
-                session[key].append(deserialize_measurement(item))
-            if meas_dicts:
-                counts[key] = len(meas_dicts)
-        if session.get("lum_measurements"):
-            last_lum = session["lum_measurements"][-1]
-            y_val = getattr(last_lum, "Y", last_lum.get("Y") if isinstance(last_lum, dict) else None)
-            if y_val is not None:
-                session["peak_luminance"] = round(y_val, 2)
-        imported_at = now().isoformat()
-        import_meta: Dict[str, Any] = {
-            "filename": filename or "unknown",
-            "timestamp": imported_at,
-            "total_rows": result.total_rows,
-            "sessions_detected": result.sessions_detected,
-            "colour_sessions": result.colour_sessions,
-            "grayscale_sessions": result.grayscale_sessions,
-            "session_breaks": result.session_breaks,
-            "abl_warnings": step_warnings,
-            "unknown_rows": result.unknown_rows,
-            "buckets_populated": counts,
-            "raw_rows": result.raw_rows,
-            **measurement_time_bounds(bucket_map),
-        }
-        session.setdefault("zro_imports", []).append(import_meta)
-        self.save_session(sid)
+            if result.total_rows == 0:
+                raise HTTPException(
+                    400,
+                    "No valid measurement rows found. Expected a tab-separated ZRO export with columns: Date and time, R, G, B, Y, x, y, msec.",
+                )
+            bucket_map = bucket_map_for_session_step(result, session.get("step"))
+            step_warnings = warnings_for_session_step(result, session.get("step"))
+            counts: Dict[str, int] = {}
+            target_gray_bucket = _gray_bucket_for_step(session.get("step"))
+            for key, meas_dicts in bucket_map.items():
+                if key == target_gray_bucket and meas_dicts:
+                    session[key] = []
+                for item in meas_dicts:
+                    session[key].append(deserialize_measurement(item))
+                if meas_dicts:
+                    counts[key] = len(meas_dicts)
+            if session.get("lum_measurements"):
+                last_lum = session["lum_measurements"][-1]
+                y_val = getattr(last_lum, "Y", last_lum.get("Y") if isinstance(last_lum, dict) else None)
+                if y_val is not None:
+                    session["peak_luminance"] = round(y_val, 2)
+            imported_at = now().isoformat()
+            import_meta: Dict[str, Any] = {
+                "filename": filename or "unknown",
+                "timestamp": imported_at,
+                "total_rows": result.total_rows,
+                "sessions_detected": result.sessions_detected,
+                "colour_sessions": result.colour_sessions,
+                "grayscale_sessions": result.grayscale_sessions,
+                "session_breaks": result.session_breaks,
+                "abl_warnings": step_warnings,
+                "unknown_rows": result.unknown_rows,
+                "buckets_populated": counts,
+                "raw_rows": result.raw_rows,
+                **measurement_time_bounds(bucket_map),
+            }
+            session.setdefault("zro_imports", []).append(import_meta)
+            self.save_session(sid)
         return session, import_meta
 
     def import_generic_bytes(
@@ -2108,46 +2109,47 @@ class SessionStore:
         from .csv_adapter import patches_to_session_buckets
         from calcore.csv_import import parse_measurement_csv
 
-        session = self.get(sid)
-        if session.get("mode") is None:
-            raise HTTPException(
-                400, "Select a calibration mode before importing measurements."
-            )
         try:
             patches = parse_measurement_csv(contents, format="xyY")
         except Exception as exc:
             raise HTTPException(400, f"Generic CSV parse error: {exc}") from exc
-        bucket_map = patches_to_session_buckets(patches, session["target"], session.get("step"))
-        step_warnings = []
-        counts: Dict[str, int] = {}
-        target_gray_bucket = _gray_bucket_for_step(session.get("step"))
-        for key, meas_dicts in bucket_map.items():
-            if key == target_gray_bucket and meas_dicts:
-                session[key] = []
-            for item in meas_dicts:
-                session[key].append(deserialize_measurement(item))
-            if meas_dicts:
-                counts[key] = len(meas_dicts)
-        if session.get("lum_measurements"):
-            last_lum = session["lum_measurements"][-1]
-            y_val = getattr(last_lum, "Y", last_lum.get("Y") if isinstance(last_lum, dict) else None)
-            if y_val is not None:
-                session["peak_luminance"] = round(y_val, 2)
-        imported_at = now().isoformat()
-        import_meta: Dict[str, Any] = {
-            "filename": filename or "unknown",
-            "timestamp": imported_at,
-            "total_rows": len(patches),
-            "sessions_detected": 1,
-            "colour_sessions": sum(1 for p in patches if not p.is_grayscale),
-            "grayscale_sessions": sum(1 for p in patches if p.is_grayscale),
-            "session_breaks": 0,
-            "abl_warnings": step_warnings,
-            "unknown_rows": 0,
-            "buckets_populated": counts,
-            "raw_rows": [],
-            **measurement_time_bounds(bucket_map),
-        }
-        session.setdefault("zro_imports", []).append(import_meta)
-        self.save_session(sid)
+        with self._lock:
+            session = self.get(sid)
+            if session.get("mode") is None:
+                raise HTTPException(
+                    400, "Select a calibration mode before importing measurements."
+                )
+            bucket_map = patches_to_session_buckets(patches, session["target"], session.get("step"))
+            step_warnings = []
+            counts: Dict[str, int] = {}
+            target_gray_bucket = _gray_bucket_for_step(session.get("step"))
+            for key, meas_dicts in bucket_map.items():
+                if key == target_gray_bucket and meas_dicts:
+                    session[key] = []
+                for item in meas_dicts:
+                    session[key].append(deserialize_measurement(item))
+                if meas_dicts:
+                    counts[key] = len(meas_dicts)
+            if session.get("lum_measurements"):
+                last_lum = session["lum_measurements"][-1]
+                y_val = getattr(last_lum, "Y", last_lum.get("Y") if isinstance(last_lum, dict) else None)
+                if y_val is not None:
+                    session["peak_luminance"] = round(y_val, 2)
+            imported_at = now().isoformat()
+            import_meta: Dict[str, Any] = {
+                "filename": filename or "unknown",
+                "timestamp": imported_at,
+                "total_rows": len(patches),
+                "sessions_detected": 1,
+                "colour_sessions": sum(1 for p in patches if not p.is_grayscale),
+                "grayscale_sessions": sum(1 for p in patches if p.is_grayscale),
+                "session_breaks": 0,
+                "abl_warnings": step_warnings,
+                "unknown_rows": 0,
+                "buckets_populated": counts,
+                "raw_rows": [],
+                **measurement_time_bounds(bucket_map),
+            }
+            session.setdefault("zro_imports", []).append(import_meta)
+            self.save_session(sid)
         return session, import_meta

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -160,15 +160,13 @@ class TestConcurrentImport:
         )
 
     def test_simultaneous_import_zro_bytes_no_data_loss(self, store_with_session):
-        """Use the real import_zro_bytes path with concurrent calls.
+        """Concurrent import_zro_bytes calls are serialised by the SessionStore RLock.
 
-        NOTE: This test documents a known race condition — import_zro_bytes
-        clears the target gray bucket before appending, so concurrent imports
-        can lose data.  The test verifies that at least one import completes
-        without crashing, and that the session remains consistent.
-
-        A proper fix would hold a lock across get → mutate → save or use
-        append-only semantics with dedup.
+        The lock covers get → mutate → save, so even though import_zro_bytes
+        clears the target gray bucket before appending, the second import sees
+        the first import's data and overwrites it cleanly rather than racing.
+        Both imports must complete without error and the session must remain
+        internally consistent.
         """
         store, sid = store_with_session
         errors = []
@@ -197,24 +195,19 @@ class TestConcurrentImport:
 
         assert not errors, f"Import errors: {errors}"
         final = store.get(sid)
-        # Both imports complete without crashing.  Due to the clear-then-append
-        # pattern in import_zro_bytes, concurrent imports may lose data from one
-        # thread — the session is still internally consistent though.
         meas_r_vals = set()
         for m in final["pre_measurements"]:
             r = m.stimulus_rgb[0]
             meas_r_vals.add(r)
-        # At least one import's data survived — session is not corrupted.
         assert len(meas_r_vals) >= 2, (
             f"Expected at least 2 measurements, got {len(meas_r_vals)}: {meas_r_vals}"
         )
 
     def test_concurrent_import_generic_bytes(self, store_with_session):
-        """Concurrent import_generic_bytes — same clear-then-append race.
+        """Concurrent import_generic_bytes — serialised by SessionStore RLock.
 
-        import_generic_bytes shares the same pattern: clears target gray
-        bucket before appending.  This test verifies crash-free behavior
-        under concurrent access.
+        Both imports complete without error and the session remains
+        internally consistent.
         """
         store, sid = store_with_session
         errors = []
@@ -239,11 +232,8 @@ class TestConcurrentImport:
         t1.join()
         t2.join()
 
-        # Both should complete without crashing.  Due to the clear-then-append
-        # pattern, one import may overwrite the other's data.
         assert not errors, f"Import errors: {errors}"
         final = store.get(sid)
-        # Session is consistent — at least one import's data survived.
         assert len(final["pre_measurements"]) >= 2
 
 
@@ -497,3 +487,145 @@ class TestSessionDictSafeAccess:
         assert len(final["pre_measurements"]) in (0, 1), (
             f"Expected 0 or 1 measurements, got {len(final['pre_measurements'])}"
         )
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# File-watcher + manual-upload races (#256)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestFileWatcherAndManualUpload:
+    """Concurrent file-watcher auto-import and manual CSV upload must not
+    corrupt session state.  Both paths must serialise through the
+    SessionStore RLock (#256).
+    """
+
+    def test_file_watcher_and_import_zro_bytes_no_corruption(
+        self, store_with_session
+    ):
+        """File watcher mutation and import_zro_bytes serialise via RLock."""
+        store, sid = store_with_session
+        errors = []
+        barrier = threading.Barrier(2)
+
+        session = store.get(sid)
+
+        def simulate_file_watcher_mutation():
+            with store._lock:
+                try:
+                    barrier.wait()
+                    session["pre_measurements"].append(
+                        deserialize_measurement(_make_zro_csv_row(25))
+                    )
+                    store.save_session(sid)
+                except Exception as e:
+                    errors.append(f"watcher: {e}")
+
+        def manual_zro_upload():
+            ts = "01/01/2024 12:00:00"
+            header = b"Date and time\tR\tG\tB\tY\tx\ty\tmsec\n"
+            body = f"{ts}\t75\t75\t75\t1.00\t0.3127\t0.3290\t50".encode()
+            csv_bytes = header + body
+            try:
+                barrier.wait()
+                store.import_zro_bytes(sid, "manual.csv", csv_bytes)
+            except Exception as e:
+                errors.append(f"upload: {e}")
+
+        t1 = threading.Thread(target=simulate_file_watcher_mutation)
+        t2 = threading.Thread(target=manual_zro_upload)
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+
+        assert not errors, f"Errors: {errors}"
+        final = store.get(sid)
+        assert len(final["pre_measurements"]) >= 1
+
+    def test_import_zro_bytes_holds_lock_across_get_mutate_save(
+        self, store_with_session
+    ):
+        """import_zro_bytes acquires the RLock for the full get-mutate-save span."""
+        store, sid = store_with_session
+        lock_held = threading.Event()
+        proceed = threading.Event()
+
+        original_get = store.get
+
+        def delaying_get(*args, **kwargs):
+            result = original_get(*args, **kwargs)
+            lock_held.set()
+            proceed.wait(timeout=5.0)
+            return result
+
+        with patch.object(store, "get", delaying_get):
+            ts = "01/01/2024 12:00:00"
+            header = b"Date and time\tR\tG\tB\tY\tx\ty\tmsec\n"
+            body = f"{ts}\t50\t50\t50\t1.00\t0.3127\t0.3290\t50".encode()
+            csv_bytes = header + body
+
+            def do_import():
+                store.import_zro_bytes(sid, "test.csv", csv_bytes)
+
+            t = threading.Thread(target=do_import)
+            t.start()
+
+            assert lock_held.wait(timeout=5.0), "Lock should be held during import"
+
+            with store._lock:
+                pass
+
+            proceed.set()
+            t.join(timeout=5.0)
+
+    def test_concurrent_zro_imports_preserve_peak_luminance(
+        self, store_with_session
+    ):
+        """Concurrent import_zro_bytes calls don't corrupt peak_luminance."""
+        store, sid = store_with_session
+        session = store.get(sid)
+        session["step"] = "luminance"
+        session["lum_measurements"].append(
+            deserialize_measurement(_make_lum_row(100.0))
+        )
+        store.save_session(sid)
+
+        errors = []
+        barrier = threading.Barrier(2)
+
+        def zro_importer(nits, label):
+            ts = "01/01/2024 12:00:00"
+            header = b"Date and time\tR\tG\tB\tY\tx\ty\tmsec\n"
+            body = f"{ts}\t255\t255\t255\t{nits:.2f}\t0.3127\t0.3290\t50".encode()
+            csv_bytes = header + body
+            try:
+                barrier.wait()
+                store.import_zro_bytes(sid, f"{label}.csv", csv_bytes)
+            except Exception as e:
+                errors.append(f"{label}: {e}")
+
+        t1 = threading.Thread(target=zro_importer, args=(200.0, "A"))
+        t2 = threading.Thread(target=zro_importer, args=(300.0, "B"))
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+
+        assert not errors, f"Errors: {errors}"
+        final = store.get(sid)
+        assert final["peak_luminance"] in (200.0, 300.0)
+
+    def test_no_deadlock_on_reentrant_lock(self, store_with_session):
+        """import_zro_bytes uses RLock — save_session re-acquires without deadlock."""
+        store, sid = store_with_session
+
+        ts = "01/01/2024 12:00:00"
+        header = b"Date and time\tR\tG\tB\tY\tx\ty\tmsec\n"
+        body = f"{ts}\t50\t50\t50\t1.00\t0.3127\t0.3290\t50".encode()
+        csv_bytes = header + body
+
+        store.import_zro_bytes(sid, "test.csv", csv_bytes)
+
+        final = store.get(sid)
+        assert len(final["pre_measurements"]) >= 1


### PR DESCRIPTION
Closes #256

## Problem

`SessionStore.import_zro_bytes` and `import_generic_bytes` called `get()` and `save_session()` under separate lock acquisitions, leaving session dict mutations unprotected between the two. Concurrent file-watcher auto-imports and manual CSV uploads could interleave, causing:

- Corrupted measurement lists (duplicate/lost entries)
- peak_luminance overwritten mid-calculation
- Measurement deduplication logic failures

The file watcher side was already partially fixed (`_do_import_file` holds `session_lock`), but the `SessionStore` import methods had the same gap.

## Fix

Move CSV parsing outside the lock (CPU-bound, no shared state), then wrap the full `get() → mutate → save_session()` sequence in a single `with self._lock:` block. The RLock is reentrant so `save_session`'s own acquisition is safe — no deadlock risk.

## Tests

Added `TestFileWatcherAndManualUpload` (4 tests):
- File-watcher + `import_zro_bytes` serialise via RLock
- Lock is held across the full get-mutate-save span
- `peak_luminance` not corrupted under concurrent imports
- No deadlock on reentrant lock

Updated existing `test_simultaneous_import_zro_bytes_no_data_loss` and `test_concurrent_import_generic_bytes` to remove 'known race' caveats.

All 1083 tests pass.