### PR TITLE
Fix: Use correct gamma (2.2) for SDR BT.1886 EOTF

### DIFF
--- a/calcore/targets.py
+++ b/calcore/targets.py
@@ -33,7 +33,8 @@ def target_xyz_for_patch(
             rel = pq_eotf(n) / 10000.0
             target_y = measured_peak_y * rel
         elif cfg.eotf.lower() == "bt1886":
-            target_y = bt1886_eotf(n, measured_peak_y, measured_black_y, gamma=2.4)
+            gamma = 2.2 if cfg.mode.lower() == "sdr" else 2.4
+            target_y = bt1886_eotf(n, measured_peak_y, measured_black_y, gamma=gamma)
         else:
             gamma = (
                 2.2

--- a/calcore/targets.py
+++ b/calcore/targets.py
@@ -33,6 +33,7 @@ def target_xyz_for_patch(
             rel = pq_eotf(n) / 10000.0
             target_y = measured_peak_y * rel
         elif cfg.eotf.lower() == "bt1886":
+            # Use target's gamma: 2.2 for SDR (per SDR_TARGET in models.py), 2.4 for others
             gamma = 2.2 if cfg.mode.lower() == "sdr" else 2.4
             target_y = bt1886_eotf(n, measured_peak_y, measured_black_y, gamma=gamma)
         else:

--- a/tests/golden/data/sdr_bt709_grayscale.json
+++ b/tests/golden/data/sdr_bt709_grayscale.json
@@ -1,7 +1,7 @@
 {
-  "grayscale_avg_de": 1.1915755841757187,
-  "grayscale_max_de": 2.088598553075223,
-  "grayscale_over_3": 0,
+  "grayscale_avg_de": 2.344320097258325,
+  "grayscale_max_de": 4.238467727676889,
+  "grayscale_over_3": 5,
   "gamma_midtones": 2.3644412093905407,
   "pq_err_midtones": null,
   "color_75_avg_de": null,


### PR DESCRIPTION
## Summary
Fixes #366: The BT.1886 EOTF calculation was hardcoded to use gamma=2.4, but the SDR target specifies gamma=2.2. This caused ~10% luminance error in midtones, inflating delta-E values and causing incorrect gamma tracking recommendations.

## Root Cause
In `calcore/targets.py:36`, the BT.1886 EOTF was computed with a hardcoded gamma of 2.4, regardless of the calibration mode. For SDR sessions, the correct gamma is 2.2 (as defined in `SDR_TARGET`).

## Changes
- `calcore/targets.py`: Modified the BT.1886 case to derive gamma from the calibration mode
  - SDR mode: gamma=2.2 (matching SDR_TARGET definition)
  - Other modes: gamma=2.4 (default)
- Added inline comment explaining the mode-based gamma derivation for future maintainers

## Testing

### Unit Tests
- All existing unit tests pass (43 passed)
- Fix verified with gamma_midtones remaining in plausible range (1.5–3.5)

### Golden Dataset Regression
⚠️ **Expected baseline changes**: Grayscale delta-E metrics increased because reference Y values now use correct gamma (2.2):
- `grayscale_avg_de`: 1.19 → 2.34 (+96%)
- `grayscale_max_de`: 2.09 → 4.24 (+103%)
- `grayscale_over_3`: 0 → 5 patches

This is **correct behavior**. The reference dataset's measured gamma (~2.35) is now further from the corrected target (2.2), showing that the display needs more aggressive gamma adjustment. The old baseline was artificially low due to the buggy gamma=2.4 target.

### Downstream Impact Assessment
- **No breaking changes**: Higher delta-E values flow through existing decision logic correctly
  - LLM decision rules (calcore/llm.py) use thresholds of avg ΔE > 2.0 and max ΔE > 3.0 — these will now trigger appropriately for SDR sessions
  - Guidance logic (calibrator/guidance.py) checks de > 3.0 for luminance error flagging — this is now correct
- Case sensitivity verified: `cfg.mode.lower() == "sdr"` is defensive against different case inputs

---
_Generated with [Claude Code](https://claude.ai/code/session_01RN2jGsQpeGg1FiR3bA2U7h)_