### PR TITLE
Add PredictedSettingsCard for LLM warm-start display (#336)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -51,7 +51,7 @@ import { AppShell }     from './components/AppShell';
 export default function App() {
   const sess = useSession();
   const { session, profiles, watchStatus, watchDefaultPath, bridgeStatus, bridgeUrl, dogegenStatus, adbStatus, loading,
-          llmInsight, llmStreaming, llmError, dismissLlmInsight, saveTvSettings, getSuggestedPatches, runSuggestedPatches } = sess;
+          llmInsight, llmStreaming, llmError, dismissLlmInsight, saveTvSettings, getSuggestedPatches, runSuggestedPatches, getPredictedSettings } = sess;
   const [showStartOver, setShowStartOver] = useState(false);
   const [showComparison, setShowComparison] = useState(false);
 
@@ -96,9 +96,9 @@ export default function App() {
       case 'prepare':        return <Prepare       {...stepProps} onConfirmPrepared={sess.confirmPrepared} onSetLightspaceTier={sess.setLightspaceTier} onSetGrayscaleRamp={sess.setGrayscaleRamp} onSetSignalRange={sess.setSignalRange} onSetCodeScale={sess.setCodeScale} onSetPatternGenerator={sess.setPatternGenerator} onConfigureLlm={sess.configureLlm} onGetLlmStatus={sess.getLlmStatus} />;
       case 'pre_grayscale':  return <PreGrayscale  {...stepProps} />;
       case 'luminance':      return <Luminance     {...stepProps} adbStatus={adbStatus} onAdbSetPicture={sess.adbSetPicture} onAdbGetPicture={sess.adbGetPicture} onAdbDeploy={sess.adbDeploy} onRefreshAdb={sess.refreshAdbStatus} />;
-      case 'white_balance':  return <WhiteBalance  {...stepProps} />;
-      case 'gamma':          return <Gamma         {...stepProps} onSetGammaWorkflow={sess.setGammaWorkflow} />;
-      case 'color_tuner':    return <ColorTuner    {...stepProps} adbStatus={adbStatus} onAdbApply={sess.adbApply} onAdbReset={sess.adbReset} onAdbDeploy={sess.adbDeploy} onRefreshAdb={sess.refreshAdbStatus} />;
+      case 'white_balance':  return <WhiteBalance  {...stepProps} getPredictedSettings={getPredictedSettings} />;
+      case 'gamma':          return <Gamma         {...stepProps} onSetGammaWorkflow={sess.setGammaWorkflow} getPredictedSettings={getPredictedSettings} />;
+      case 'color_tuner':    return <ColorTuner    {...stepProps} adbStatus={adbStatus} onAdbApply={sess.adbApply} onAdbReset={sess.adbReset} onAdbDeploy={sess.adbDeploy} onRefreshAdb={sess.refreshAdbStatus} getPredictedSettings={getPredictedSettings} />;
       case 'post_grayscale': return <PostGrayscale {...stepProps} />;
       case 'suggested_patches': return <SuggestedPatches {...stepProps} getSuggestedPatches={getSuggestedPatches} runSuggestedPatches={runSuggestedPatches} />;
       case 'report':         return <Report        session={session} onPrev={sess.prevStep} />;

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -131,6 +131,13 @@ export const api = {
   runSuggestedPatches: (sid, patches) =>
     api.post(`/api/session/${sid}/suggested-patches/run`, { patches }),
 
+  // Predicted starting settings (#336)
+  getPredictedSettings: (sid, phase) => {
+    const url = new URL(`/api/session/${sid}/predicted-settings`, window.location.origin);
+    if (phase) url.searchParams.set('phase', phase);
+    return api.get(url.toString());
+  },
+
   // OSD Command Translator (#167)
   translateOsd: (sid, plan) =>
     api.post(`/api/session/${sid}/osd/translate`, { plan }),

--- a/frontend/src/components/PredictedSettingsCard.jsx
+++ b/frontend/src/components/PredictedSettingsCard.jsx
@@ -8,7 +8,7 @@ export function PredictedSettingsCard({ getPredictedSettings, phase }) {
   useEffect(() => {
     let cancelled = false;
     setLoading(true);
-    getPredictedSettings(phase)
+    Promise.resolve(getPredictedSettings ? getPredictedSettings(phase) : null)
       .then((res) => {
         if (!cancelled) setData(res);
       })
@@ -75,8 +75,8 @@ export function PredictedSettingsCard({ getPredictedSettings, phase }) {
       </div>
       <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.82rem' }}>
         <tbody>
-          {settings.map((s, i) => (
-            <tr key={i} style={{ borderBottom: '1px solid var(--border-subtle, rgba(255,255,255,0.06))' }}>
+          {settings.map((s) => (
+            <tr key={`${s.menu}:${s.setting}`} style={{ borderBottom: '1px solid var(--border-subtle, rgba(255,255,255,0.06))' }}>
               <td style={{ padding: '7px 0', color: 'var(--ink2)', whiteSpace: 'nowrap' }}>
                 {s.menu} › {s.setting}
               </td>

--- a/frontend/src/components/PredictedSettingsCard.jsx
+++ b/frontend/src/components/PredictedSettingsCard.jsx
@@ -1,0 +1,97 @@
+import { useState, useEffect } from 'react';
+import { Card } from './Card';
+
+export function PredictedSettingsCard({ getPredictedSettings, phase }) {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    getPredictedSettings(phase)
+      .then((res) => {
+        if (!cancelled) setData(res);
+      })
+      .catch(() => {
+        if (!cancelled) setData(null);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, [getPredictedSettings, phase]);
+
+  if (loading) return null;
+
+  if (!data || !data.predicted) {
+    const reason = data?.reason || 'Prediction unavailable.';
+    return (
+      <Card title="Predicted Starting Point" style={{ marginBottom: 16 }}>
+        <div style={{ fontSize: '0.82rem', color: 'var(--ink2)', fontStyle: 'italic' }}>
+          {reason}
+        </div>
+      </Card>
+    );
+  }
+
+  const { predicted } = data;
+  const { settings, confidence, source } = predicted;
+
+  if (source === 'cold_start' || !settings || settings.length === 0) {
+    return (
+      <Card title="Predicted Starting Point" style={{ marginBottom: 16 }}>
+        <div style={{ fontSize: '0.82rem', color: 'var(--ink2)', fontStyle: 'italic' }}>
+          No prior data for this TV — measuring from defaults.
+        </div>
+      </Card>
+    );
+  }
+
+  const confidencePct = Math.round((confidence ?? 0) * 100);
+
+  return (
+    <Card title="Predicted Starting Point" style={{ marginBottom: 16 }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 10 }}>
+        <span style={{
+          fontSize: '0.7rem',
+          fontWeight: 700,
+          letterSpacing: '0.08em',
+          textTransform: 'uppercase',
+          color: 'var(--ink2)',
+        }}>
+          From history
+        </span>
+        <span style={{
+          marginLeft: 'auto',
+          fontSize: '0.72rem',
+          fontWeight: 600,
+          color: 'var(--accent)',
+          padding: '2px 8px',
+          border: '1px solid var(--accent)',
+          borderRadius: 10,
+        }}>
+          {confidencePct}% confidence
+        </span>
+      </div>
+      <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.82rem' }}>
+        <tbody>
+          {settings.map((s, i) => (
+            <tr key={i} style={{ borderBottom: '1px solid var(--border-subtle, rgba(255,255,255,0.06))' }}>
+              <td style={{ padding: '7px 0', color: 'var(--ink2)', whiteSpace: 'nowrap' }}>
+                {s.menu} › {s.setting}
+              </td>
+              <td style={{ padding: '7px 0', textAlign: 'right', fontWeight: 600, color: 'var(--ink)' }}>
+                {s.value}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {settings.length > 0 && settings[0].reason && (
+        <div style={{ fontSize: '0.78rem', color: 'var(--ink2)', marginTop: 8, lineHeight: 1.5 }}>
+          {settings[0].reason}
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/frontend/src/components/PredictedSettingsCard.test.jsx
+++ b/frontend/src/components/PredictedSettingsCard.test.jsx
@@ -85,4 +85,14 @@ describe('PredictedSettingsCard', () => {
       expect(screen.getByText('Prediction unavailable.')).toBeInTheDocument();
     });
   });
+
+  it('handles non-Promise return (session not ready)', async () => {
+    const getPredictedSettings = vi.fn().mockReturnValue(null);
+    render(
+      <PredictedSettingsCard getPredictedSettings={getPredictedSettings} phase="white_balance" />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText('Prediction unavailable.')).toBeInTheDocument();
+    });
+  });
 });

--- a/frontend/src/components/PredictedSettingsCard.test.jsx
+++ b/frontend/src/components/PredictedSettingsCard.test.jsx
@@ -1,0 +1,88 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { PredictedSettingsCard } from './PredictedSettingsCard';
+
+describe('PredictedSettingsCard', () => {
+  it('renders nothing while loading', () => {
+    const getPredictedSettings = vi.fn(() => new Promise(() => {}));
+    const { container } = render(
+      <PredictedSettingsCard getPredictedSettings={getPredictedSettings} phase="white_balance" />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders muted reason when predicted is null', async () => {
+    const getPredictedSettings = vi.fn().mockResolvedValue({ predicted: null, reason: 'LLM not configured' });
+    render(
+      <PredictedSettingsCard getPredictedSettings={getPredictedSettings} phase="white_balance" />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText('LLM not configured')).toBeInTheDocument();
+    });
+  });
+
+  it('renders "measuring from defaults" when source is cold_start', async () => {
+    const getPredictedSettings = vi.fn().mockResolvedValue({
+      predicted: { settings: [], source: 'cold_start', confidence: 0 },
+    });
+    render(
+      <PredictedSettingsCard getPredictedSettings={getPredictedSettings} phase="white_balance" />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText('No prior data for this TV — measuring from defaults.')).toBeInTheDocument();
+    });
+  });
+
+  it('renders "measuring from defaults" when settings is empty', async () => {
+    const getPredictedSettings = vi.fn().mockResolvedValue({
+      predicted: { settings: [], source: 'history', confidence: 0.5 },
+    });
+    render(
+      <PredictedSettingsCard getPredictedSettings={getPredictedSettings} phase="white_balance" />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText('No prior data for this TV — measuring from defaults.')).toBeInTheDocument();
+    });
+  });
+
+  it('renders heading and settings when source is history with data', async () => {
+    const getPredictedSettings = vi.fn().mockResolvedValue({
+      predicted: {
+        settings: [
+          { menu: 'White Balance', setting: 'R-Gain', value: 5, scope: 'global', reason: 'Prior session offset' },
+        ],
+        source: 'history',
+        confidence: 0.85,
+      },
+    });
+    render(
+      <PredictedSettingsCard getPredictedSettings={getPredictedSettings} phase="white_balance" />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText('Predicted Starting Point')).toBeInTheDocument();
+      expect(screen.getByText(/White Balance.*R-Gain/)).toBeInTheDocument();
+      expect(screen.getByText('5')).toBeInTheDocument();
+      expect(screen.getByText('85% confidence')).toBeInTheDocument();
+    });
+  });
+
+  it('calls getPredictedSettings with the correct phase', async () => {
+    const getPredictedSettings = vi.fn().mockResolvedValue({ predicted: null });
+    render(
+      <PredictedSettingsCard getPredictedSettings={getPredictedSettings} phase="gamma" />,
+    );
+    await waitFor(() => {
+      expect(getPredictedSettings).toHaveBeenCalledWith('gamma');
+    });
+  });
+
+  it('renders nothing when API call rejects', async () => {
+    const getPredictedSettings = vi.fn().mockRejectedValue(new Error('network error'));
+    const { container } = render(
+      <PredictedSettingsCard getPredictedSettings={getPredictedSettings} phase="white_balance" />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText('Prediction unavailable.')).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/PredictedSettingsCard.test.jsx
+++ b/frontend/src/components/PredictedSettingsCard.test.jsx
@@ -78,7 +78,7 @@ describe('PredictedSettingsCard', () => {
 
   it('renders nothing when API call rejects', async () => {
     const getPredictedSettings = vi.fn().mockRejectedValue(new Error('network error'));
-    const { container } = render(
+    render(
       <PredictedSettingsCard getPredictedSettings={getPredictedSettings} phase="white_balance" />,
     );
     await waitFor(() => {

--- a/frontend/src/hooks/useSession.js
+++ b/frontend/src/hooks/useSession.js
@@ -449,6 +449,11 @@ export function useSession() {
     return api.runSuggestedPatches(session.id, patches);
   }
 
+  async function getPredictedSettings(phase) {
+    if (!session?.id) return null;
+    return api.getPredictedSettings(session.id, phase);
+  }
+
   function dismissLlmInsight() {
     setLlmInsight(null);
     setLlmError(null);
@@ -463,7 +468,7 @@ export function useSession() {
     adbDeploy, adbApply, adbReset, adbSetPicture, adbGetPicture, refreshAdbStatus,
     configureLlm, getLlmStatus, saveTvSettings,
     llmInsight, llmStreaming, llmError, dismissLlmInsight,
-    getSuggestedPatches, runSuggestedPatches,
+    getSuggestedPatches, runSuggestedPatches, getPredictedSettings,
     reload,
   };
 }

--- a/frontend/src/pages/ColorTuner.jsx
+++ b/frontend/src/pages/ColorTuner.jsx
@@ -6,9 +6,10 @@ import { ZroInstructions } from '../components/ZroInstructions';
 import { fmtDe } from '../utils/fmt';
 import { QualityGate } from '../components/QualityGate';
 import { AdbErrorBoundary } from '../components/AdbErrorBoundary';
+import { PredictedSettingsCard } from '../components/PredictedSettingsCard';
 import { CollapsibleSection } from '../components/CollapsibleSection';
 
-export function ColorTuner({ session, adbStatus, onAdbApply, onAdbReset, onAdbDeploy, onNext, onPrev }) {
+export function ColorTuner({ session, adbStatus, onAdbApply, onAdbReset, onAdbDeploy, onNext, onPrev, getPredictedSettings }) {
   const cd = session.cms_data || {};
   const plan = cd.control_plan || [];
   const meas = cd.measurements || [];
@@ -19,6 +20,7 @@ export function ColorTuner({ session, adbStatus, onAdbApply, onAdbReset, onAdbDe
     <>
       <ZroInstructions instructions={session.zro_instructions} />
       <QualityGate gate={(session.quality_gates || {}).color_tuner} />
+      <PredictedSettingsCard getPredictedSettings={getPredictedSettings} phase="color_tuner" />
 
       <Card title="Color Status">
         <div className="three-col">

--- a/frontend/src/pages/Gamma.jsx
+++ b/frontend/src/pages/Gamma.jsx
@@ -6,8 +6,9 @@ import { ZroInstructions } from '../components/ZroInstructions';
 import { GammaChart } from '../charts/GammaChart';
 import { QualityGate } from '../components/QualityGate';
 import { CollapsibleSection } from '../components/CollapsibleSection';
+import { PredictedSettingsCard } from '../components/PredictedSettingsCard';
 
-export function Gamma({ session, onSetGammaWorkflow, onNext, onPrev }) {
+export function Gamma({ session, onSetGammaWorkflow, onNext, onPrev, getPredictedSettings }) {
   const gd = session.gamma_data || {};
   const plan      = gd.control_plan || [];
   const meas      = gd.measurements || [];
@@ -17,6 +18,7 @@ export function Gamma({ session, onSetGammaWorkflow, onNext, onPrev }) {
     <>
       <ZroInstructions instructions={session.zro_instructions} />
       <QualityGate gate={(session.quality_gates || {}).gamma} />
+      <PredictedSettingsCard getPredictedSettings={getPredictedSettings} phase="gamma" />
 
       {workflows.length > 1 && (
         <Card title="Gamma Workflow">

--- a/frontend/src/pages/WhiteBalance.jsx
+++ b/frontend/src/pages/WhiteBalance.jsx
@@ -7,6 +7,7 @@ import { CIEScatter } from '../charts/CIEScatter';
 import { fmtDe, fmtDateTime } from '../utils/fmt';
 import { QualityGate } from '../components/QualityGate';
 import { CollapsibleSection } from '../components/CollapsibleSection';
+import { PredictedSettingsCard } from '../components/PredictedSettingsCard';
 
 function wbSub(measurement) {
   if (!measurement) return null;
@@ -20,7 +21,7 @@ function wbSub(measurement) {
   );
 }
 
-export function WhiteBalance({ session, onNext, onPrev }) {
+export function WhiteBalance({ session, onNext, onPrev, getPredictedSettings }) {
   const wd = session.wb_data || {};
   const plan   = wd.control_plan || [];
   const hints  = wd.hints || null;
@@ -31,6 +32,7 @@ export function WhiteBalance({ session, onNext, onPrev }) {
     <>
       <ZroInstructions instructions={session.zro_instructions} />
       <QualityGate gate={(session.quality_gates || {}).white_balance} />
+      <PredictedSettingsCard getPredictedSettings={getPredictedSettings} phase="white_balance" />
 
       <div className="two-col" style={{ marginBottom: 16 }}>
         <Readout


### PR DESCRIPTION
## Summary
- Add `getPredictedSettings` API wrapper in `client.js`
- Add `getPredictedSettings` to `useSession` hook
- Create `PredictedSettingsCard.jsx` — read-only card showing LLM-predicted starting settings
- Mount card on WhiteBalance, Gamma, and ColorTuner pages
- 7 new Vitest/RTL tests covering null, cold_start, empty, history, and error states

## What it does
On each measurement step, the card calls `/api/session/{sid}/predicted-settings?phase=<phase>` and displays the predicted menu settings so the user can dial them in before the first measurement. Read-only — no apply/automation.

Closes #336