### PR TITLE
Add LlmConnectionCard for LLM endpoint setup and connection test

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -93,7 +93,7 @@ export default function App() {
     }
     switch (session.step) {
       case 'select_mode':    return <SelectMode    {...stepProps} onConfirmMode={sess.confirmMode} />;
-      case 'prepare':        return <Prepare       {...stepProps} onConfirmPrepared={sess.confirmPrepared} onSetLightspaceTier={sess.setLightspaceTier} onSetGrayscaleRamp={sess.setGrayscaleRamp} onSetSignalRange={sess.setSignalRange} onSetCodeScale={sess.setCodeScale} onSetPatternGenerator={sess.setPatternGenerator} onConfigureLlm={sess.configureLlm} onGetLlmStatus={sess.getLlmStatus} />;
+      case 'prepare':        return <Prepare       {...stepProps} onConfirmPrepared={sess.confirmPrepared} onSetLightspaceTier={sess.setLightspaceTier} onSetGrayscaleRamp={sess.setGrayscaleRamp} onSetSignalRange={sess.setSignalRange} onSetCodeScale={sess.setCodeScale} onSetPatternGenerator={sess.setPatternGenerator} />;
       case 'pre_grayscale':  return <PreGrayscale  {...stepProps} />;
       case 'luminance':      return <Luminance     {...stepProps} adbStatus={adbStatus} onAdbSetPicture={sess.adbSetPicture} onAdbGetPicture={sess.adbGetPicture} onAdbDeploy={sess.adbDeploy} onRefreshAdb={sess.refreshAdbStatus} />;
       case 'white_balance':  return <WhiteBalance  {...stepProps} getPredictedSettings={getPredictedSettings} />;

--- a/frontend/src/components/LlmConnectionCard.jsx
+++ b/frontend/src/components/LlmConnectionCard.jsx
@@ -1,0 +1,141 @@
+import { useEffect, useState } from 'react';
+import { Button } from './Button';
+import { getLlmStatus, configureLlm } from '../api/client';
+
+export function LlmConnectionCard({ sid }) {
+  const [endpoint, setEndpoint] = useState('');
+  const [model, setModel] = useState('');
+  const [apiKey, setApiKey] = useState('');
+  const [status, setStatus] = useState(null); // null | 'testing' | { configured, reachable, model, error }
+  const [savedModel, setSavedModel] = useState(null);
+
+  useEffect(() => {
+    if (!sid) return;
+    getLlmStatus(sid).then(data => {
+      if (data?.configured) {
+        setEndpoint(data.endpoint || '');
+        setModel(data.model || '');
+        setStatus(data);
+      }
+    }).catch(() => {});
+  }, [sid]);
+
+  async function handleSave() {
+    if (!sid) return;
+    const body = { endpoint: endpoint.trim(), model: model.trim() };
+    if (apiKey) body.api_key = apiKey;
+    const result = await configureLlm(sid, body);
+    setSavedModel(result?.model || null);
+    setApiKey('');
+  }
+
+  async function handleTest() {
+    if (!sid) return;
+    setStatus('testing');
+    try {
+      const data = await getLlmStatus(sid);
+      setStatus(data);
+    } catch (err) {
+      setStatus({ configured: false, reachable: false, error: err.message });
+    }
+  }
+
+  const statusBadge = (() => {
+    if (status === 'testing') {
+      return (
+        <span style={{ fontSize: '0.8rem', fontWeight: 600, padding: '5px 10px', borderRadius: 'var(--radius)', color: 'var(--ink2)', background: 'var(--panel2)', border: '1px solid var(--line)' }}>
+          Testing…
+        </span>
+      );
+    }
+    if (!status || !status.configured) {
+      return (
+        <span style={{ fontSize: '0.8rem', fontWeight: 600, padding: '5px 10px', borderRadius: 'var(--radius)', color: 'var(--ink2)', background: 'var(--panel2)', border: '1px solid var(--line)' }}>
+          Not configured
+        </span>
+      );
+    }
+    if (status.reachable) {
+      return (
+        <span style={{ fontSize: '0.8rem', fontWeight: 600, padding: '5px 10px', borderRadius: 'var(--radius)', color: 'var(--green)', background: 'var(--green-dim)', border: '1px solid #22c98759' }}>
+          Reachable ({status.model})
+        </span>
+      );
+    }
+    return (
+      <span style={{ fontSize: '0.8rem', fontWeight: 600, padding: '5px 10px', borderRadius: 'var(--radius)', color: 'var(--red)', background: 'var(--red-dim)', border: '1px solid #e74c3c4d' }}>
+        {status.error || 'Unreachable'}
+      </span>
+    );
+  })();
+
+  return (
+    <div className="card">
+      <div style={{ fontSize: '1rem', fontWeight: 700, color: 'var(--ink)', marginBottom: 12 }}>
+        AI Assistant
+      </div>
+      <div className="text-sm muted" style={{ marginBottom: 16 }}>
+        Connect an OpenAI-compatible LLM (e.g. Ollama, LiteLLM) to get real-time coaching
+        after each ZRO import. If unconfigured the rest of the workflow is unaffected.
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
+          <label style={{ fontSize: '0.78rem', fontWeight: 600, color: 'var(--ink2)', textTransform: 'uppercase', letterSpacing: '0.06em' }}>
+            Endpoint URL
+          </label>
+          <input
+            type="url"
+            value={endpoint}
+            onChange={e => setEndpoint(e.target.value)}
+            placeholder="http://localhost:11434/v1"
+            autoComplete="off"
+            spellCheck={false}
+            style={{ background: 'var(--panel2)', border: '1px solid var(--line2)', borderRadius: 'var(--radius)', color: 'var(--ink)', fontSize: '0.84rem', padding: '7px 10px', width: '100%', maxWidth: 480, outline: 'none', fontFamily: 'inherit' }}
+          />
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
+          <label style={{ fontSize: '0.78rem', fontWeight: 600, color: 'var(--ink2)', textTransform: 'uppercase', letterSpacing: '0.06em' }}>
+            Model name
+          </label>
+          <input
+            type="text"
+            value={model}
+            onChange={e => setModel(e.target.value)}
+            placeholder="llama3"
+            autoComplete="off"
+            spellCheck={false}
+            style={{ background: 'var(--panel2)', border: '1px solid var(--line2)', borderRadius: 'var(--radius)', color: 'var(--ink)', fontSize: '0.84rem', padding: '7px 10px', width: '100%', maxWidth: 480, outline: 'none', fontFamily: 'inherit' }}
+          />
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
+          <label style={{ fontSize: '0.78rem', fontWeight: 600, color: 'var(--ink2)', textTransform: 'uppercase', letterSpacing: '0.06em' }}>
+            API key{' '}
+            <span style={{ fontSize: '0.72rem', fontWeight: 400, textTransform: 'none', letterSpacing: 0, color: 'var(--line2)' }}>
+              (optional — never shown again)
+            </span>
+          </label>
+          <input
+            type="password"
+            value={apiKey}
+            onChange={e => setApiKey(e.target.value)}
+            placeholder="sk-…"
+            autoComplete="new-password"
+            style={{ background: 'var(--panel2)', border: '1px solid var(--line2)', borderRadius: 'var(--radius)', color: 'var(--ink)', fontSize: '0.84rem', padding: '7px 10px', width: '100%', maxWidth: 480, outline: 'none', fontFamily: 'inherit' }}
+          />
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 6, marginTop: 2 }}>
+          <div className="btn-group">
+            <Button small onClick={handleSave}>Save</Button>
+            <Button small onClick={handleTest}>Test connection</Button>
+            {statusBadge}
+          </div>
+          {savedModel && (
+            <div style={{ fontSize: '0.78rem', color: 'var(--green)' }}>
+              Saved — configured model: {savedModel}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/LlmConnectionCard.jsx
+++ b/frontend/src/components/LlmConnectionCard.jsx
@@ -8,6 +8,7 @@ export function LlmConnectionCard({ sid }) {
   const [apiKey, setApiKey] = useState('');
   const [status, setStatus] = useState(null); // null | 'testing' | { configured, reachable, model, error }
   const [savedModel, setSavedModel] = useState(null);
+  const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     if (!sid) return;
@@ -21,22 +22,31 @@ export function LlmConnectionCard({ sid }) {
   }, [sid]);
 
   async function handleSave() {
-    if (!sid) return;
+    if (!sid || loading) return;
+    setLoading(true);
+    setSavedModel(null);
     const body = { endpoint: endpoint.trim(), model: model.trim() };
-    if (apiKey) body.api_key = apiKey;
-    const result = await api.configureLlm(sid, body);
-    setSavedModel(result?.model || null);
-    setApiKey('');
+    if (apiKey.trim()) body.api_key = apiKey.trim();
+    try {
+      const result = await api.configureLlm(sid, body);
+      setSavedModel(result?.model || null);
+      setApiKey('');
+    } finally {
+      setLoading(false);
+    }
   }
 
   async function handleTest() {
-    if (!sid) return;
+    if (!sid || loading) return;
+    setLoading(true);
     setStatus('testing');
     try {
       const data = await api.getLlmStatus(sid);
       setStatus(data);
     } catch (err) {
       setStatus({ configured: false, reachable: false, error: err.message });
+    } finally {
+      setLoading(false);
     }
   }
 
@@ -125,8 +135,8 @@ export function LlmConnectionCard({ sid }) {
         </div>
         <div style={{ display: 'flex', flexDirection: 'column', gap: 6, marginTop: 2 }}>
           <div className="btn-group">
-            <Button small onClick={handleSave}>Save</Button>
-            <Button small onClick={handleTest}>Test connection</Button>
+            <Button small onClick={handleSave} disabled={loading}>Save</Button>
+            <Button small onClick={handleTest} disabled={loading}>Test connection</Button>
             {statusBadge}
           </div>
           {savedModel && (

--- a/frontend/src/components/LlmConnectionCard.jsx
+++ b/frontend/src/components/LlmConnectionCard.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Button } from './Button';
-import { getLlmStatus, configureLlm } from '../api/client';
+import * as api from '../api/client';
 
 export function LlmConnectionCard({ sid }) {
   const [endpoint, setEndpoint] = useState('');
@@ -11,7 +11,7 @@ export function LlmConnectionCard({ sid }) {
 
   useEffect(() => {
     if (!sid) return;
-    getLlmStatus(sid).then(data => {
+    api.getLlmStatus(sid).then(data => {
       if (data?.configured) {
         setEndpoint(data.endpoint || '');
         setModel(data.model || '');
@@ -24,7 +24,7 @@ export function LlmConnectionCard({ sid }) {
     if (!sid) return;
     const body = { endpoint: endpoint.trim(), model: model.trim() };
     if (apiKey) body.api_key = apiKey;
-    const result = await configureLlm(sid, body);
+    const result = await api.configureLlm(sid, body);
     setSavedModel(result?.model || null);
     setApiKey('');
   }
@@ -33,7 +33,7 @@ export function LlmConnectionCard({ sid }) {
     if (!sid) return;
     setStatus('testing');
     try {
-      const data = await getLlmStatus(sid);
+      const data = await api.getLlmStatus(sid);
       setStatus(data);
     } catch (err) {
       setStatus({ configured: false, reachable: false, error: err.message });

--- a/frontend/src/components/LlmConnectionCard.test.jsx
+++ b/frontend/src/components/LlmConnectionCard.test.jsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { LlmConnectionCard } from './LlmConnectionCard';
+import * as client from '../api/client';
+
+vi.mock('../api/client', () => ({
+  getLlmStatus: vi.fn(),
+  configureLlm: vi.fn(),
+}));
+
+const sid = 'test-session-123';
+
+describe('LlmConnectionCard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows "Not configured" when getLlmStatus returns configured:false', async () => {
+    client.getLlmStatus.mockResolvedValue({ configured: false });
+    render(<LlmConnectionCard sid={sid} />);
+    expect(await screen.findByText('Not configured')).toBeInTheDocument();
+  });
+
+  it('shows green reachable badge with model when reachable', async () => {
+    client.getLlmStatus.mockResolvedValue({ configured: true, reachable: true, model: 'llama3' });
+    render(<LlmConnectionCard sid={sid} />);
+    expect(await screen.findByText('Reachable (llama3)')).toBeInTheDocument();
+  });
+
+  it('shows error when configured but unreachable', async () => {
+    client.getLlmStatus.mockResolvedValue({ configured: true, reachable: false, error: 'HTTP 401: Unauthorized' });
+    render(<LlmConnectionCard sid={sid} />);
+    await screen.findByText('Not configured');
+    await userEvent.click(screen.getByText('Test connection'));
+    expect(await screen.findByText('HTTP 401: Unauthorized')).toBeInTheDocument();
+  });
+
+  it('clicking Save calls configureLlm with entered field values', async () => {
+    client.getLlmStatus.mockResolvedValue({ configured: false });
+    client.configureLlm.mockResolvedValue({ configured: true, model: 'llama3' });
+    render(<LlmConnectionCard sid={sid} />);
+    await screen.findByText('Not configured');
+
+    await userEvent.type(screen.getByPlaceholderText('http://localhost:11434/v1'), 'http://localhost:11434/v1');
+    await userEvent.type(screen.getByPlaceholderText('llama3'), 'llama3');
+    await userEvent.click(screen.getByText('Save'));
+
+    expect(client.configureLlm).toHaveBeenCalledOnce();
+    expect(client.configureLlm).toHaveBeenCalledWith(sid, { endpoint: 'http://localhost:11434/v1', model: 'llama3' });
+  });
+
+  it('prefills endpoint and model from status on mount when already configured', async () => {
+    client.getLlmStatus.mockResolvedValue({ configured: true, reachable: true, model: 'gpt-4', endpoint: 'https://api.openai.com/v1' });
+    render(<LlmConnectionCard sid={sid} />);
+    const endpointInput = await screen.findByDisplayValue('https://api.openai.com/v1');
+    expect(endpointInput).toBeInTheDocument();
+    expect(screen.getByDisplayValue('gpt-4')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/LlmConnectionCard.test.jsx
+++ b/frontend/src/components/LlmConnectionCard.test.jsx
@@ -57,4 +57,38 @@ describe('LlmConnectionCard', () => {
     expect(endpointInput).toBeInTheDocument();
     expect(screen.getByDisplayValue('gpt-4')).toBeInTheDocument();
   });
+
+  it('disables buttons while saving', async () => {
+    client.getLlmStatus.mockResolvedValue({ configured: false });
+    let resolveConfigure;
+    client.configureLlm.mockImplementation(() => new Promise(r => { resolveConfigure = r; }));
+    render(<LlmConnectionCard sid={sid} />);
+    await screen.findByText('Not configured');
+
+    await userEvent.type(screen.getByPlaceholderText('http://localhost:11434/v1'), 'http://localhost:11434/v1');
+    await userEvent.type(screen.getByPlaceholderText('llama3'), 'llama3');
+    await userEvent.click(screen.getByText('Save'));
+
+    expect(screen.getByText('Save')).toBeDisabled();
+    expect(screen.getByText('Test connection')).toBeDisabled();
+
+    resolveConfigure({ configured: true, model: 'llama3' });
+    await screen.findByText('Saved — configured model: llama3');
+
+    expect(screen.getByText('Save')).not.toBeDisabled();
+    expect(screen.getByText('Test connection')).not.toBeDisabled();
+  });
+
+  it('trims whitespace from endpoint, model, and api_key on save', async () => {
+    client.getLlmStatus.mockResolvedValue({ configured: false });
+    client.configureLlm.mockResolvedValue({ configured: true, model: 'llama3' });
+    render(<LlmConnectionCard sid={sid} />);
+    await screen.findByText('Not configured');
+
+    await userEvent.type(screen.getByPlaceholderText('http://localhost:11434/v1'), '  http://localhost:11434/v1  ');
+    await userEvent.type(screen.getByPlaceholderText('llama3'), '  llama3  ');
+    await userEvent.click(screen.getByText('Save'));
+
+    expect(client.configureLlm).toHaveBeenCalledWith(sid, { endpoint: 'http://localhost:11434/v1', model: 'llama3' });
+  });
 });

--- a/frontend/src/pages/Prepare.jsx
+++ b/frontend/src/pages/Prepare.jsx
@@ -2,10 +2,11 @@ import { useEffect, useState } from 'react';
 import { Card } from '../components/Card';
 import { Button } from '../components/Button';
 import { DogegenCard } from '../components/DogegenCard';
+import { LlmConnectionCard } from '../components/LlmConnectionCard';
 import { Tooltip } from '../components/Tooltip';
 import { CollapsibleSection } from '../components/CollapsibleSection';
 
-export function Prepare({ session, dogegenStatus, onConfirmPrepared, onPrev, onSetLightspaceTier, onSetGrayscaleRamp, onSetSignalRange, onSetCodeScale, onSetPatternGenerator, onSaveDogegenConfig, onStartDogegen, onStopDogegen, onConfigureLlm, onGetLlmStatus }) {
+export function Prepare({ session, dogegenStatus, onConfirmPrepared, onPrev, onSetLightspaceTier, onSetGrayscaleRamp, onSetSignalRange, onSetCodeScale, onSetPatternGenerator, onSaveDogegenConfig, onStartDogegen, onStopDogegen }) {
   const pd = session.prepare_data || {};
 
   const currentTier        = session.lightspace_tier      || 'free';
@@ -22,30 +23,12 @@ export function Prepare({ session, dogegenStatus, onConfirmPrepared, onPrev, onS
   const [selectedSignalRange, setSelectedSignalRange] = useState(currentSignalRange);
   const [selectedCodeScale,   setSelectedCodeScale]   = useState(currentCodeScale);
   const [selectedGenerator,   setSelectedGenerator]   = useState(currentGenerator);
-  const [settingsLoading, setSettingsLoading] = useState(false);
-
-  // AI Assistant state
-  const llmCfg = session.llm_config || {};
-  const [llmEnabled,   setLlmEnabled]   = useState(!!(llmCfg.endpoint && llmCfg.model));
-  const [llmEndpoint,  setLlmEndpoint]  = useState(llmCfg.endpoint || '');
-  const [llmModel,     setLlmModel]     = useState(llmCfg.model || '');
-  const [llmApiKey,    setLlmApiKey]    = useState('');
-  const [llmTestStatus, setLlmTestStatus] = useState(null); // null | 'testing' | 'ok' | 'unreachable' | 'error'
-  const [llmTestError,  setLlmTestError]  = useState('');
 
   useEffect(() => setSelectedTier(currentTier), [currentTier]);
   useEffect(() => setSelectedSteps(currentSteps), [currentSteps]);
   useEffect(() => setSelectedSignalRange(currentSignalRange), [currentSignalRange]);
   useEffect(() => setSelectedCodeScale(currentCodeScale), [currentCodeScale]);
   useEffect(() => setSelectedGenerator(currentGenerator), [currentGenerator]);
-
-  // Sync LLM config from session when it changes (e.g. after a round-trip)
-  useEffect(() => {
-    const cfg = session.llm_config || {};
-    setLlmEnabled(!!(cfg.endpoint && cfg.model));
-    setLlmEndpoint(cfg.endpoint || '');
-    setLlmModel(cfg.model || '');
-  }, [session.llm_config?.endpoint, session.llm_config?.model]);
 
   const availableRamps = selectedGenerator === 'lightspace_connect'
     ? rampOptions.filter(o => !o.requires_paid || selectedTier === 'paid')
@@ -89,71 +72,6 @@ export function Prepare({ session, dogegenStatus, onConfirmPrepared, onPrev, onS
   function handleCodeScaleChange(codeScale) {
     setSelectedCodeScale(codeScale);
     if (onSetCodeScale) onSetCodeScale(codeScale);
-  }
-
-  async function handleLlmToggle(enabled) {
-    setLlmEnabled(enabled);
-    setSettingsLoading(true);
-    try {
-      if (!enabled) {
-        setLlmEndpoint('');
-        setLlmModel('');
-        setLlmTestStatus(null);
-        if (onConfigureLlm) await onConfigureLlm({ endpoint: '', model: '' });
-      }
-    } finally {
-      setSettingsLoading(false);
-    }
-  }
-
-  async function handleLlmEndpointBlur(value) {
-    setSettingsLoading(true);
-    try {
-      if (onConfigureLlm) await onConfigureLlm({ endpoint: value.trim() });
-    } finally {
-      setSettingsLoading(false);
-    }
-  }
-
-  async function handleLlmModelBlur(value) {
-    setSettingsLoading(true);
-    try {
-      if (onConfigureLlm) await onConfigureLlm({ model: value.trim() });
-    } finally {
-      setSettingsLoading(false);
-    }
-  }
-
-  async function handleLlmApiKeyBlur(value) {
-    if (!value || !onConfigureLlm) return;
-    setSettingsLoading(true);
-    try {
-      await onConfigureLlm({ api_key: value });
-      setLlmApiKey('');
-    } finally {
-      setSettingsLoading(false);
-    }
-  }
-
-  async function handleTestConnection() {
-    if (!onGetLlmStatus) return;
-    setLlmTestStatus('testing');
-    setLlmTestError('');
-    try {
-      const data = await onGetLlmStatus();
-      if (data?.configured && data?.reachable) {
-        setLlmTestStatus('ok');
-      } else if (data?.configured) {
-        setLlmTestStatus('unreachable');
-        setLlmTestError(data?.error || '');
-      } else {
-        setLlmTestStatus('error');
-        setLlmTestError('Endpoint and model must both be set.');
-      }
-    } catch {
-      setLlmTestStatus('error');
-      setLlmTestError('Request failed — is the server running?');
-    }
   }
 
   const measurementSummary = [
@@ -411,92 +329,8 @@ export function Prepare({ session, dogegenStatus, onConfirmPrepared, onPrev, onS
         </CollapsibleSection>
       )}
 
-      {/* Section 4: AI Assistant — collapsed by default */}
-      <CollapsibleSection title="AI Assistant" storageKey="prepare-ai" defaultOpen={false}>
-        <Card>
-          <div className="text-sm muted" style={{ marginBottom: 16 }}>
-            Connect an OpenAI-compatible LLM (e.g. Ollama, LiteLLM) to get real-time coaching
-            after each ZRO import. If unconfigured the rest of the workflow is unaffected.
-          </div>
-          <label style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 16, cursor: 'pointer', userSelect: 'none' }}>
-            <input
-              type="checkbox"
-              checked={llmEnabled}
-              onChange={e => handleLlmToggle(e.target.checked)}
-              style={{ width: 16, height: 16, accentColor: 'var(--accent)', cursor: 'pointer' }}
-            />
-            <span style={{ fontSize: '0.875rem', fontWeight: 500 }}>Enable AI Assistant</span>
-          </label>
-          {llmEnabled && (
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
-              <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
-                <label style={{ fontSize: '0.78rem', fontWeight: 600, color: 'var(--ink2)', textTransform: 'uppercase', letterSpacing: '0.06em' }}>
-                  Endpoint URL
-                </label>
-                <input
-                  type="url"
-                  value={llmEndpoint}
-                  onChange={e => setLlmEndpoint(e.target.value)}
-                  onBlur={e => handleLlmEndpointBlur(e.target.value)}
-                  placeholder="http://localhost:11434/v1"
-                  autoComplete="off"
-                  spellCheck={false}
-                  disabled={settingsLoading}
-                  style={{ background: 'var(--panel2)', border: '1px solid var(--line2)', borderRadius: 'var(--radius)', color: 'var(--ink)', fontSize: '0.84rem', padding: '7px 10px', width: '100%', maxWidth: 480, outline: 'none', fontFamily: 'inherit' }}
-                />
-              </div>
-              <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
-                <label style={{ fontSize: '0.78rem', fontWeight: 600, color: 'var(--ink2)', textTransform: 'uppercase', letterSpacing: '0.06em' }}>
-                  Model name
-                </label>
-                <input
-                  type="text"
-                  value={llmModel}
-                  onChange={e => setLlmModel(e.target.value)}
-                  onBlur={e => handleLlmModelBlur(e.target.value)}
-                  placeholder="llama3"
-                  autoComplete="off"
-                  spellCheck={false}
-                  disabled={settingsLoading}
-                  style={{ background: 'var(--panel2)', border: '1px solid var(--line2)', borderRadius: 'var(--radius)', color: 'var(--ink)', fontSize: '0.84rem', padding: '7px 10px', width: '100%', maxWidth: 480, outline: 'none', fontFamily: 'inherit' }}
-                />
-              </div>
-              <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
-                <label style={{ fontSize: '0.78rem', fontWeight: 600, color: 'var(--ink2)', textTransform: 'uppercase', letterSpacing: '0.06em' }}>
-                  API key{' '}
-                  <span style={{ fontSize: '0.72rem', fontWeight: 400, textTransform: 'none', letterSpacing: 0, color: 'var(--line2)' }}>
-                    (optional — never shown)
-                  </span>
-                </label>
-                <input
-                  type="password"
-                  value={llmApiKey}
-                  onChange={e => setLlmApiKey(e.target.value)}
-                  onBlur={e => handleLlmApiKeyBlur(e.target.value)}
-                  placeholder="sk-…"
-                  autoComplete="new-password"
-                  disabled={settingsLoading}
-                  style={{ background: 'var(--panel2)', border: '1px solid var(--line2)', borderRadius: 'var(--radius)', color: 'var(--ink)', fontSize: '0.84rem', padding: '7px 10px', width: '100%', maxWidth: 480, outline: 'none', fontFamily: 'inherit' }}
-                />
-              </div>
-              <div style={{ display: 'flex', flexDirection: 'column', gap: 6, marginTop: 2 }}>
-                <div className="btn-group">
-                  <Button small onClick={handleTestConnection}>Test Connection</Button>
-                  {llmTestStatus === 'testing'    && <span style={{ fontSize: '0.8rem', fontWeight: 600, padding: '5px 10px', borderRadius: 'var(--radius)', color: 'var(--ink2)', background: 'var(--panel2)', border: '1px solid var(--line)' }}>Testing…</span>}
-                  {llmTestStatus === 'ok'         && <span style={{ fontSize: '0.8rem', fontWeight: 600, padding: '5px 10px', borderRadius: 'var(--radius)', color: 'var(--green)', background: 'var(--green-dim)', border: '1px solid #22c98759' }}>✓ Connected</span>}
-                  {llmTestStatus === 'unreachable'&& <span style={{ fontSize: '0.8rem', fontWeight: 600, padding: '5px 10px', borderRadius: 'var(--radius)', color: 'var(--red)',   background: 'var(--red-dim)',   border: '1px solid #e74c3c4d' }}>✗ Unreachable</span>}
-                  {llmTestStatus === 'error'      && <span style={{ fontSize: '0.8rem', fontWeight: 600, padding: '5px 10px', borderRadius: 'var(--radius)', color: 'var(--red)',   background: 'var(--red-dim)',   border: '1px solid #e74c3c4d' }}>✗ Error</span>}
-                </div>
-                {llmTestError && (llmTestStatus === 'unreachable' || llmTestStatus === 'error') && (
-                  <div style={{ fontSize: '0.78rem', color: 'var(--red)', fontFamily: 'monospace', padding: '6px 8px', background: 'var(--red-dim)', borderRadius: 'var(--radius)', wordBreak: 'break-all', maxWidth: 480 }}>
-                    {llmTestError}
-                  </div>
-                )}
-              </div>
-            </div>
-          )}
-        </Card>
-      </CollapsibleSection>
+      {/* Section 4: AI Assistant */}
+      <LlmConnectionCard sid={session.id} />
 
       <div className="btn-group">
         <Button onClick={onPrev}>← Back</Button>


### PR DESCRIPTION
## 📺 Overview

Extracts the inline LLM config UI from `Prepare.jsx` into a standalone `LlmConnectionCard` component with Save and Test connection buttons.

Closes #338

### What does this PR do?
* **Type of change:** [x] New feature
* **Component(s) affected:** UI / Prepare page

---

## 🛠️ Technical Context & Implementation

* **The Problem:** LLM connection setup was embedded as inline JSX in `Prepare.jsx` with 6 state variables and 5 handler functions, all piped through prop drilling from `App.jsx`.
* **The Solution:** Extract into a self-contained `LlmConnectionCard` that calls the API client directly via `sid\).
* **Impact on existing workflows/APIs:** No backend changes. The existing `configureLlm` and `getLlmStatus` client wrappers are reused as-is.

---

## 🧪 Testing & Validation

### Environment Details
* **OS / Target Display:** macOS / Frontend only
* **Hardware/Mock Used:** Vitest + React Testing Library (mocked API client)

### Verification Steps
1. `cd frontend && npx vitest run src/components/LlmConnectionCard.test.jsx`
2. All 5 new tests pass (not-configured, reachable, unreachable error, save call args, prefill)
3. Full frontend suite: 33/33 passing

---

## 🧼 Checklist
* [x] Code adheres to project style guidelines
* [x] Unit tests added and passing
* [ ] Documentation updated (not needed — no public API changes)
* [x] No credentials or paths leaked
