### PR TITLE
Fix: Allow grayscale targets to use session white point instead of hardcoded D65

### DIFF
--- a/calcore/analysis.py
+++ b/calcore/analysis.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import math
 import statistics
-from typing import Any, Dict, List, Optional, Sequence
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
-from .colour import D65_xy, ciede2000, xyz_to_lab
+from .colour import D65_XYZ, D65_xy, ciede2000, xyY_to_xyz, xyz_to_lab
 from .eotf import pq_eotf
 from .models import AnalysisConfig, Patch, Summary
 from .targets import target_xyz_for_patch
@@ -22,12 +22,31 @@ def max_patch(rows: List[Dict[str, Any]], key: str) -> Optional[Dict[str, Any]]:
     return max(rows, key=lambda r: r.get(key, float("-inf")))
 
 
-def analyze(patches: List[Patch], cfg: AnalysisConfig, white_point_xy=None) -> Summary:
+def analyze(
+    patches: List[Patch],
+    cfg: AnalysisConfig,
+    white_point_xy: Optional[Tuple[float, float]] = None,
+) -> Summary:
+    """Analyze a list of measured patches against calibration targets.
+
+    Args:
+        patches: Measured color/grayscale patches from the instrument.
+        cfg: Analysis configuration (mode, EOTF, target color space, code range).
+        white_point_xy: Target white point chromaticity (x, y). Defaults to D65
+            (0.3127, 0.3290). Used for both grayscale target XYZ computation and
+            as the LAB reference white, so target and measured values are evaluated
+            in the same chromatic context.
+    """
     if not patches:
         raise ValueError("No valid patches found in the CSV.")
 
     if white_point_xy is None:
         white_point_xy = D65_xy
+
+    # Derive an absolute XYZ reference white at Y=100 from the chromaticity.
+    # xyz_to_lab expects absolute XYZ (not normalized), consistent with measured XYZ.
+    wx, wy = white_point_xy
+    white_xyz: Tuple[float, float, float] = xyY_to_xyz(wx, wy, 100.0)
 
     grayscale = [p for p in patches if p.is_grayscale]
     colors = [p for p in patches if not p.is_grayscale]
@@ -63,8 +82,8 @@ def analyze(patches: List[Patch], cfg: AnalysisConfig, white_point_xy=None) -> S
             measured_black_y,
             white_point_xy,
         )
-        targ_lab = xyz_to_lab(target_xyz)
-        meas_lab = xyz_to_lab(p.meas_xyz)
+        targ_lab = xyz_to_lab(target_xyz, white_xyz)
+        meas_lab = xyz_to_lab(p.meas_xyz, white_xyz)
         de = ciede2000(targ_lab, meas_lab)
         gray_des.append(de)
 
@@ -112,8 +131,8 @@ def analyze(patches: List[Patch], cfg: AnalysisConfig, white_point_xy=None) -> S
             measured_black_y,
             white_point_xy,
         )
-        targ_lab = xyz_to_lab(target_xyz)
-        meas_lab = xyz_to_lab(p.meas_xyz)
+        targ_lab = xyz_to_lab(target_xyz, white_xyz)
+        meas_lab = xyz_to_lab(p.meas_xyz, white_xyz)
         de = ciede2000(targ_lab, meas_lab)
 
         # Chroma-only approximation: keep measured L* fixed while comparing chromaticity mismatch.

--- a/calcore/analysis.py
+++ b/calcore/analysis.py
@@ -4,7 +4,7 @@ import math
 import statistics
 from typing import Any, Dict, List, Optional, Sequence
 
-from .colour import ciede2000, xyz_to_lab
+from .colour import D65_xy, ciede2000, xyz_to_lab
 from .eotf import pq_eotf
 from .models import AnalysisConfig, Patch, Summary
 from .targets import target_xyz_for_patch
@@ -22,9 +22,12 @@ def max_patch(rows: List[Dict[str, Any]], key: str) -> Optional[Dict[str, Any]]:
     return max(rows, key=lambda r: r.get(key, float("-inf")))
 
 
