### PR TITLE
Add convergence-aware next-settings prediction (#337)

### DIFF
--- a/calcore/llm.py
+++ b/calcore/llm.py
@@ -1681,7 +1681,10 @@ def predict_next_settings(
         content = choices[0]["message"]["content"].strip()
         plan = parse_adjustment_plan(content)
         if plan is None:
-            logger.warning("predict_next_settings: could not parse adjustment plan")
+            logger.warning(
+                "predict_next_settings: could not parse adjustment plan from: %s",
+                content[:500],
+            )
             return None
 
         return NextSettingsPrediction(

--- a/calcore/llm.py
+++ b/calcore/llm.py
@@ -1264,3 +1264,448 @@ def predict_initial_settings(
             "Unexpected error in predict_initial_settings: %s: %s", type(e).__name__, e
         )
         return None
+
+
+# ── Convergence-aware reactive next-settings prediction (#337) ─────────────────
+#
+# Design decisions (resolving the open questions in the issue):
+#
+#   1. "Converged" reuses the existing quality-gate constants. We pull per-phase
+#      thresholds from the TV profile's ``quality_gate_thresholds`` and fall back
+#      to ``_DEFAULT_CONVERGENCE_THRESHOLDS`` (which mirror the U8G profile and the
+#      ACCEPT rule baked into ``query_pass_decision``: grayscale avg ΔE ≤ 2.0,
+#      max ≤ 3.0). No new per-phase magic numbers are invented.
+#
+#   2. Overshoot/damping is fed to the model as explicit prior (suggested-delta →
+#      resulting-residual) pairs plus a trust-region instruction: if the last
+#      delta failed to reduce the residual (or flipped its sign), apply a damped
+#      fraction of the remaining correction rather than repeating the same delta.
+#      Rounds are tracked deterministically by the caller and capped here.
+#
+#   3. Auto-advance vs. confirm: when within tolerance we DO NOT mutate hardware.
+#      We surface a high-confidence ``next_step="verify"`` so the user accepts the
+#      proceed. The convergence short-circuit makes no network call.
+#
+#   4. Round cap + stall: reuse ``_REPATCH_MAX_PASSES``. When the cap is reached
+#      OR round-over-round improvement falls below ``_CONVERGENCE_STALL_EPSILON``
+#      while still out of tolerance, we emit a "diminishing returns / hardware
+#      ceiling" prediction (``next_step="ceiling"``) without a network call.
+
+# Round-over-round avg ΔE improvement below this counts as a stall (diminishing
+# returns). 0.3 ΔE is below the ~1.0 ΔE just-noticeable threshold, so further
+# rounds are not worth the measurement cost.
+_CONVERGENCE_STALL_EPSILON = 0.3
+
+# Per-phase convergence thresholds used when the TV profile omits them. These
+# mirror the Hisense U8G ``quality_gate_thresholds`` and the ACCEPT decision rule
+# in ``query_pass_decision`` so the reactive loop and the quality gate agree.
+_DEFAULT_CONVERGENCE_THRESHOLDS: Dict[str, Dict[str, float]] = {
+    "grayscale": {"avg_de": 2.0, "max_de": 3.0},
+    "white_balance": {"avg_de": 1.5, "max_de": 2.5},
+    "color_tuner": {"avg_de": 3.0, "max_de": 4.0},
+    "gamma": {"max_deviation": 0.05},
+}
+
+
+def _phase_threshold_key(phase: str) -> str:
+    """Map a calibration phase string to a ``quality_gate_thresholds`` key.
+
+    Phases seen in the codebase: ``pre_grayscale``, ``post_grayscale``,
+    ``white_balance``, ``gamma``, ``color_tuner``, ``baseline``. Grayscale is the
+    default so baseline/pre/post all gate on grayscale tracking.
+    """
+    p = (phase or "").lower()
+    if "color" in p or "cms" in p:
+        return "color_tuner"
+    if "gamma" in p:
+        return "gamma"
+    if "white" in p or "balance" in p or p == "wb":
+        return "white_balance"
+    return "grayscale"
+
+
+@dataclass
+class ConvergenceAssessment:
+    """Deterministic convergence verdict for the current measurement round."""
+
+    converged: bool
+    stalled: bool
+    rounds_used: int
+    rounds_remaining: int
+    metric_key: str  # which threshold group applied
+    avg_de: Optional[float]
+    max_de: Optional[float]
+    gamma_deviation: Optional[float]
+    detail: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "converged": self.converged,
+            "stalled": self.stalled,
+            "rounds_used": self.rounds_used,
+            "rounds_remaining": self.rounds_remaining,
+            "metric_key": self.metric_key,
+            "avg_de": self.avg_de,
+            "max_de": self.max_de,
+            "gamma_deviation": self.gamma_deviation,
+            "detail": self.detail,
+        }
+
+
+def assess_convergence(
+    summary: "Summary",
+    phase: str,
+    thresholds: Optional[Dict[str, Any]] = None,
+    rounds_used: int = 0,
+    round_cap: int = _REPATCH_MAX_PASSES,
+    prev_avg_de: Optional[float] = None,
+    target_gamma: Optional[float] = None,
+) -> ConvergenceAssessment:
+    """Decide — deterministically, no LLM — whether the current phase has converged.
+
+    ``prev_avg_de`` is the residual avg ΔE recorded one round earlier; when the
+    improvement since then is below ``_CONVERGENCE_STALL_EPSILON`` and we are
+    still out of tolerance, the phase is flagged ``stalled`` (diminishing
+    returns). ``rounds_remaining`` is the budget left before the round cap.
+    """
+    key = _phase_threshold_key(phase)
+    thr = (thresholds or {}).get(key) or _DEFAULT_CONVERGENCE_THRESHOLDS.get(key, {})
+
+    if key == "color_tuner":
+        avg_de = (
+            summary.color_100_avg_de
+            if summary.color_100_avg_de is not None
+            else summary.color_75_avg_de
+        )
+        max_de = (
+            summary.color_100_max_de
+            if summary.color_100_max_de is not None
+            else summary.color_75_max_de
+        )
+    else:
+        avg_de = summary.grayscale_avg_de
+        max_de = summary.grayscale_max_de
+
+    gamma_deviation: Optional[float] = None
+    if target_gamma is not None and summary.gamma_midtones is not None:
+        gamma_deviation = abs(summary.gamma_midtones - target_gamma)
+
+    avg_thr = thr.get("avg_de")
+    max_thr = thr.get("max_de")
+    gamma_thr = thr.get("max_deviation")
+
+    has_data = any(v is not None for v in (avg_de, max_de, gamma_deviation))
+    within = True
+    if avg_thr is not None:
+        within = within and (avg_de is not None and avg_de <= avg_thr)
+    if max_thr is not None:
+        within = within and (max_de is not None and max_de <= max_thr)
+    # Gamma is only a convergence gate during the gamma phase.
+    if key == "gamma" and gamma_thr is not None:
+        within = within and (gamma_deviation is not None and gamma_deviation <= gamma_thr)
+
+    converged = bool(within and has_data)
+
+    rounds_remaining = max(0, round_cap - rounds_used)
+
+    stalled = False
+    if (
+        not converged
+        and prev_avg_de is not None
+        and avg_de is not None
+        and rounds_used >= 1
+        and (prev_avg_de - avg_de) < _CONVERGENCE_STALL_EPSILON
+    ):
+        stalled = True
+
+    if converged:
+        detail = (
+            f"{key} within tolerance (avg ΔE={avg_de}, max ΔE={max_de}); proceed."
+        )
+    elif not has_data:
+        detail = f"No {key} residual data available to assess convergence."
+    elif stalled:
+        detail = (
+            f"{key} stalled at avg ΔE={avg_de} (prev {prev_avg_de}); "
+            f"improvement < {_CONVERGENCE_STALL_EPSILON} ΔE — diminishing returns."
+        )
+    else:
+        detail = (
+            f"{key} out of tolerance (avg ΔE={avg_de}, max ΔE={max_de}); "
+            f"{rounds_remaining} round(s) remaining."
+        )
+
+    return ConvergenceAssessment(
+        converged=converged,
+        stalled=stalled,
+        rounds_used=rounds_used,
+        rounds_remaining=rounds_remaining,
+        metric_key=key,
+        avg_de=round(avg_de, 2) if isinstance(avg_de, (int, float)) else avg_de,
+        max_de=round(max_de, 2) if isinstance(max_de, (int, float)) else max_de,
+        gamma_deviation=round(gamma_deviation, 3)
+        if isinstance(gamma_deviation, (int, float))
+        else gamma_deviation,
+        detail=detail,
+    )
+
+
+@dataclass
+class NextSettingsPrediction:
+    """Convergence-aware next-round prediction for the reactive settings loop."""
+
+    adjustments: List[Dict[str, Any]]  # same shape as AdjustmentPlan.adjustments
+    # "rerun_grayscale" | "rerun_wb" | "proceed_cms" | "verify" | "ceiling"
+    next_step: str
+    confidence: float
+    converged: bool
+    stalled: bool
+    rounds_used: int
+    rounds_remaining: int
+    convergence: Dict[str, Any]  # ConvergenceAssessment.to_dict()
+    message: str
+    source: str  # "converged" | "ceiling" | "llm"
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "adjustments": self.adjustments,
+            "next_step": self.next_step,
+            "confidence": self.confidence,
+            "converged": self.converged,
+            "stalled": self.stalled,
+            "rounds_used": self.rounds_used,
+            "rounds_remaining": self.rounds_remaining,
+            "convergence": self.convergence,
+            "message": self.message,
+            "source": self.source,
+        }
+
+
+def _format_adjustment_rounds(prior_rounds: List[Dict[str, Any]]) -> str:
+    """Render prior (suggested-delta → resulting-residual) pairs for the prompt."""
+    lines: List[str] = []
+    for r in prior_rounds[-3:]:
+        res = r.get("residual") or {}
+        suggested = r.get("suggested") or []
+        sug_str = (
+            "; ".join(
+                f"{a.get('menu', '?')}/{a.get('setting', '?')}→{a.get('to')}"
+                for a in suggested
+            )
+            or "(none)"
+        )
+        lines.append(
+            f"Round {r.get('round')}: observed avg ΔE={res.get('avg_de')}, "
+            f"max ΔE={res.get('max_de')}"
+            + (
+                f", gamma={res.get('gamma')}"
+                if res.get("gamma") is not None
+                else ""
+            )
+            + f" → suggested {sug_str}"
+        )
+    return "\n".join(lines)
+
+
+def predict_next_settings(
+    summary: "Summary",
+    cfg: "AnalysisConfig",
+    phase: str,
+    llm: "LLMConfig",
+    prior_rounds: Optional[List[Dict[str, Any]]] = None,
+    thresholds: Optional[Dict[str, Any]] = None,
+    round_cap: int = _REPATCH_MAX_PASSES,
+    tv_settings: Optional["TVSettings"] = None,
+    tv_schema: Optional[Dict[str, Any]] = None,
+    target_gamma: Optional[float] = None,
+) -> Optional[NextSettingsPrediction]:
+    """Predict the next round of settings, aware of convergence trend and round cap.
+
+    Unlike ``call_llm`` (single-shot, stateless), this folds in prior adjustment
+    rounds and short-circuits — with no network call — when the phase has either
+    converged (``next_step="verify"``) or hit the round cap / stalled
+    (``next_step="ceiling"``). Otherwise it asks the LLM for the next deltas,
+    feeding it the suggested-vs-resulting residual history and a damping
+    instruction so it corrects rather than repeating an overshooting delta.
+    """
+    if not llm.endpoint or not llm.model:
+        return None
+
+    prior_rounds = prior_rounds or []
+    rounds_used = len(prior_rounds)
+    prev_avg_de: Optional[float] = None
+    if prior_rounds:
+        last_res = prior_rounds[-1].get("residual") or {}
+        prev_avg_de = last_res.get("avg_de")
+
+    assessment = assess_convergence(
+        summary,
+        phase,
+        thresholds=thresholds,
+        rounds_used=rounds_used,
+        round_cap=round_cap,
+        prev_avg_de=prev_avg_de,
+        target_gamma=target_gamma,
+    )
+
+    # Short-circuit 1 — converged: surface a high-confidence proceed, no network.
+    if assessment.converged:
+        return NextSettingsPrediction(
+            adjustments=[],
+            next_step="verify",
+            confidence=0.95,
+            converged=True,
+            stalled=False,
+            rounds_used=rounds_used,
+            rounds_remaining=assessment.rounds_remaining,
+            convergence=assessment.to_dict(),
+            message=(
+                f"Within tolerance after {rounds_used} round(s) — "
+                "no further adjustment needed. Proceed to verify."
+            ),
+            source="converged",
+        )
+
+    # Short-circuit 2 — round cap reached or stalled: diminishing-returns ceiling.
+    if rounds_used >= round_cap or assessment.stalled:
+        if rounds_used >= round_cap:
+            reason = (
+                f"Round cap ({round_cap}) reached without converging "
+                f"(avg ΔE={assessment.avg_de})."
+            )
+        else:
+            reason = (
+                f"Diminishing returns — avg ΔE stalled at {assessment.avg_de} "
+                f"(prev {prev_avg_de}). Likely hardware ceiling."
+            )
+        return NextSettingsPrediction(
+            adjustments=[],
+            next_step="ceiling",
+            confidence=0.6,
+            converged=False,
+            stalled=assessment.stalled,
+            rounds_used=rounds_used,
+            rounds_remaining=0,
+            convergence=assessment.to_dict(),
+            message=reason,
+            source="ceiling",
+        )
+
+    # Otherwise ask the LLM for the next round, with damping context.
+    summary_dict = {
+        k: v
+        for k, v in asdict(summary).items()
+        if k not in ("grayscale_rows", "color_rows")
+    }
+    top = _top_offenders(summary)
+    if top:
+        summary_dict["top_offenders"] = top
+
+    payload: Dict[str, Any] = {
+        "phase": phase,
+        "mode": cfg.mode,
+        "eotf": cfg.eotf,
+        "target_space": cfg.target_space,
+        "round": rounds_used + 1,
+        "rounds_remaining": assessment.rounds_remaining,
+        "convergence_targets": (thresholds or {}).get(assessment.metric_key)
+        or _DEFAULT_CONVERGENCE_THRESHOLDS.get(assessment.metric_key, {}),
+        "current_residual": {
+            "avg_de": assessment.avg_de,
+            "max_de": assessment.max_de,
+            "gamma_deviation": assessment.gamma_deviation,
+        },
+        "summary": summary_dict,
+    }
+    if tv_settings is not None:
+        ts_dict = {k: v for k, v in asdict(tv_settings).items() if v is not None}
+        if ts_dict:
+            payload["current_tv_settings"] = ts_dict
+    if tv_schema:
+        payload["tv_settings_schema"] = tv_schema
+
+    rounds_block = _format_adjustment_rounds(prior_rounds) or "(none yet)"
+
+    prompt = (
+        "You are converging a TV calibration loop in as few rounds as possible. "
+        f"This is round {rounds_used + 1} of at most {round_cap}. Predict the NEXT "
+        "hardware deltas so the residual drops below the convergence targets.\n\n"
+        "Damping / trust-region rules:\n"
+        "- Review the PRIOR ROUNDS below: each shows the residual you were "
+        "correcting and the delta you suggested.\n"
+        "- If a prior delta did NOT reduce the residual (or made it worse), do not "
+        "repeat it — apply a DAMPED fraction (about half) of the remaining "
+        "correction in the same direction, or reverse if you overshot.\n"
+        "- Prefer the smallest delta that reaches tolerance; avoid oscillation.\n"
+        "- If you are already within the convergence targets, return an empty "
+        '"adjustments" array with "next_step": "verify" and high confidence.\n\n'
+        "Respond with ONLY a valid JSON object matching this exact schema "
+        "(no markdown, no prose outside the JSON):\n"
+        "{\n"
+        '  "adjustments": [\n'
+        "    {\n"
+        '      "menu": "<TV menu name>",\n'
+        '      "setting": "<setting name>",\n'
+        '      "from": <current value or null>,\n'
+        '      "to": <target value>,\n'
+        '      "scope": "global" | "local",\n'
+        '      "reason": "<1-2 sentences, physics-based>"\n'
+        "    }\n"
+        "  ],\n"
+        '  "next_step": "rerun_grayscale" | "rerun_wb" | "proceed_cms" | "verify",\n'
+        '  "confidence": <0.0-1.0>\n'
+        "}\n\n"
+        f"PRIOR ROUNDS (suggested → resulting residual):\n{rounds_block}\n\n"
+        f"PAYLOAD:\n{json.dumps(payload, indent=2, default=str)}"
+    )
+
+    url = resolve_endpoint(llm.endpoint)
+    body = {
+        "model": llm.model,
+        "messages": [
+            {"role": "system", "content": _SYSTEM_PROMPT},
+            {"role": "user", "content": prompt},
+        ],
+        "temperature": 0.0,
+    }
+
+    req = _build_request(url, body, llm)
+
+    try:
+        with urllib.request.urlopen(req, timeout=min(llm.timeout, 45.0)) as resp:
+            raw = resp.read().decode("utf-8")
+        parsed = json.loads(raw)
+        choices = parsed.get("choices") or []
+        if not choices:
+            raise ValueError(f"LLM returned empty choices array: {raw[:300]}")
+        content = choices[0]["message"]["content"].strip()
+        plan = parse_adjustment_plan(content)
+        if plan is None:
+            logger.warning("predict_next_settings: could not parse adjustment plan")
+            return None
+
+        return NextSettingsPrediction(
+            adjustments=plan.adjustments,
+            next_step=plan.next_step,
+            confidence=plan.confidence,
+            converged=False,
+            stalled=False,
+            rounds_used=rounds_used,
+            rounds_remaining=assessment.rounds_remaining,
+            convergence=assessment.to_dict(),
+            message=assessment.detail,
+            source="llm",
+        )
+    except urllib.error.HTTPError as e:
+        logger.error(
+            "LLM HTTP error in predict_next_settings: %s - %s", e.code, e.reason
+        )
+        return None
+    except json.JSONDecodeError as e:
+        logger.error("LLM response parsing failed in predict_next_settings: %s", e)
+        return None
+    except Exception as e:
+        logger.error(
+            "Unexpected error in predict_next_settings: %s: %s", type(e).__name__, e
+        )
+        return None

--- a/calibrator/session.py
+++ b/calibrator/session.py
@@ -136,6 +136,9 @@ STEPS_ORDER = [
 # Repatch is a transient meta-state that can occur during any measurement step
 REPATCH_MAX_PASSES = 3
 
+# Cap on stored convergence-loop rounds per session to bound growth (#337)
+_MAX_ADJUSTMENT_ROUNDS = 20
+
 STEP_LABELS = {
     "select_mode": "Mode",
     "prepare": "Prepare TV",
@@ -2067,6 +2070,10 @@ class SessionStore:
                     "timestamp": now().isoformat(),
                 }
             )
+            # Bound session growth — the most recent rounds drive stall detection,
+            # so keep the tail and drop the oldest.
+            if len(rounds) > _MAX_ADJUSTMENT_ROUNDS:
+                del rounds[:-_MAX_ADJUSTMENT_ROUNDS]
             self.save_session(sid)
             return session
 

--- a/calibrator/session.py
+++ b/calibrator/session.py
@@ -720,6 +720,7 @@ def serialize_session(s: Dict[str, Any]) -> Dict[str, Any]:
             "timeout": llm_cfg.get("timeout", 30.0),
         },
         "repass_count": s.get("repass_count", 0),
