### PR TITLE
Fix getPredictedSettings memoization in useSession hook

### DIFF
--- a/frontend/src/hooks/useSession.js
+++ b/frontend/src/hooks/useSession.js
@@ -449,10 +449,10 @@ export function useSession() {
     return api.runSuggestedPatches(session.id, patches);
   }
 
-  async function getPredictedSettings(phase) {
+  const getPredictedSettings = useCallback(async (phase) => {
     if (!session?.id) return null;
     return api.getPredictedSettings(session.id, phase);
-  }
+  }, [session?.id]);
 
   function dismissLlmInsight() {
     setLlmInsight(null);


### PR DESCRIPTION
Closes #349

Wrap `getPredictedSettings` in `useCallback` with `session.id` dependency to prevent `PredictedSettingsCard` from re-fetching on every session state update (measurement import, step transition, etc.).