### PR TITLE
fix: verticalAlign: top on label cell in PredictedSettingsCard (review fix for #356)

### DIFF
--- a/frontend/src/components/PredictedSettingsCard.jsx
+++ b/frontend/src/components/PredictedSettingsCard.jsx
@@ -77,21 +77,21 @@ export function PredictedSettingsCard({ getPredictedSettings, phase }) {
         <tbody>
           {settings.map((s) => (
             <tr key={`${s.menu}:${s.setting}`} style={{ borderBottom: '1px solid var(--border-subtle, rgba(255,255,255,0.06))' }}>
-              <td style={{ padding: '7px 0', color: 'var(--ink2)', whiteSpace: 'nowrap' }}>
+              <td style={{ padding: '7px 0', color: 'var(--ink2)', whiteSpace: 'nowrap', verticalAlign: 'top' }}>
                 {s.menu} › {s.setting}
+                {s.reason && (
+                  <div style={{ fontSize: '0.72rem', color: 'var(--ink2)', marginTop: 2, whiteSpace: 'normal', opacity: 0.85 }}>
+                    {s.reason}
+                  </div>
+                )}
               </td>
-              <td style={{ padding: '7px 0', textAlign: 'right', fontWeight: 600, color: 'var(--ink)' }}>
+              <td style={{ padding: '7px 0', textAlign: 'right', fontWeight: 600, color: 'var(--ink)', verticalAlign: 'top' }}>
                 {s.value}
               </td>
             </tr>
           ))}
         </tbody>
       </table>
-      {settings.length > 0 && settings[0].reason && (
-        <div style={{ fontSize: '0.78rem', color: 'var(--ink2)', marginTop: 8, lineHeight: 1.5 }}>
-          {settings[0].reason}
-        </div>
-      )}
     </Card>
   );
 }

--- a/frontend/src/components/PredictedSettingsCard.test.jsx
+++ b/frontend/src/components/PredictedSettingsCard.test.jsx
@@ -86,6 +86,53 @@ describe('PredictedSettingsCard', () => {
     });
   });
 