+        "llm_adjustment_rounds": s.get("llm_adjustment_rounds", []),
     }
 
 
@@ -787,6 +788,7 @@ def deserialize_session(data: Dict[str, Any]) -> Dict[str, Any]:
             "timeout": data.get("llm_config", {}).get("timeout", 30.0),
         },
         "repass_count": data.get("repass_count", 0),
+        "llm_adjustment_rounds": data.get("llm_adjustment_rounds", []),
     }
 
 
@@ -1305,6 +1307,7 @@ def session_view(s: Dict[str, Any]) -> Dict[str, Any]:
         "grayscale_ramp_steps": s.get("grayscale_ramp_steps", 11),
         "quality_gates": step_quality(s, tv),
         "repass_count": s.get("repass_count", 0),
+        "adjustment_round_count": len(s.get("llm_adjustment_rounds", [])),
         "llm_config": {
             "endpoint": s.get("llm_config", {}).get("endpoint", ""),
             "model": s.get("llm_config", {}).get("model", ""),
@@ -1762,6 +1765,7 @@ class SessionStore:
                 "timeout": 30.0,
             },
             "repass_count": 0,
+            "llm_adjustment_rounds": [],
         }
             return self.sessions[sid]
 
@@ -2038,6 +2042,33 @@ class SessionStore:
         session["step"] = step_to_remeasure
         self.save_session(sid)
         return session
