### PR TITLE
Sync session.llm_config after LlmConnectionCard save

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -93,7 +93,7 @@ export default function App() {
     }
     switch (session.step) {
       case 'select_mode':    return <SelectMode    {...stepProps} onConfirmMode={sess.confirmMode} />;
-      case 'prepare':        return <Prepare       {...stepProps} onConfirmPrepared={sess.confirmPrepared} onSetLightspaceTier={sess.setLightspaceTier} onSetGrayscaleRamp={sess.setGrayscaleRamp} onSetSignalRange={sess.setSignalRange} onSetCodeScale={sess.setCodeScale} onSetPatternGenerator={sess.setPatternGenerator} />;
+      case 'prepare':        return <Prepare       {...stepProps} onConfirmPrepared={sess.confirmPrepared} onSetLightspaceTier={sess.setLightspaceTier} onSetGrayscaleRamp={sess.setGrayscaleRamp} onSetSignalRange={sess.setSignalRange} onSetCodeScale={sess.setCodeScale} onSetPatternGenerator={sess.setPatternGenerator} onConfigureLlm={sess.configureLlm} />;
       case 'pre_grayscale':  return <PreGrayscale  {...stepProps} />;
       case 'luminance':      return <Luminance     {...stepProps} adbStatus={adbStatus} onAdbSetPicture={sess.adbSetPicture} onAdbGetPicture={sess.adbGetPicture} onAdbDeploy={sess.adbDeploy} onRefreshAdb={sess.refreshAdbStatus} />;
       case 'white_balance':  return <WhiteBalance  {...stepProps} getPredictedSettings={getPredictedSettings} />;

--- a/frontend/src/components/LlmConnectionCard.jsx
+++ b/frontend/src/components/LlmConnectionCard.jsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { Button } from './Button';
 import * as api from '../api/client';
 
-export function LlmConnectionCard({ sid }) {
+export function LlmConnectionCard({ sid, onConfigureLlm }) {
   const [endpoint, setEndpoint] = useState('');
   const [model, setModel] = useState('');
   const [apiKey, setApiKey] = useState('');
@@ -28,7 +28,9 @@ export function LlmConnectionCard({ sid }) {
     const body = { endpoint: endpoint.trim(), model: model.trim() };
     if (apiKey.trim()) body.api_key = apiKey.trim();
     try {
-      const result = await api.configureLlm(sid, body);
+      const result = onConfigureLlm
+        ? await onConfigureLlm(body)
+        : await api.configureLlm(sid, body);
       setSavedModel(result?.model || null);
       setApiKey('');
     } finally {

--- a/frontend/src/components/LlmConnectionCard.test.jsx
+++ b/frontend/src/components/LlmConnectionCard.test.jsx
@@ -79,6 +79,21 @@ describe('LlmConnectionCard', () => {
     expect(screen.getByText('Test connection')).not.toBeDisabled();
   });
 
+  it('calls onConfigureLlm callback when provided instead of raw API', async () => {
+    const onConfigureLlm = vi.fn().mockResolvedValue({ configured: true, model: 'llama3' });
+    client.getLlmStatus.mockResolvedValue({ configured: false });
+    render(<LlmConnectionCard sid={sid} onConfigureLlm={onConfigureLlm} />);
+    await screen.findByText('Not configured');
+
+    await userEvent.type(screen.getByPlaceholderText('http://localhost:11434/v1'), 'http://localhost:11434/v1');
+    await userEvent.type(screen.getByPlaceholderText('llama3'), 'llama3');
+    await userEvent.click(screen.getByText('Save'));
+
+    expect(onConfigureLlm).toHaveBeenCalledOnce();
+    expect(onConfigureLlm).toHaveBeenCalledWith({ endpoint: 'http://localhost:11434/v1', model: 'llama3' });
+    expect(client.configureLlm).not.toHaveBeenCalled();
+  });
+
   it('trims whitespace from endpoint, model, and api_key on save', async () => {
     client.getLlmStatus.mockResolvedValue({ configured: false });
     client.configureLlm.mockResolvedValue({ configured: true, model: 'llama3' });

--- a/frontend/src/hooks/useSession.js
+++ b/frontend/src/hooks/useSession.js
@@ -426,7 +426,9 @@ export function useSession() {
 
   async function configureLlm(payload) {
     if (!session?.id) return;
-    return api.configureLlm(session.id, payload);
+    const result = await api.configureLlm(session.id, payload);
+    setSession(await api.getSession());
+    return result;
   }
 
   async function getLlmStatus() {

--- a/frontend/src/pages/Prepare.jsx
+++ b/frontend/src/pages/Prepare.jsx
@@ -7,7 +7,7 @@ import { LlmHistoryCard } from '../components/LlmHistoryCard';
 import { Tooltip } from '../components/Tooltip';
 import { CollapsibleSection } from '../components/CollapsibleSection';
 
-export function Prepare({ session, dogegenStatus, onConfirmPrepared, onPrev, onSetLightspaceTier, onSetGrayscaleRamp, onSetSignalRange, onSetCodeScale, onSetPatternGenerator, onSaveDogegenConfig, onStartDogegen, onStopDogegen }) {
+export function Prepare({ session, dogegenStatus, onConfirmPrepared, onPrev, onSetLightspaceTier, onSetGrayscaleRamp, onSetSignalRange, onSetCodeScale, onSetPatternGenerator, onSaveDogegenConfig, onStartDogegen, onStopDogegen, onConfigureLlm }) {
   const pd = session.prepare_data || {};
 
   const currentTier        = session.lightspace_tier      || 'free';
@@ -333,7 +333,7 @@ export function Prepare({ session, dogegenStatus, onConfirmPrepared, onPrev, onS
       {/* Section 4: AI Assistant — collapsed by default, user remembers preference */}
       <CollapsibleSection title="AI Assistant" storageKey="prepare-ai" defaultOpen={false}>
         <LlmHistoryCard sid={session.id} />
-        <LlmConnectionCard sid={session.id} />
+        <LlmConnectionCard sid={session.id} onConfigureLlm={onConfigureLlm} />
       </CollapsibleSection>
 
       <div className="btn-group">


### PR DESCRIPTION
## Summary

 called  directly, but the response was never fed back into  state. This left  stale in React, so any component branching on  (e.g. LLM SSE stream start) showed incorrect state after save.

## Fix

Follows the  callback pattern:

1. **** now reloads session state from the server after the API call, keeping  fresh.
2. **** accepts an  callback prop and calls it instead of the raw API when provided. Falls back to  when the prop is absent.
3. **** accepts and passes  down.
4. **** wires  into the Prepare step.
5. **Test** added for the callback path; existing tests continue to cover the fallback path.

## Testing

- Lint: clean
- Unit tests: 42/42 passing (including new callback test)

Closes #350