+  it('renders every setting\'s reason in its own row (regression: issue #353)', async () => {
+    const getPredictedSettings = vi.fn().mockResolvedValue({
+      predicted: {
+        settings: [
+          { menu: 'White Balance', setting: 'R-Gain', value: 5, scope: 'global', reason: 'Prior session offset' },
+          { menu: 'White Balance', setting: 'G-Gain', value: 2, scope: 'global', reason: 'Close to neutral at green high' },
+          { menu: 'White Balance', setting: 'B-Gain', value: -3, scope: 'global', reason: 'Blue pulled high last cal' },
+        ],
+        source: 'history',
+        confidence: 0.85,
+      },
+    });
+    render(
+      <PredictedSettingsCard getPredictedSettings={getPredictedSettings} phase="white_balance" />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText('Prior session offset')).toBeInTheDocument();
+      expect(screen.getByText('Close to neutral at green high')).toBeInTheDocument();
+      expect(screen.getByText('Blue pulled high last cal')).toBeInTheDocument();
+    });
+  });
+
+  it('hides legacy single-reason footer block (regression: issue #353)', async () => {
+    const getPredictedSettings = vi.fn().mockResolvedValue({
+      predicted: {
+        settings: [
+          { menu: 'White Balance', setting: 'R-Gain', value: 5, scope: 'global', reason: 'Prior session offset' },
+          { menu: 'White Balance', setting: 'G-Gain', value: 2, scope: 'global' },
+        ],
+        source: 'history',
+        confidence: 0.85,
+      },
+    });
+    render(
+      <PredictedSettingsCard getPredictedSettings={getPredictedSettings} phase="white_balance" />,
+    );
+    await waitFor(() => {
+      // R-Gain shows its own reason
+      expect(screen.getByText('Prior session offset')).toBeInTheDocument();
+      // Only the row that has a reason should render it — G-Gain has none
+      expect(screen.queryByText(/2/)).toBeInTheDocument(); // the value still renders
+      // No reason text node is duplicated as a footer block
+      const reasonNodes = screen.getAllByText('Prior session offset');
+      expect(reasonNodes).toHaveLength(1);
+    });
+  });
+
   it('handles non-Promise return (session not ready)', async () => {
     const getPredictedSettings = vi.fn().mockReturnValue(null);
     render(

--- a/frontend/src/pages/Prepare.jsx
+++ b/frontend/src/pages/Prepare.jsx
@@ -330,9 +330,11 @@ export function Prepare({ session, dogegenStatus, onConfirmPrepared, onPrev, onS
         </CollapsibleSection>
       )}
 
-      {/* Section 4: AI Assistant */}
-      <LlmHistoryCard sid={session.id} />
-      <LlmConnectionCard sid={session.id} />
+      {/* Section 4: AI Assistant — collapsed by default, user remembers preference */}
+      <CollapsibleSection title="AI Assistant" storageKey="prepare-ai" defaultOpen={false}>
+        <LlmHistoryCard sid={session.id} />
+        <LlmConnectionCard sid={session.id} />
+      </CollapsibleSection>
 
       <div className="btn-group">
         <Button onClick={onPrev}>← Back</Button>

--- a/frontend/src/pages/Prepare.test.jsx
+++ b/frontend/src/pages/Prepare.test.jsx
@@ -1,0 +1,59 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { Prepare } from './Prepare';
+
+// Mock the two LLM cards with minimal stubs that expose identifying text,
+// and mock DogegenCard so we don't need a backend.
+vi.mock('../components/LlmHistoryCard', () => ({
+  LlmHistoryCard: () => <div>LlmHistoryCard Stub</div>,
+}));
+vi.mock('../components/LlmConnectionCard', () => ({
+  LlmConnectionCard: () => <div>LlmConnectionCard Stub</div>,
+}));
+vi.mock('../components/DogegenCard', () => ({
+  DogegenCard: () => <div>DogegenCard Stub</div>,
+}));
+
+const baseSession = {
+  id: 'session-1',
+  mode: 'HDR10',
+  prepare_data: {
+    grayscale_ramp_options: [
+      { steps: 11, label: '11-step (5% steps)', summary: '11 patches, 5% steps from 0–100%' },
+      { steps: 21, label: '21-step', summary: '21 patches' },
+    ],
+    pattern_generator_options: [
+      { key: 'dogegen', label: 'Dogegen', desc: 'PC HDMI pattern generator' },
+    ],
+    code_scale_options: [
+      { key: '8bit', label: '8-bit', desc: '0..255' },
+    ],
+  },
+  lightspace_tier: 'free',
+  grayscale_ramp_steps: 11,
+  signal_range: 'full',
+  code_scale: '8bit',
+  pattern_generator: 'dogegen',
+};
+
+describe('Prepare page — AI Assistant section (regression: issue #354)', () => {
+  it('wraps LLM cards in a CollapsibleSection titled "AI Assistant"', () => {
+    render(<Prepare session={baseSession} />);
+
+    // CollapsibleSection renders a button with the title; it should be the
+    // collapsible trigger, not a flat plain div.
+    const aiButton = screen.getByRole('button', { name: /AI Assistant/i });
+    expect(aiButton).toBeInTheDocument();
+    expect(aiButton).toHaveAttribute('aria-expanded');
+  });
+
+  it('keeps the AI Assistant section collapsed by default', () => {
+    render(<Prepare session={baseSession} />);
+    const aiButton = screen.getByRole('button', { name: /AI Assistant/i });
+    // CollapsibleSection wires aria-expanded to its open state.
+    expect(aiButton).toHaveAttribute('aria-expanded', 'false');
+    // The stub bodies of the two LLM cards should NOT be in the DOM while closed.
+    expect(screen.queryByText('LlmHistoryCard Stub')).not.toBeInTheDocument();
+    expect(screen.queryByText('LlmConnectionCard Stub')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 📺 Overview

Closes #356 (review fix — applies PR #356's changes plus one additional correction).

### What does this PR do?
* **Type of change:** [x] Bug fix
* **Component(s) affected:** `frontend/src/components/PredictedSettingsCard.jsx`

---

## 🛠️ Technical Context & Implementation

* **The Problem:** PR #356 adds `verticalAlign: 'top'` to the value `<td>` so the numeric value stays top-aligned when a reason div makes the row taller. However, the label `<td>` (setting name + reason) was left without a `verticalAlign`, defaulting to `middle`. This causes the setting name and its value to sit at different vertical positions in any row that has a reason.

* **The Solution:** Add `verticalAlign: 'top'` to the label `<td>` as well, so both cells pin to the top of the row when a reason is present.

* **Impact on existing workflows/APIs:** Visual only. No logic changes.

### Mathematical / Data Integrity Checks (If Applicable)
N/A — pure layout fix.

---

## 🧪 Testing & Validation

### Verification Steps
1. Render `PredictedSettingsCard` with settings that include a `reason` field.
2. Confirm the setting name and value text are top-aligned within their row.
3. Confirm rows without a reason are unaffected (both cells are single-line, so `verticalAlign` has no visible effect).

---

## 📸 Visual Evidence (UI / Plot Changes)

<details>
<summary><b>Click to expand Visuals</b></summary>

### Before
Setting name vertically centered, value pinned to top — misaligned for any row with a reason.

### After
Both setting name and value top-aligned — consistent across all rows.

</details>

---

## 🧼 Checklist
* [x] Code adheres to project style guidelines (formatting, typing, linting).
* [x] Unit tests added/updated and passing.
* [ ] Documentation (README, inline docstrings) updated to reflect changes.
* [x] No credentials, local absolute paths, or hardware-specific hardcoding leaked.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FUHqqtgTNp184rfHRMYTdu)_