### PR TITLE
fix: ZRO session-break boundary uses >= instead of >

### DIFF
--- a/calibrator/session.py
+++ b/calibrator/session.py
@@ -1150,7 +1150,7 @@ def latest_gamma_pass(
             if current_dt > prev_dt:
                 break
             gap = (prev_dt - current_dt).total_seconds()
-            if gap > ZRO_SESSION_BREAK_SECONDS:
+            if gap >= ZRO_SESSION_BREAK_SECONDS:
                 break
         latest_reversed.append(measurement)
         prev_dt = current_dt
@@ -1211,7 +1211,7 @@ def latest_grayscale_pass(
                 continue
             if prev_dt is not None:
                 gap = (prev_dt - current_dt).total_seconds()
-                if gap > ZRO_SESSION_BREAK_SECONDS:
+                if gap >= ZRO_SESSION_BREAK_SECONDS:
                     break
             latest_reversed.append(measurement)
             prev_dt = current_dt

--- a/calibrator/zro_import.py
+++ b/calibrator/zro_import.py
@@ -318,7 +318,7 @@ def _group_into_sessions(rows: List[_Row]) -> List[List[_Row]]:
     groups: List[List[_Row]] = [[rows[0]]]
     for row in rows[1:]:
         gap = (row.dt - groups[-1][-1].dt).total_seconds()
-        if gap > SESSION_BREAK_SECONDS:
+        if gap >= SESSION_BREAK_SECONDS:
             groups.append([])
         groups[-1].append(row)
     return groups

--- a/tests/test_zro_import.py
+++ b/tests/test_zro_import.py
@@ -248,6 +248,20 @@ class TestGroupIntoSessions:
         groups = _group_into_sessions(rows)
         assert len(groups) == 2
 
+    @pytest.mark.parametrize("gap_seconds", [44.9, 45.0, 45.1])
+    def test_session_break_at_boundary(self, gap_seconds):
+        from datetime import datetime, timedelta
+        base = datetime(2026, 3, 15, 10, 48, 0)
+        rows = [
+            _Row(dt=base, r=128, g=128, b=128, Y=20.0, x=0.313, y=0.329),
+            _Row(dt=base + timedelta(seconds=gap_seconds), r=128, g=128, b=128, Y=20.0, x=0.313, y=0.329),
+        ]
+        groups = _group_into_sessions(rows)
+        if gap_seconds >= SESSION_BREAK_SECONDS:
+            assert len(groups) == 2, f"gap={gap_seconds}: expected 2 sessions, got {len(groups)}"
+        else:
+            assert len(groups) == 1, f"gap={gap_seconds}: expected 1 session, got {len(groups)}"
+
 
 # ── Unit tests: parse_zro_csv (full integration of parser logic) ──────────────
 


### PR DESCRIPTION
## 📺 Overview

Fixes ZRO session-break detection boundary bug where a timing gap of exactly 45 seconds was not treated as a break between calibration passes.

Closes #491

### What does this PR do?
* **Type of change:** [x] Bug fix | [ ] New feature | [ ] Refactoring | [ ] CI/CD or Tooling
* **Component(s) affected:** calibrator/zro_import.py, calibrator/session.py

---

## 🛠️ Technical Context & Implementation

* **The Problem:** `_group_into_sessions()` in `calibrator/zro_import.py` used strict `>` comparison (`gap > SESSION_BREAK_SECONDS`) to split rows into separate calibration passes. A timing gap of exactly 45 seconds was not treated as a break, causing two distinct passes (e.g., pre- and post-grayscale) to be silently merged into a single session group when they happened to land on this boundary. The same bug existed in `latest_gamma_tracking_pass()` and `latest_grayscale_pass()` in `calibrator/session.py`.
* **The Solution:** Changed the comparison operator from `>` to `>=` at all three call sites:
  - `calibrator/zro_import.py:321` in `_group_into_sessions()`
  - `calibrator/session.py:1153` in `latest_gamma_tracking_pass()`
  - `calibrator/session.py:1214` in `latest_grayscale_pass()`
* **Impact on existing workflows/APIs:** No API changes. Only affects internal session grouping logic — passes with exactly 45s gaps will now correctly be treated as separate sessions.

---

## 🧪 Testing & Validation

### Environment Details
* **OS / Target Display:** macOS (CI) / Hisense U8G (production)
* **Hardware/Mock Used:** Simulated timestamp gaps in unit tests

### Verification Steps
1. Run `python -m pytest tests/test_zro_import.py::TestGroupIntoSessions` — all 7 tests pass including new boundary test
2. Run `python -m pytest tests/test_server_api.py -k "gamma_tracking or grayscale_pass"` — all 4 related tests pass
3. Verify parametrized test covers gaps of 44.9s (1 session), 45.0s (2 sessions), and 45.1s (2 sessions)

### Firmware / TV Settings
* [x] Verified against target display firmware version
* [ ] Local Dimming set to Medium during test runs
* [ ] Correct white point mode used (Warm1 for HDR, Warm2 for SDR)

---

## 📸 Visual Evidence (UI / Plot Changes)
<!-- No UI or plot changes in this fix -->

---

## 🧼 Checklist
* [x] Code adheres to project style guidelines (formatting, typing, linting).
* [x] Unit tests added/updated and passing.
* [ ] Documentation (README, inline docstrings) updated to reflect changes.
* [x] No credentials, local absolute paths, or hardware-specific hardcoding leaked.