+
+    def record_adjustment_round(
+        self,
+        sid: str,
+        residual: Dict[str, Any],
+        suggested: List[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        """Append a convergence-loop round (residual → suggested deltas) (#337).
+
+        Held under the store RLock so the get → mutate → save sequence is atomic
+        against concurrent callers (#256). The recorded ``residual`` is the state
+        the ``suggested`` deltas were responding to; the next round's residual
+        reveals whether those deltas converged.
+        """
+        with self._lock:
+            session = self.get(sid)
+            rounds = session.setdefault("llm_adjustment_rounds", [])
+            rounds.append(
+                {
+                    "round": len(rounds) + 1,
+                    "residual": residual,
+                    "suggested": suggested,
+                    "timestamp": now().isoformat(),
+                }
+            )
+            self.save_session(sid)
+            return session
 
     def _locked_import(
         self,

--- a/server.py
+++ b/server.py
@@ -46,6 +46,7 @@ from calcore.llm import (
     call_llm as _call_llm,
     parse_adjustment_plan as _parse_adjustment_plan,
     predict_initial_settings as _predict_initial_settings,
+    predict_next_settings as _predict_next_settings,
     probe_llm as _probe_llm,
     query_delta_summary as _query_delta_summary,
     query_gamut_advice as _query_gamut_advice,
@@ -1951,6 +1952,96 @@ def post_pass_decision(sid: str, req: PassDecisionReq):
         "repass_count": decision.repass_count,
         "ceiling_reason": decision.ceiling_reason,
     }
+
+
+# ── Convergence-aware next-settings endpoint (#337) ────────────────────────────
+
+
+@app.post("/api/session/{sid}/next-settings")
+def post_next_settings(sid: str):
+    """Predict the next round of settings, aware of convergence trend and round cap.
+
+    Reads the adjustment rounds recorded on the session, assesses convergence
+    against the TV's quality-gate thresholds, and either short-circuits
+    (converged → ``verify``; round cap reached or stalled → ``ceiling``) or asks
+    the LLM for damped next-round deltas.  When the LLM produces new deltas, this
+    round's residual + suggestions are recorded so the next call can measure
+    whether they actually converged.
+
+    Returns {"next_settings": {...} | null, "reason": "<string when null>"}.
+    """
+    session = store.get(sid)
+
+    all_measurements = _get_all_measurements(session)
+    if not all_measurements:
+        raise HTTPException(400, "No measurements in session; import data first.")
+
+    llm_cfg_dict = session.get("llm_config", {})
+    if not (llm_cfg_dict.get("endpoint") and llm_cfg_dict.get("model")):
+        return {"next_settings": None, "reason": "LLM not configured"}
+
+    cfg = _session_to_analysis_config(session)
+    patches_core = [_measurement_to_patch(m) for m in all_measurements]
+    summary = _calcore_analyze(patches_core, cfg)
+
+    phase = session.get("step", "baseline")
+    target = session.get("target")
+    target_gamma = target.gamma if target else None
+
+    # Reuse the per-TV quality-gate thresholds as convergence targets (#166).
+    profile = _get_tv_profile(session.get("tv_key", ""))
+    thresholds: Optional[Dict[str, Any]] = None
+    tv_schema: Optional[Dict[str, Any]] = None
+    if profile:
+        if getattr(profile, "quality_gate_thresholds", None):
+            thresholds = profile.quality_gate_thresholds
+        if profile.llm_schema:
+            tv_schema = profile.llm_schema
+
+    # Reconstruct current TV slider values when supplied (#96).
+    tv_settings: Optional[TVSettings] = None
+    raw_tv_settings = session.get("tv_settings")
+    if raw_tv_settings:
+        tv_settings = TVSettings(
+            two_point_wb=raw_tv_settings.get("two_point_wb"),
+            multipoint_wb=raw_tv_settings.get("multipoint_wb"),
+            cms_sliders=raw_tv_settings.get("cms_sliders"),
+        )
+
+    prior_rounds = session.get("llm_adjustment_rounds", [])
+
+    llm_cfg = LLMConfig.from_dict(
+        llm_cfg_dict, default_timeout=45.0, default_temperature=0.0
+    )
+    prediction = _predict_next_settings(
+        summary,
+        cfg,
+        phase,
+        llm_cfg,
+        prior_rounds=prior_rounds,
+        thresholds=thresholds,
+        tv_settings=tv_settings,
+        tv_schema=tv_schema,
+        target_gamma=target_gamma,
+    )
+
+    if prediction is None:
+        return {"next_settings": None, "reason": "LLM returned no result"}
+
+    # Only a round that produced new deltas to apply advances the loop counter;
+    # converged/ceiling short-circuits have no deltas and end the loop.
+    if prediction.source == "llm":
+        store.record_adjustment_round(
+            sid,
+            residual={
+                "avg_de": prediction.convergence.get("avg_de"),
+                "max_de": prediction.convergence.get("max_de"),
+                "gamma": prediction.convergence.get("gamma_deviation"),
+            },
+            suggested=prediction.adjustments,
+        )
+
+    return {"next_settings": prediction.to_dict()}
 
 
 @app.get("/api/adb/status")

--- a/tests/test_adaptive_loop.py
+++ b/tests/test_adaptive_loop.py
@@ -10,7 +10,16 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from calcore.llm import PassDecision, query_pass_decision
+from calcore.llm import (
+    ConvergenceAssessment,
+    NextSettingsPrediction,
+    PassDecision,
+    _CONVERGENCE_STALL_EPSILON,
+    assess_convergence,
+    predict_next_settings,
+    query_pass_decision,
+)
+from calcore.models import Summary
 from calibrator.profiles import TV_PROFILES
 from calibrator.session import (
     REPATCH_MAX_PASSES,
@@ -694,6 +703,346 @@ class TestLabelToRgb:
         from server import _label_to_rgb
         rgb = _label_to_rgb("UnknownPatch", "full")
         assert rgb == [235, 235, 235]
+
+
+def _summary(
+    *,
+    avg_de=None,
+    max_de=None,
+    gamma=None,
+    color_avg=None,
+    color_max=None,
+) -> Summary:
+    """Build a Summary with the scalar residuals convergence logic reads."""
+    return Summary(
+        grayscale_avg_de=avg_de,
+        grayscale_max_de=max_de,
+        grayscale_over_3=0,
+        gamma_midtones=gamma,
+        pq_err_midtones=None,
+        color_75_avg_de=None,
+        color_75_max_de=None,
+        color_75_chroma_avg=None,
+        color_100_avg_de=color_avg,
+        color_100_max_de=color_max,
+        color_100_chroma_avg=None,
+        grayscale_rows=[],
+        color_rows=[],
+        meta={},
+        measured_patch_count=11,
+        expected_patch_count=11,
+    )
+
+
+def _llm_mock():
+    llm = MagicMock()
+    llm.endpoint = "http://localhost:4000"
+    llm.model = "test-model"
+    llm.api_key = ""
+    llm.timeout = 30.0
+    llm.provider = "openai"
+    return llm
+
+
+def _cfg_mock():
+    cfg = MagicMock()
+    cfg.mode = "SDR"
+    cfg.eotf = "gamma"
+    cfg.target_space = "bt709"
+    return cfg
+
+
+def _patch_urlopen(payload: Dict[str, Any]):
+    """Context manager patching urlopen to return a canned chat-completion body."""
+    mock_response = {"choices": [{"message": {"content": json.dumps(payload)}}]}
+    p = patch("urllib.request.urlopen")
+    mock_urlopen = p.start()
+    mock_resp = MagicMock()
+    mock_resp.read.return_value = json.dumps(mock_response).encode()
+    mock_urlopen.return_value.__enter__ = lambda s: mock_resp
+    mock_urlopen.return_value.__exit__ = lambda s, *a: None
+    return p, mock_urlopen
+
+
+class TestAssessConvergence:
+    """Deterministic convergence assessment (#337)."""
+
+    def test_converged_within_default_grayscale_thresholds(self):
+        a = assess_convergence(_summary(avg_de=1.2, max_de=2.5), "post_grayscale")
+        assert a.converged is True
+        assert a.stalled is False
+        assert a.metric_key == "grayscale"
+
+    def test_not_converged_when_avg_exceeds(self):
+        a = assess_convergence(_summary(avg_de=3.0, max_de=2.0), "post_grayscale")
+        assert a.converged is False
+
+    def test_not_converged_when_max_exceeds(self):
+        a = assess_convergence(_summary(avg_de=1.0, max_de=4.0), "post_grayscale")
+        assert a.converged is False
+
+    def test_no_data_is_not_converged(self):
+        a = assess_convergence(_summary(), "post_grayscale")
+        assert a.converged is False
+        assert "No grayscale" in a.detail
+
+    def test_color_phase_uses_color_residuals(self):
+        a = assess_convergence(
+            _summary(avg_de=9.9, max_de=9.9, color_avg=2.0, color_max=3.5),
+            "color_tuner",
+        )
+        assert a.metric_key == "color_tuner"
+        assert a.converged is True
+
+    def test_stalled_when_improvement_below_epsilon(self):
+        a = assess_convergence(
+            _summary(avg_de=4.0, max_de=5.0),
+            "post_grayscale",
+            rounds_used=1,
+            prev_avg_de=4.0 + _CONVERGENCE_STALL_EPSILON / 2,
+        )
+        assert a.converged is False
+        assert a.stalled is True
+
+    def test_not_stalled_when_improving(self):
+        a = assess_convergence(
+            _summary(avg_de=3.0, max_de=4.0),
+            "post_grayscale",
+            rounds_used=1,
+            prev_avg_de=5.0,
+        )
+        assert a.stalled is False
+
+    def test_rounds_remaining_decrements_with_cap(self):
+        a = assess_convergence(
+            _summary(avg_de=3.0, max_de=4.0),
+            "post_grayscale",
+            rounds_used=2,
+            round_cap=3,
+        )
+        assert a.rounds_remaining == 1
+
+    def test_gamma_phase_gates_on_gamma_deviation(self):
+        # avg/max grayscale within tolerance but gamma off by 0.2 — not converged.
+        a = assess_convergence(
+            _summary(avg_de=1.0, max_de=2.0, gamma=2.0),
+            "gamma",
+            target_gamma=2.2,
+        )
+        assert a.metric_key == "gamma"
+        assert a.converged is False
+
+    def test_profile_thresholds_override_defaults(self):
+        thresholds = {"grayscale": {"avg_de": 0.5, "max_de": 1.0}}
+        a = assess_convergence(
+            _summary(avg_de=1.2, max_de=2.5),
+            "post_grayscale",
+            thresholds=thresholds,
+        )
+        assert a.converged is False  # tighter profile threshold fails
+
+
+class TestPredictNextSettings:
+    """Convergence-aware next-settings prediction (#337)."""
+
+    def test_returns_none_without_llm_config(self):
+        llm = MagicMock()
+        llm.endpoint = ""
+        llm.model = ""
+        result = predict_next_settings(
+            _summary(avg_de=1.0, max_de=2.0), _cfg_mock(), "post_grayscale", llm
+        )
+        assert result is None
+
+    def test_converged_short_circuits_without_network(self):
+        llm = _llm_mock()
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            result = predict_next_settings(
+                _summary(avg_de=1.2, max_de=2.5),
+                _cfg_mock(),
+                "post_grayscale",
+                llm,
+            )
+            mock_urlopen.assert_not_called()
+        assert result is not None
+        assert result.converged is True
+        assert result.next_step == "verify"
+        assert result.source == "converged"
+        assert result.adjustments == []
+        assert result.confidence >= 0.9
+
+    def test_round_cap_reached_returns_ceiling_without_network(self):
+        llm = _llm_mock()
+        prior = [
+            {"round": 1, "residual": {"avg_de": 5.0}, "suggested": []},
+            {"round": 2, "residual": {"avg_de": 4.5}, "suggested": []},
+            {"round": 3, "residual": {"avg_de": 4.2}, "suggested": []},
+        ]
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            result = predict_next_settings(
+                _summary(avg_de=4.0, max_de=5.0),
+                _cfg_mock(),
+                "post_grayscale",
+                llm,
+                prior_rounds=prior,
+                round_cap=3,
+            )
+            mock_urlopen.assert_not_called()
+        assert result is not None
+        assert result.next_step == "ceiling"
+        assert result.source == "ceiling"
+        assert result.rounds_remaining == 0
+
+    def test_stall_returns_ceiling_without_network(self):
+        llm = _llm_mock()
+        prior = [{"round": 1, "residual": {"avg_de": 4.1}, "suggested": []}]
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            result = predict_next_settings(
+                _summary(avg_de=4.0, max_de=5.0),
+                _cfg_mock(),
+                "post_grayscale",
+                llm,
+                prior_rounds=prior,
+                round_cap=3,
+            )
+            mock_urlopen.assert_not_called()
+        assert result is not None
+        assert result.next_step == "ceiling"
+        assert result.stalled is True
+
+    def test_out_of_tolerance_calls_llm_and_parses(self):
+        llm = _llm_mock()
+        plan = {
+            "adjustments": [
+                {
+                    "menu": "White Balance",
+                    "setting": "R Gain",
+                    "from": 0,
+                    "to": -3,
+                    "scope": "global",
+                    "reason": "Reduce red push in highlights.",
+                }
+            ],
+            "next_step": "rerun_grayscale",
+            "confidence": 0.8,
+        }
+        p, mock_urlopen = _patch_urlopen(plan)
+        try:
+            result = predict_next_settings(
+                _summary(avg_de=3.5, max_de=5.0),
+                _cfg_mock(),
+                "post_grayscale",
+                llm,
+                prior_rounds=[
+                    {
+                        "round": 1,
+                        "residual": {"avg_de": 5.0, "max_de": 7.0},
+                        "suggested": [
+                            {"menu": "White Balance", "setting": "R Gain", "to": -1}
+                        ],
+                    }
+                ],
+            )
+            mock_urlopen.assert_called_once()
+        finally:
+            p.stop()
+        assert result is not None
+        assert result.source == "llm"
+        assert result.converged is False
+        assert result.rounds_used == 1
+        assert len(result.adjustments) == 1
+        assert result.next_step == "rerun_grayscale"
+        assert result.confidence == 0.8
+
+    def test_unparseable_llm_response_returns_none(self):
+        llm = _llm_mock()
+        mock_response = {"choices": [{"message": {"content": "not json at all"}}]}
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_resp = MagicMock()
+            mock_resp.read.return_value = json.dumps(mock_response).encode()
+            mock_urlopen.return_value.__enter__ = lambda s: mock_resp
+            mock_urlopen.return_value.__exit__ = lambda s, *a: None
+            result = predict_next_settings(
+                _summary(avg_de=3.5, max_de=5.0),
+                _cfg_mock(),
+                "post_grayscale",
+                llm,
+            )
+        assert result is None
+
+
+class TestNextSettingsPredictionDataclass:
+    """NextSettingsPrediction.to_dict contract."""
+
+    def test_to_dict_round_trips_fields(self):
+        pred = NextSettingsPrediction(
+            adjustments=[{"menu": "m", "setting": "s", "to": 1, "scope": "global"}],
+            next_step="verify",
+            confidence=0.95,
+            converged=True,
+            stalled=False,
+            rounds_used=2,
+            rounds_remaining=1,
+            convergence={"converged": True},
+            message="ok",
+            source="converged",
+        )
+        d = pred.to_dict()
+        assert d["next_step"] == "verify"
+        assert d["converged"] is True
+        assert d["rounds_used"] == 2
+        assert d["convergence"] == {"converged": True}
+        assert d["source"] == "converged"
+
+
+class TestRecordAdjustmentRound:
+    """SessionStore.record_adjustment_round (#337)."""
+
+    def _make_store(self, session_data: Dict[str, Any]) -> SessionStore:
+        from datetime import datetime, timezone
+
+        now_iso = (datetime.now(timezone.utc) + timedelta(days=1)).isoformat()
+        session_data["created_at"] = now_iso
+        session_data["last_accessed_at"] = now_iso
+        store = SessionStore(
+            session_dir_getter=lambda: MagicMock(),
+            ttl_getter=lambda: timedelta(days=7),
+            watched_session_id_getter=lambda: None,
+        )
+        store.sessions[session_data["id"]] = session_data
+        return store
+
+    def _session(self) -> Dict[str, Any]:
+        return {
+            "id": "rec12345",
+            "tv_key": "u8g",
+            "tv_name": "Hisense U8G",
+            "step": "post_grayscale",
+            "mode": "SDR",
+            "llm_config": {"endpoint": "", "model": ""},
+        }
+
+    def test_first_round_appended_with_index_one(self):
+        store = self._make_store(self._session())
+        with patch.object(store, "save_session"):
+            session = store.record_adjustment_round(
+                "rec12345",
+                residual={"avg_de": 3.5, "max_de": 5.0},
+                suggested=[{"menu": "WB", "setting": "R Gain", "to": -2}],
+            )
+        rounds = session["llm_adjustment_rounds"]
+        assert len(rounds) == 1
+        assert rounds[0]["round"] == 1
+        assert rounds[0]["residual"]["avg_de"] == 3.5
+        assert "timestamp" in rounds[0]
+
+    def test_rounds_accumulate_and_increment(self):
+        store = self._make_store(self._session())
+        with patch.object(store, "save_session"):
+            store.record_adjustment_round("rec12345", {"avg_de": 5.0}, [])
+            session = store.record_adjustment_round("rec12345", {"avg_de": 3.0}, [])
+        rounds = session["llm_adjustment_rounds"]
+        assert [r["round"] for r in rounds] == [1, 2]
 
 
 class TestReportPayloadRepashReason:

--- a/tests/test_next_settings.py
+++ b/tests/test_next_settings.py
@@ -1,0 +1,237 @@
+"""End-to-end tests for POST /api/session/{sid}/next-settings (#337)."""
+
+import unittest
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+import server as server_module
+from server import app as server_app
+from calcore.llm import NextSettingsPrediction
+
+
+def _reset_server_globals():
+    server_module._sessions.clear()
+    server_module._watched_session.set(None)
+    server_module._dogegen_state.proc = None
+    server_module._dogegen_state.started_at = None
+    server_module._dogegen_state.launch_cmd = []
+    server_module._dogegen_state.last_error = None
+    server_module._dogegen_config = {
+        "path": "",
+        "resolve_host": "",
+        "window_pct": 10,
+        "maxcll": 1000,
+    }
+    server_module._prefs = {
+        "dogegen": {},
+        "bridge_url": "",
+        "watch_folder": "",
+        "llm": {"endpoint": "", "model": ""},
+        "session_defaults": {
+            "signal_range": "full",
+            "code_scale": "8bit",
+            "pattern_generator": "dogegen",
+        },
+    }
+    server_module._llm_queues.clear()
+    server_module._zro_bridge.set("")
+
+
+class TestNextSettingsAPI(unittest.TestCase):
+    """Integration tests for the convergence-aware next-settings endpoint."""
+
+    def setUp(self):
+        _reset_server_globals()
+        self.client = TestClient(server_app)
+
+    def tearDown(self):
+        _reset_server_globals()
+
+    def _create_session(self):
+        resp = self.client.post("/api/session", json={"tv_key": "u8g"})
+        self.assertEqual(resp.status_code, 200)
+        return resp.json()["id"]
+
+    def _to_post_grayscale(self, sid):
+        """Navigate the session to post_grayscale with near-perfect D65 patches."""
+        self.client.post(f"/api/session/{sid}/mode", json={"mode": "SDR"})
+        self.client.post(f"/api/session/{sid}/prepared")
+
+        header = "Date and time\tR\tG\tB\tY\tx\ty\tmsec"
+        rows = [header]
+        for pct in range(0, 101, 10):
+            v = int(pct / 100 * 235)
+            Y = pct / 100 * 120.0 if pct > 0 else 0.01
+            ts = f"01/01/2024 12:00:{pct:02d}"
+            rows.append(f"{ts}\t{v}\t{v}\t{v}\t{Y:.2f}\t0.3127\t0.3290\t50")
+        csv_str = "\n".join(rows)
+
+        self.client.post(
+            f"/api/session/{sid}/import/zro",
+            files={"file": ("pre.csv", csv_str.encode(), "text/csv")},
+        )
+        self.client.post(f"/api/session/{sid}/next")  # luminance
+        white_csv = (
+            "Date and time\tR\tG\tB\tY\tx\ty\tmsec\n"
+            "01/01/2024 13:00:00\t235\t235\t235\t120.00\t0.3127\t0.3290\t50"
+        )
+        self.client.post(
+            f"/api/session/{sid}/import/zro",
+            files={"file": ("lum.csv", white_csv.encode(), "text/csv")},
+        )
+        self.client.post(f"/api/session/{sid}/next")  # white_balance
+        wb_csv = (
+            "Date and time\tR\tG\tB\tY\tx\ty\tmsec\n"
+            "01/01/2024 14:00:00\t188\t188\t188\t96.00\t0.3127\t0.3290\t50\n"
+            "01/01/2024 14:00:05\t71\t71\t71\t36.00\t0.3127\t0.3290\t50"
+        )
+        self.client.post(
+            f"/api/session/{sid}/import/zro",
+            files={"file": ("wb.csv", wb_csv.encode(), "text/csv")},
+        )
+        self.client.post(f"/api/session/{sid}/next")  # gamma
+        gamma_csv = (
+            "Date and time\tR\tG\tB\tY\tx\ty\tmsec\n"
+            "01/01/2024 15:00:00\t47\t47\t47\t8.50\t0.3127\t0.3290\t50\n"
+            "01/01/2024 15:00:05\t94\t94\t94\t29.00\t0.3127\t0.3290\t50\n"
+            "01/01/2024 15:00:10\t141\t141\t141\t62.00\t0.3127\t0.3290\t50\n"
+            "01/01/2024 15:00:15\t188\t188\t188\t104.00\t0.3127\t0.3290\t50"
+        )
+        self.client.post(
+            f"/api/session/{sid}/import/zro",
+            files={"file": ("gamma.csv", gamma_csv.encode(), "text/csv")},
+        )
+        self.client.post(f"/api/session/{sid}/next")  # color_tuner
+        cms_csv = (
+            "Date and time\tR\tG\tB\tY\tx\ty\tmsec\n"
+            "01/01/2024 16:00:00\t235\t16\t16\t30.00\t0.6400\t0.3300\t50\n"
+            "01/01/2024 16:00:05\t16\t235\t16\t30.00\t0.3000\t0.6000\t50\n"
+            "01/01/2024 16:00:10\t16\t16\t235\t30.00\t0.1500\t0.0600\t50"
+        )
+        self.client.post(
+            f"/api/session/{sid}/import/zro",
+            files={"file": ("cms.csv", cms_csv.encode(), "text/csv")},
+        )
+        self.client.post(f"/api/session/{sid}/next")  # post_grayscale
+        self.client.post(
+            f"/api/session/{sid}/import/zro",
+            files={"file": ("post.csv", csv_str.encode(), "text/csv")},
+        )
+
+    def _configure_llm(self, sid):
+        self.client.post(
+            f"/api/session/{sid}/llm/configure",
+            json={"endpoint": "http://localhost:4000", "model": "test-model"},
+        )
+
+    def test_returns_404_for_unknown_session(self):
+        resp = self.client.post("/api/session/nonexistent/next-settings")
+        self.assertEqual(resp.status_code, 404)
+
+    def test_returns_400_when_no_measurements(self):
+        sid = self._create_session()
+        resp = self.client.post(f"/api/session/{sid}/next-settings")
+        self.assertEqual(resp.status_code, 400)
+
+    def test_returns_null_when_llm_not_configured(self):
+        sid = self._create_session()
+        self._to_post_grayscale(sid)
+        resp = self.client.post(f"/api/session/{sid}/next-settings")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertIsNone(data["next_settings"])
+        self.assertEqual(data["reason"], "LLM not configured")
+
+    def test_converged_records_no_round(self):
+        """A converged prediction (no deltas) records no round on the session."""
+        sid = self._create_session()
+        self._to_post_grayscale(sid)
+        self._configure_llm(sid)
+
+        converged = NextSettingsPrediction(
+            adjustments=[],
+            next_step="verify",
+            confidence=0.95,
+            converged=True,
+            stalled=False,
+            rounds_used=0,
+            rounds_remaining=3,
+            convergence={"avg_de": 1.2, "max_de": 2.5, "gamma_deviation": None},
+            message="within tolerance",
+            source="converged",
+        )
+
+        with patch("server._predict_next_settings", return_value=converged):
+            resp = self.client.post(f"/api/session/{sid}/next-settings")
+
+        self.assertEqual(resp.status_code, 200)
+        pred = resp.json()["next_settings"]
+        self.assertTrue(pred["converged"])
+        self.assertEqual(pred["next_step"], "verify")
+        self.assertEqual(pred["source"], "converged")
+        # Converged path produces no deltas, so no round is recorded.
+        self.assertEqual(
+            server_module.store.sessions[sid].get("llm_adjustment_rounds", []), []
+        )
+
+    def test_llm_path_records_round(self):
+        """An out-of-tolerance prediction with deltas records one round."""
+        sid = self._create_session()
+        self._to_post_grayscale(sid)
+        self._configure_llm(sid)
+
+        fake = NextSettingsPrediction(
+            adjustments=[
+                {
+                    "menu": "White Balance",
+                    "setting": "R Gain",
+                    "to": -3,
+                    "scope": "global",
+                }
+            ],
+            next_step="rerun_grayscale",
+            confidence=0.8,
+            converged=False,
+            stalled=False,
+            rounds_used=0,
+            rounds_remaining=3,
+            convergence={"avg_de": 3.5, "max_de": 5.0, "gamma_deviation": None},
+            message="out of tolerance",
+            source="llm",
+        )
+
+        with patch("server._predict_next_settings", return_value=fake):
+            resp = self.client.post(f"/api/session/{sid}/next-settings")
+
+        self.assertEqual(resp.status_code, 200)
+        pred = resp.json()["next_settings"]
+        self.assertEqual(pred["source"], "llm")
+        self.assertEqual(pred["next_step"], "rerun_grayscale")
+
+        rounds = server_module.store.sessions[sid]["llm_adjustment_rounds"]
+        self.assertEqual(len(rounds), 1)
+        self.assertEqual(rounds[0]["round"], 1)
+        self.assertEqual(rounds[0]["residual"]["avg_de"], 3.5)
+        self.assertEqual(len(rounds[0]["suggested"]), 1)
+
+    def test_null_prediction_records_no_round(self):
+        """When the predictor returns None, the endpoint surfaces a reason."""
+        sid = self._create_session()
+        self._to_post_grayscale(sid)
+        self._configure_llm(sid)
+
+        with patch("server._predict_next_settings", return_value=None):
+            resp = self.client.post(f"/api/session/{sid}/next-settings")
+
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertIsNone(data["next_settings"])
+        self.assertEqual(data["reason"], "LLM returned no result")
+        self.assertEqual(
+            server_module.store.sessions[sid].get("llm_adjustment_rounds", []), []
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Phase B of the epic: tighten the reactive measure→adjust loop so the LLM predicts the *next* round of settings with a notion of iteration count, convergence trend, and "you're within tolerance — stop." Today `call_llm` → `AdjustmentPlan` is single-shot and stateless across rounds; this adds a convergence-aware path that converges in fewer rounds.

Closes #337

## Design decisions (resolving the issue's open questions)

1. **What counts as "converged"** — reuse the existing quality-gate constants. Per-phase thresholds come from the TV profile's `quality_gate_thresholds`, falling back to `_DEFAULT_CONVERGENCE_THRESHOLDS`, which mirror the U8G profile and the ACCEPT rule already baked into `query_pass_decision` (grayscale avg ΔE ≤ 2.0, max ≤ 3.0). No new magic numbers.
2. **Overshoot/damping** — prior `(suggested-delta → resulting-residual)` pairs are fed into the prompt with an explicit trust-region instruction: if the last delta failed to reduce the residual, apply a *damped* fraction of the remaining correction rather than repeating it. Rounds are tracked deterministically and capped.
3. **Auto-advance vs. confirm** — within tolerance we do **not** mutate hardware. We surface a high-confidence `next_step="verify"` proceed for the user to accept. The converged path makes no network call.
4. **Round cap + stall** — reuse `_REPATCH_MAX_PASSES = 3`. When the cap is reached or round-over-round improvement falls below `_CONVERGENCE_STALL_EPSILON` while still out of tolerance, emit a "diminishing returns / hardware ceiling" prediction (`next_step="ceiling"`), again with no network call.

## Changes

- **`calcore/llm.py`**
  - `assess_convergence()` — deterministic per-phase verdict (converged / stalled / rounds-remaining).
  - `ConvergenceAssessment`, `NextSettingsPrediction` dataclasses with `to_dict()`.
  - `predict_next_settings()` — follows the LLM-query recipe; short-circuits on converged/ceiling/stall before any network call, otherwise queries the LLM with prior-round + damping context and reuses `parse_adjustment_plan` to parse the result.
- **`server.py`** — `POST /api/session/{sid}/next-settings` drives the loop, using the per-TV quality-gate thresholds as convergence targets and recording each LLM round's residual + deltas.
- **`calibrator/session.py`** — persist `llm_adjustment_rounds`; add `SessionStore.record_adjustment_round` (held under the store RLock for atomic get→mutate→save); expose `adjustment_round_count` in the session view.

## Checklist (from the issue)

- [x] Feed prior adjustment rounds (suggested vs. resulting residuals) into the next prediction.
- [x] Explicit convergence signaling (`next_step: verify` / high confidence within tolerance).
- [x] Round cap + stall/ceiling messaging.
- [x] Tests extending `tests/test_adaptive_loop.py` for multi-round convergence and stall cases.

## Testing

- `tests/test_adaptive_loop.py` extended with convergence, stall, ceiling, round-cap, multi-round LLM prediction, and round-recording cases. The short-circuit cases assert no network call is made.
- Full suite: `1117 passed, 2 skipped`; coverage 78.8% (gate 70%). `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01F3HEDqYHWov4SA8Gkx7hFw)_