-def analyze(patches: List[Patch], cfg: AnalysisConfig) -> Summary:
+def analyze(patches: List[Patch], cfg: AnalysisConfig, white_point_xy=None) -> Summary:
     if not patches:
         raise ValueError("No valid patches found in the CSV.")
+
+    if white_point_xy is None:
+        white_point_xy = D65_xy
 
     grayscale = [p for p in patches if p.is_grayscale]
     colors = [p for p in patches if not p.is_grayscale]
@@ -58,6 +61,7 @@ def analyze(patches: List[Patch], cfg: AnalysisConfig) -> Summary:
             cfg,
             measured_peak_y_effective,
             measured_black_y,
+            white_point_xy,
         )
         targ_lab = xyz_to_lab(target_xyz)
         meas_lab = xyz_to_lab(p.meas_xyz)
@@ -106,6 +110,7 @@ def analyze(patches: List[Patch], cfg: AnalysisConfig) -> Summary:
             cfg,
             measured_peak_y_effective,
             measured_black_y,
+            white_point_xy,
         )
         targ_lab = xyz_to_lab(target_xyz)
         meas_lab = xyz_to_lab(p.meas_xyz)

--- a/calcore/targets.py
+++ b/calcore/targets.py
@@ -17,6 +17,7 @@ def target_xyz_for_patch(
     cfg: AnalysisConfig,
     measured_peak_y: Optional[float],
     measured_black_y: float,
+    white_point_xy: Tuple[float, float] = D65_xy,
 ) -> Tuple[float, float, float]:
     if code_max <= 0:
         raise ValueError(f"Invalid code_max: {code_max}, must be a positive integer")
@@ -43,7 +44,7 @@ def target_xyz_for_patch(
                 else float(cfg.eotf)
             )
             target_y = gamma_eotf(n, gamma=gamma) * measured_peak_y
-        return xyY_to_xyz(D65_xy[0], D65_xy[1], target_y)
+        return xyY_to_xyz(white_point_xy[0], white_point_xy[1], target_y)
 
     matrix = detect_matrix(cfg.target_space)
     return rgb_to_xyz(target_rgb, matrix)

--- a/calcore/targets.py
+++ b/calcore/targets.py
@@ -19,6 +19,17 @@ def target_xyz_for_patch(
     measured_black_y: float,
     white_point_xy: Tuple[float, float] = D65_xy,
 ) -> Tuple[float, float, float]:
+    """Compute the ideal target XYZ for a single patch.
+
+    For grayscale patches, applies the session EOTF to derive target luminance Y,
+    then converts to XYZ using white_point_xy as the chromaticity (default D65).
+    For color patches, converts the target RGB to XYZ via the target color space matrix.
+
+    Args:
+        white_point_xy: Chromaticity (x, y) of the target white point. Defaults to
+            D65 (0.3127, 0.3290). Pass the session target's white_point_xy for
+            non-D65 calibrations so grayscale targets are placed correctly.
+    """
     if code_max <= 0:
         raise ValueError(f"Invalid code_max: {code_max}, must be a positive integer")
 

--- a/server.py
+++ b/server.py
@@ -1309,7 +1309,9 @@ def gamut_diagnosis(sid: str):
         )
     cfg = _session_to_analysis_config(session)
     patches = [_measurement_to_patch(m) for m in cms_meas]
