### PR TITLE
Remove incorrect U8G 20-point WB sign-inversion claim

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -272,7 +272,6 @@ Use the following as authoritative grounding when planning:
 - Dogegen must be running and stable on the Windows PC before any measurement loop begins
 - ArgyllCMS commands are blocking; retry logic must account for USB timeouts
 - Dogegen pattern sequencing must be deterministic — any race condition in timing corrupts a measurement run
-- 20-point WB sliders on the U8G are sign-inverted: negative values brighten/cool, positive values darken/warm.  This is empirically confirmed and must be accounted for in any correction math.
 - Inter-node bleed is real; use conservative correction factor (~0.55) for Round 1 sweeps
 - Firmware tone mapping wall exists in the 40-70% signal range; do not attempt to correct it via menu controls
 - Local Dimming must be set to Medium during all calibration sessions to match viewing conditions

--- a/QE_AUDIT.md
+++ b/QE_AUDIT.md
@@ -51,8 +51,6 @@ not get reported.
 - **SDR** = BT.1886 EOTF / gamma 2.2; **HDR10** = PQ EOTF. EOTF and gamma are
   **not interchangeable** — confirm neither is silently substituted for the
   other (regression: #487, #388).
-- **U8G 20-point WB sliders are sign-inverted**: negative brightens/cools,
-  positive darkens/warms. Any correction that flips this sign is a Critical bug.
 - Conservative Round-1 correction factor (~0.55) for inter-node bleed.
 - Do **not** "correct" the 40–70% firmware tone-mapping wall via menu controls.
 - `CalibrationTarget.primaries` must always be normalized to dict form (#362).


### PR DESCRIPTION
## 📺 Overview

Removes an incorrect hardware constraint claim from `AGENTS.md` and `QE_AUDIT.md` stating that the Hisense U8G 20-point white balance sliders are sign-inverted.

### What does this PR do?
* **Type of change:** [x] Bug fix (incorrect documentation)
* **Component(s) affected:** `AGENTS.md`, `QE_AUDIT.md`

---

## 🛠️ Technical Context & Implementation

* **The Problem:** `AGENTS.md` and `QE_AUDIT.md` both claimed the U8G 20-point WB sliders are sign-inverted (negative = brightens/cools, positive = darkens/warms), and that any correction flipping this sign would be a Critical bug. This claim was never implemented anywhere in the codebase — no negation logic exists in the correction math.
* **The Solution:** Empirical testing on the physical TV confirmed that the 20-point sliders behave the same as the 2-point sliders: higher values warm/brighten, lower values cool/darken. The incorrect claim has been removed from both documentation files.
* **Impact on existing workflows/APIs:** None — no code implemented the inversion, so behavior is unchanged.

### Mathematical / Data Integrity Checks (If Applicable)
* [x] No matrix or LUT changes; documentation-only fix.

---

## 🧪 Testing & Validation

### Environment Details
* **OS / Target Display:** Hisense U8G (physical hardware)

### Verification Steps
1. Manually adjust a 20-point WB node on the U8G and confirm higher values warm the image (consistent with 2-point behavior).

### Firmware / TV Settings
* [x] Verified against target display (physical U8G)

---

## 🧼 Checklist
* [x] No code changes — documentation only.
* [x] No credentials, local absolute paths, or hardware-specific hardcoding leaked.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DXUoaTJprV1mqRdpQLDDY4)_