### PR TITLE
feat: LLM Bootstrap from History panel (#340)

### DIFF
--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -120,6 +120,7 @@ export const api = {
   // LLM
   configureLlm:  (sid, body)  => api.post(`/api/session/${sid}/llm/configure`, body),
   getLlmStatus:  (sid)        => api.get(`/api/session/${sid}/llm/status`),
+  getLlmHistorySummary: (sid)  => api.get(`/api/session/${sid}/llm/history-summary`),
   saveTvSettings: (sid, body) => api.post(`/api/session/${sid}/tv-settings`, body),
 
   // Suggested patches

--- a/frontend/src/components/LlmHistoryCard.jsx
+++ b/frontend/src/components/LlmHistoryCard.jsx
@@ -1,0 +1,48 @@
+import { useState, useEffect } from 'react';
+import * as api from '../api/client';
+
+export function LlmHistoryCard({ sid }) {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    Promise.resolve(sid ? api.getLlmHistorySummary(sid) : null)
+      .then((res) => {
+        if (!cancelled) setData(res);
+      })
+      .catch(() => {
+        if (!cancelled) setData(null);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, [sid]);
+
+  if (loading) return null;
+
+  const sessionCount = data?.session_count ?? 0;
+  const hasFinals = data?.has_final_settings ?? false;
+
+  return (
+    <div className="card">
+      <div style={{ fontSize: '1rem', fontWeight: 700, color: 'var(--ink)', marginBottom: 12 }}>
+        Bootstrap from History
+      </div>
+      <div style={{ fontSize: '0.82rem', color: 'var(--ink2)', lineHeight: 1.6 }}>
+        {sessionCount === 0 ? (
+          <>First calibration for this TV — the LLM will learn from this run.</>
+        ) : (
+          <>Priming the LLM from {sessionCount} prior session{sessionCount !== 1 ? 's' : ''}.</>
+        )}
+      </div>
+      {sessionCount > 0 && !hasFinals && (
+        <div style={{ fontSize: '0.78rem', color: 'var(--line2)', marginTop: 10, lineHeight: 1.5 }}>
+          Prior runs have no saved settings yet — predictions improve after the next completed run.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/LlmHistoryCard.jsx
+++ b/frontend/src/components/LlmHistoryCard.jsx
@@ -4,16 +4,18 @@ import * as api from '../api/client';
 export function LlmHistoryCard({ sid }) {
   const [data, setData] = useState(null);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
     setLoading(true);
+    setError(false);
     Promise.resolve(sid ? api.getLlmHistorySummary(sid) : null)
       .then((res) => {
         if (!cancelled) setData(res);
       })
       .catch(() => {
-        if (!cancelled) setData(null);
+        if (!cancelled) setError(true);
       })
       .finally(() => {
         if (!cancelled) setLoading(false);
@@ -22,6 +24,19 @@ export function LlmHistoryCard({ sid }) {
   }, [sid]);
 
   if (loading) return null;
+
+  if (error) {
+    return (
+      <div className="card">
+        <div style={{ fontSize: '1rem', fontWeight: 700, color: 'var(--ink)', marginBottom: 12 }}>
+          Bootstrap from History
+        </div>
+        <div style={{ fontSize: '0.82rem', color: 'var(--line2)', fontStyle: 'italic' }}>
+          Unable to load history.
+        </div>
+      </div>
+    );
+  }
 
   const sessionCount = data?.session_count ?? 0;
   const hasFinals = data?.has_final_settings ?? false;

--- a/frontend/src/components/LlmHistoryCard.test.jsx
+++ b/frontend/src/components/LlmHistoryCard.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { LlmHistoryCard } from './LlmHistoryCard';
 import * as client from '../api/client';

--- a/frontend/src/components/LlmHistoryCard.test.jsx
+++ b/frontend/src/components/LlmHistoryCard.test.jsx
@@ -61,11 +61,9 @@ describe('LlmHistoryCard', () => {
     expect(screen.queryByText(/Prior runs have no saved settings yet/)).not.toBeInTheDocument();
   });
 
-  it('renders nothing when API call rejects', async () => {
+  it('renders subtle error message when API call rejects', async () => {
     client.getLlmHistorySummary.mockRejectedValue(new Error('network error'));
-    const { container } = render(<LlmHistoryCard sid={sid} />);
-    await waitFor(() => {
-      expect(container).toBeEmptyDOMElement();
-    });
+    render(<LlmHistoryCard sid={sid} />);
+    expect(await screen.findByText('Unable to load history.')).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/LlmHistoryCard.test.jsx
+++ b/frontend/src/components/LlmHistoryCard.test.jsx
@@ -1,0 +1,71 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { LlmHistoryCard } from './LlmHistoryCard';
+import * as client from '../api/client';
+
+vi.mock('../api/client', () => ({
+  getLlmHistorySummary: vi.fn(),
+}));
+
+const sid = 'test-session-123';
+
+describe('LlmHistoryCard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders nothing while loading', () => {
+    client.getLlmHistorySummary.mockImplementation(() => new Promise(() => {}));
+    const { container } = render(<LlmHistoryCard sid={sid} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders first-calibration message when session_count is 0', async () => {
+    client.getLlmHistorySummary.mockResolvedValue({
+      tv_key: 'u8g',
+      session_count: 0,
+      has_final_settings: false,
+    });
+    render(<LlmHistoryCard sid={sid} />);
+    expect(await screen.findByText(/First calibration for this TV/)).toBeInTheDocument();
+  });
+
+  it('renders prior-session count when session_count is greater than 0', async () => {
+    client.getLlmHistorySummary.mockResolvedValue({
+      tv_key: 'u8g',
+      session_count: 3,
+      has_final_settings: true,
+    });
+    render(<LlmHistoryCard sid={sid} />);
+    expect(await screen.findByText(/Priming the LLM from 3 prior sessions/)).toBeInTheDocument();
+  });
+
+  it('renders muted line when prior runs have no saved settings', async () => {
+    client.getLlmHistorySummary.mockResolvedValue({
+      tv_key: 'u8g',
+      session_count: 2,
+      has_final_settings: false,
+    });
+    render(<LlmHistoryCard sid={sid} />);
+    expect(await screen.findByText(/Prior runs have no saved settings yet/)).toBeInTheDocument();
+  });
+
+  it('does not render muted line when has_final_settings is true', async () => {
+    client.getLlmHistorySummary.mockResolvedValue({
+      tv_key: 'u8g',
+      session_count: 1,
+      has_final_settings: true,
+    });
+    render(<LlmHistoryCard sid={sid} />);
+    await screen.findByText(/Priming the LLM from 1 prior session/);
+    expect(screen.queryByText(/Prior runs have no saved settings yet/)).not.toBeInTheDocument();
+  });
+
+  it('renders nothing when API call rejects', async () => {
+    client.getLlmHistorySummary.mockRejectedValue(new Error('network error'));
+    const { container } = render(<LlmHistoryCard sid={sid} />);
+    await waitFor(() => {
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
+});

--- a/frontend/src/pages/Prepare.jsx
+++ b/frontend/src/pages/Prepare.jsx
@@ -3,6 +3,7 @@ import { Card } from '../components/Card';
 import { Button } from '../components/Button';
 import { DogegenCard } from '../components/DogegenCard';
 import { LlmConnectionCard } from '../components/LlmConnectionCard';
+import { LlmHistoryCard } from '../components/LlmHistoryCard';
 import { Tooltip } from '../components/Tooltip';
 import { CollapsibleSection } from '../components/CollapsibleSection';
 
@@ -330,6 +331,7 @@ export function Prepare({ session, dogegenStatus, onConfirmPrepared, onPrev, onS
       )}
 
       {/* Section 4: AI Assistant */}
+      <LlmHistoryCard sid={session.id} />
       <LlmConnectionCard sid={session.id} />
 
       <div className="btn-group">

--- a/server.py
+++ b/server.py
@@ -1193,6 +1193,25 @@ def llm_status(sid: str):
     }
 
 
+@app.get("/api/session/{sid}/llm/history-summary")
+def llm_history_summary(sid: str):
+    session = store.get(sid)
+    tv_key = session.get("tv_key", "unknown")
+    summary = _history_summary(tv_key)
+    history = _load_history(tv_key, limit=3)
+    has_finals = any(
+        (h.get("wb_final") or h.get("cms_final")) for h in history
+    )
+    return {
+        "tv_key": tv_key,
+        "session_count": summary.get("session_count", 0),
+        "latest_date": summary.get("latest_date"),
+        "latest_post_de": summary.get("latest_post_de"),
+        "baseline_post_de": summary.get("baseline_post_de"),
+        "has_final_settings": has_finals,
+    }
+
+
 @app.post("/api/session/{sid}/llm/run")
 def llm_run(sid: str):
     session = store.get(sid)

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -1473,6 +1473,26 @@ class TestLLMIntegration:
         assert data["configured"] is True
         assert data["reachable"] is True
 
+    def test_llm_history_summary_fresh_session(self, client, session_id):
+        resp = client.get(f"/api/session/{session_id}/llm/history-summary")
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["session_count"] == 0
+        assert data["tv_key"] == "u8g"
+        assert data["has_final_settings"] is False
+
+    def test_llm_history_summary_fresh_session(self, client, session_id, monkeypatch):
+        monkeypatch.setattr(server_module, "_history_summary", lambda *a, **kw: {
+            "session_count": 0, "latest_date": None,
+            "latest_post_de": None, "baseline_post_de": None,
+        })
+        monkeypatch.setattr(server_module, "_load_history", lambda *a, **kw: [])
+        resp = client.get(f"/api/session/{session_id}/llm/history-summary")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["session_count"] == 0
+        assert data["has_final_settings"] is False
+
     def test_llm_run_not_configured_returns_400(self, client, session_id):
         resp = client.post(f"/api/session/{session_id}/llm/run")
         assert resp.status_code == 400

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -1473,14 +1473,6 @@ class TestLLMIntegration:
         assert data["configured"] is True
         assert data["reachable"] is True
 
-    def test_llm_history_summary_fresh_session(self, client, session_id):
-        resp = client.get(f"/api/session/{session_id}/llm/history-summary")
-        assert resp.status_code == 200, resp.text
-        data = resp.json()
-        assert data["session_count"] == 0
-        assert data["tv_key"] == "u8g"
-        assert data["has_final_settings"] is False
-
     def test_llm_history_summary_fresh_session(self, client, session_id, monkeypatch):
         monkeypatch.setattr(server_module, "_history_summary", lambda *a, **kw: {
             "session_count": 0, "latest_date": None,
@@ -1488,9 +1480,10 @@ class TestLLMIntegration:
         })
         monkeypatch.setattr(server_module, "_load_history", lambda *a, **kw: [])
         resp = client.get(f"/api/session/{session_id}/llm/history-summary")
-        assert resp.status_code == 200
+        assert resp.status_code == 200, resp.text
         data = resp.json()
         assert data["session_count"] == 0
+        assert data["tv_key"] == "u8g"
         assert data["has_final_settings"] is False
 
     def test_llm_run_not_configured_returns_400(self, client, session_id):


### PR DESCRIPTION
## Summary
- Adds `GET /api/session/{sid}/llm/history-summary` endpoint that exposes prior-session data for the current TV's LLM context
- New read-only `LlmHistoryCard` mounted in `Prepare.jsx` above the LLM connection card
- Shows first-calibration message when no history, or priming count with a muted note when prior runs have no saved finals
- No new LLM calls — display-only, reusing existing `_history_summary` / `_load_history`

## Backend
- `server.py`: new endpoint after `llm_status` (~line 1196)
- `tests/test_server_api.py`: `test_llm_history_summary_fresh_session` — verifies `session_count: 0` for a session with no prior history

## Frontend
- `client.js`: `getLlmHistorySummary` wrapper next to `getLlmStatus`
- `LlmHistoryCard.jsx`: async fetch on mount, loading→null, empty→first-calibration, populated→count + optional no-finals note
- `LlmHistoryCard.test.jsx`: 6 tests covering loading, first-calibration, populated, no-finals, has-finals, error states

Closes #340