-    summary = _calcore_analyze(patches, cfg)
+    target = session.get("target")
+    white_point = target.white_point_xy if target else None
+    summary = _calcore_analyze(patches, cfg, white_point)
     diagnosis = _assess_gamut_constraints(
         summary.color_rows,
         cfg.target_space,
@@ -1335,7 +1337,9 @@ def gamut_advise(sid: str):
 
     cfg = _session_to_analysis_config(session)
     patches = [_measurement_to_patch(m) for m in cms_meas]
-    summary = _calcore_analyze(patches, cfg)
+    target = session.get("target")
+    white_point = target.white_point_xy if target else None
+    summary = _calcore_analyze(patches, cfg, white_point)
     diagnosis = _assess_gamut_constraints(summary.color_rows, cfg.target_space)
     diagnosis_text = _format_gamut_diagnosis(diagnosis)
 
@@ -1745,7 +1749,9 @@ def get_suggested_patches(sid: str, budget: int = 30):
 
     cfg = _session_to_analysis_config(session)
     patches_core = [_measurement_to_patch(m) for m in all_measurements]
-    summary = _calcore_analyze(patches_core, cfg)
+    target = session.get("target")
+    white_point = target.white_point_xy if target else None
+    summary = _calcore_analyze(patches_core, cfg, white_point)
 
     llm_cfg = LLMConfig.from_dict(llm_cfg_dict, default_timeout=60.0)
     phase = session.get("step", "baseline")
@@ -2024,10 +2030,11 @@ def post_next_settings(sid: str):
 
     cfg = _session_to_analysis_config(session)
     patches_core = [_measurement_to_patch(m) for m in all_measurements]
-    summary = _calcore_analyze(patches_core, cfg)
+    target = session.get("target")
+    white_point = target.white_point_xy if target else None
+    summary = _calcore_analyze(patches_core, cfg, white_point)
 
     phase = session.get("step", "baseline")
-    target = session.get("target")
     target_gamma = target.gamma if target else None
 
     # Reuse the per-TV quality-gate thresholds as convergence targets (#166).

--- a/tests/test_white_point.py
+++ b/tests/test_white_point.py
@@ -1,0 +1,105 @@
+"""Tests for white-point-aware target XYZ and delta-E computation (Issue #369)."""
+from __future__ import annotations
+
+import math
+import unittest
+
+from calcore.analysis import analyze
+from calcore.colour import D65_XYZ, D65_xy, xyY_to_xyz
+from calcore.models import AnalysisConfig, Patch
+from calcore.targets import target_xyz_for_patch
+
+# D50 white point (x=0.3457, y=0.3585) — common cinematic reference
+D50_xy = (0.3457, 0.3585)
+
+
+def _gray_patch(pct: int, code_max: int = 255, meas_xyz=(50.0, 50.0, 50.0)) -> Patch:
+    v = round(pct / 100 * code_max)
+    return Patch(
+        label=f"{pct}%",
+        r_target=v,
+        g_target=v,
+        b_target=v,
+        meas_xyz=meas_xyz,
+        kind="grayscale",
+    )
+
+
+class TestTargetXYZWhitePoint(unittest.TestCase):
+    """target_xyz_for_patch must use the supplied white point, not always D65."""
+
+    def _cfg(self) -> AnalysisConfig:
+        return AnalysisConfig(mode="sdr", eotf="gamma22", target_space="bt709", code_max=255)
+
+    def test_d65_default_matches_explicit_d65(self):
+        patch = _gray_patch(50)
+        cfg = self._cfg()
+        xyz_default = target_xyz_for_patch(patch, 255, cfg, 100.0, 0.0)
+        xyz_explicit = target_xyz_for_patch(patch, 255, cfg, 100.0, 0.0, D65_xy)
+        self.assertAlmostEqual(xyz_default[0], xyz_explicit[0], places=6)
+        self.assertAlmostEqual(xyz_default[1], xyz_explicit[1], places=6)
+        self.assertAlmostEqual(xyz_default[2], xyz_explicit[2], places=6)
+
+    def test_non_d65_white_shifts_target_xy(self):
+        """A D50 white point must produce a different target XYZ than D65."""
+        patch = _gray_patch(50)
+        cfg = self._cfg()
+        xyz_d65 = target_xyz_for_patch(patch, 255, cfg, 100.0, 0.0, D65_xy)
+        xyz_d50 = target_xyz_for_patch(patch, 255, cfg, 100.0, 0.0, D50_xy)
+        # Y (luminance) must be identical — only chromaticity changes
+        self.assertAlmostEqual(xyz_d65[1], xyz_d50[1], places=4)
+        # X and Z must differ because xy chromaticity changed
+        self.assertNotAlmostEqual(xyz_d65[0], xyz_d50[0], places=3)
+        self.assertNotAlmostEqual(xyz_d65[2], xyz_d50[2], places=3)
+
+    def test_white_patch_target_equals_white_point(self):
+        """100% gray target XYZ chromaticity must match the requested white point."""
+        patch = _gray_patch(100)
+        cfg = self._cfg()
+        for wp_xy in (D65_xy, D50_xy):
+            xyz = target_xyz_for_patch(patch, 255, cfg, 100.0, 0.0, wp_xy)
+            X, Y, Z = xyz
+            # Derived chromaticity
+            x = X / (X + Y + Z)
+            y = Y / (X + Y + Z)
+            self.assertAlmostEqual(x, wp_xy[0], places=4)
+            self.assertAlmostEqual(y, wp_xy[1], places=4)
+
+
+class TestAnalyzeWhitePoint(unittest.TestCase):
+    """analyze() must produce different delta-E values for different white points."""
+
+    def _sdr_cfg(self) -> AnalysisConfig:
+        return AnalysisConfig(mode="sdr", eotf="gamma22", target_space="bt709", code_max=255)
+
+    def test_d65_vs_d50_produces_different_delta_e(self):
+        """When the target white point differs, delta-E values must differ too."""
+        # Measure at D65 chromaticity — perfect for D65 session, wrong for D50 session
+        meas_xyz = xyY_to_xyz(D65_xy[0], D65_xy[1], 50.0)
+        patches = [_gray_patch(50, meas_xyz=meas_xyz)]
+        cfg = self._sdr_cfg()
+
+        summary_d65 = analyze(patches, cfg, white_point_xy=D65_xy)
+        summary_d50 = analyze(patches, cfg, white_point_xy=D50_xy)
+
+        de_d65 = summary_d65.grayscale_rows[0]["dE2000"]
+        de_d50 = summary_d50.grayscale_rows[0]["dE2000"]
+        # D65 measurement vs D65 target should be smaller than vs D50 target
+        self.assertLess(de_d65, de_d50)
+
+    def test_d65_default_matches_explicit_d65(self):
+        """Omitting white_point_xy must produce the same result as passing D65."""
+        meas_xyz = xyY_to_xyz(D65_xy[0], D65_xy[1], 50.0)
+        patches = [_gray_patch(50, meas_xyz=meas_xyz)]
+        cfg = self._sdr_cfg()
+
+        summary_implicit = analyze(patches, cfg)
+        summary_explicit = analyze(patches, cfg, white_point_xy=D65_xy)
+
+        de_implicit = summary_implicit.grayscale_rows[0]["dE2000"]
+        de_explicit = summary_explicit.grayscale_rows[0]["dE2000"]
+        self.assertAlmostEqual(de_implicit, de_explicit, places=6)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- **Issue #369**: Grayscale targets were always using D65 white point regardless of session target settings, causing delta-E inflation for non-D65 white points

## Changes

- Add `white_point_xy` parameter to `target_xyz_for_patch()` with D65 as default for backward compatibility
- Add `white_point_xy` parameter to `analyze()` function
- Update all callers in `server.py` to extract and pass the target's white point when available
- Prevents incorrect delta-E calculations when sessions target non-D65 white points (e.g., D50 for cinematic calibration)

## Test Plan

- Golden regression tests should verify correct delta-E calculations with different white points
- Backward compatibility maintained: all analyze() calls default to D65 if white_point_xy not provided

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01Shh4YEXta25iS8HtF1EDP2

---
_Generated by [Claude Code](https://claude.ai/code/session_01Shh4YEXta25iS8HtF1EDP2)_