### PR TITLE
Fix HDR10/PQ gamma tracking: backend computation and frontend display now agree

### DIFF
--- a/calibrator/session.py
+++ b/calibrator/session.py
@@ -53,7 +53,7 @@ from .zro_import import (
 from .utils import (
     delta_e_ciede2000_xyY,
     delta_xy,
-    gamma_from_luminance,
+    eotf_from_luminance,
     stimulus_pct_from_code_value,
 )
 
@@ -1015,7 +1015,7 @@ def m_to_dict(
         and m.Y > 0
         and target.peak_luminance_nits > 0
     ):
-        g = gamma_from_luminance(m.Y, target.peak_luminance_nits, stim_pct)
+        g = eotf_from_luminance(m.Y, target.peak_luminance_nits, stim_pct, target.eotf)
         eff_gamma = round(g, 3) if g is not None else None
     rating = (
         "invalid"

--- a/frontend/src/charts/GammaChart.jsx
+++ b/frontend/src/charts/GammaChart.jsx
@@ -1,10 +1,14 @@
 import '../charts/index.js';
 import { Line } from 'react-chartjs-2';
 import { TICK, GRID, C } from './tokens.js';
+import { isPqEotf } from '../utils/fmt.js';
 
-export function GammaChart({ measurements }) {
+export function GammaChart({ measurements, eotf }) {
   const pts = (measurements || []).filter(m => m.effective_gamma != null && m.stimulus_pct != null);
   if (!pts.length) return null;
+
+  const pq = isPqEotf(eotf);
+  const target = pq ? 1.0 : 2.2;
 
   return (
     <div className="chart-wrap">
@@ -19,8 +23,8 @@ export function GammaChart({ measurements }) {
               tension: 0.3, pointBackgroundColor: C.cyan, fill: true,
             },
             {
-              label: 'Target 2.2',
-              data: pts.map(() => 2.2),
+              label: pq ? 'Target 1.0 (PQ)' : 'Target 2.2',
+              data: pts.map(() => target),
               borderColor: C.muted, borderDash: [4, 4], pointRadius: 0,
             },
           ],

--- a/frontend/src/charts/GammaChart.test.jsx
+++ b/frontend/src/charts/GammaChart.test.jsx
@@ -1,6 +1,14 @@
 import { render, screen } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { GammaChart } from './GammaChart';
+
+let lastChartProps = null;
+vi.mock('react-chartjs-2', () => ({
+  Line: (props) => {
+    lastChartProps = props;
+    return <canvas />;
+  },
+}));
 
 describe('GammaChart', () => {
   it('renders nothing when measurements is null', () => {
@@ -68,5 +76,21 @@ describe('GammaChart', () => {
   it('renders nothing when measurements is undefined', () => {
     const { container } = render(<GammaChart />);
     expect(container).toBeEmptyDOMElement();
+  });
+
+  it('passes "Target 2.2" reference dataset when eotf is unset (SDR)', () => {
+    const measurements = [{ stimulus_pct: 50, effective_gamma: 2.2 }];
+    render(<GammaChart measurements={measurements} />);
+    const target = lastChartProps.data.datasets.find(d => d.label.startsWith('Target'));
+    expect(target.label).toBe('Target 2.2');
+    expect(target.data).toEqual([2.2]);
+  });
+
+  it('passes "Target 1.0 (PQ)" reference dataset, not "Target 2.2", when eotf="PQ (ST.2084)"', () => {
+    const measurements = [{ stimulus_pct: 50, effective_gamma: 1.0 }];
+    render(<GammaChart measurements={measurements} eotf="PQ (ST.2084)" />);
+    const target = lastChartProps.data.datasets.find(d => d.label.startsWith('Target'));
+    expect(target.label).toBe('Target 1.0 (PQ)');
+    expect(target.data).toEqual([1.0]);
   });
 });

--- a/frontend/src/charts/OverlayGammaChart.jsx
+++ b/frontend/src/charts/OverlayGammaChart.jsx
@@ -1,8 +1,9 @@
 import '../charts/index.js';
 import { Line } from 'react-chartjs-2';
 import { TICK, GRID, C } from './tokens.js';
+import { isPqEotf } from '../utils/fmt.js';
 
-export function OverlayGammaChart({ measurementsA, measurementsB }) {
+export function OverlayGammaChart({ measurementsA, measurementsB, eotf }) {
   const rawA = measurementsA ?? [];
   const rawB = measurementsB ?? [];
 
@@ -20,6 +21,9 @@ export function OverlayGammaChart({ measurementsA, measurementsB }) {
   const dataA = allStimuli.map(s => (mapA.has(s) ? mapA.get(s) : null));
   const dataB = allStimuli.map(s => (mapB.has(s) ? mapB.get(s) : null));
 
+  const pq = isPqEotf(eotf);
+  const target = pq ? 1.0 : 2.2;
+
   const datasets = [
     {
       label: 'Session A (before)',
@@ -36,8 +40,8 @@ export function OverlayGammaChart({ measurementsA, measurementsB }) {
       fill: true,
     },
     {
-      label: 'Target 2.2',
-      data: allStimuli.map(() => 2.2),
+      label: pq ? 'Target 1.0 (PQ)' : 'Target 2.2',
+      data: allStimuli.map(() => target),
       borderColor: C.muted, borderDash: [4, 4], pointRadius: 0,
     },
   ];

--- a/frontend/src/charts/OverlayGammaChart.test.jsx
+++ b/frontend/src/charts/OverlayGammaChart.test.jsx
@@ -1,6 +1,14 @@
 import { render, screen } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { OverlayGammaChart } from './OverlayGammaChart';
+
+let lastChartProps = null;
+vi.mock('react-chartjs-2', () => ({
+  Line: (props) => {
+    lastChartProps = props;
+    return <canvas />;
+  },
+}));
 
 describe('OverlayGammaChart', () => {
   it('renders nothing when both measurement sets are empty', () => {
@@ -121,5 +129,21 @@ it('renders null when both sets are null', () => {
     const measurementsB = [{ stimulus_pct: 50, effective_gamma: undefined }];
     const { container } = render(<OverlayGammaChart measurementsA={measurementsA} measurementsB={measurementsB} />);
     expect(container).toBeEmptyDOMElement();
+  });
+
+  it('passes "Target 2.2" reference dataset when eotf is unset (SDR)', () => {
+    const measurementsA = [{ stimulus_pct: 50, effective_gamma: 2.1 }];
+    render(<OverlayGammaChart measurementsA={measurementsA} measurementsB={[]} />);
+    const target = lastChartProps.data.datasets.find(d => d.label.startsWith('Target'));
+    expect(target.label).toBe('Target 2.2');
+    expect(target.data).toEqual([2.2]);
+  });
+
+  it('passes "Target 1.0 (PQ)" reference dataset, not "Target 2.2", when eotf="PQ (ST.2084)"', () => {
+    const measurementsA = [{ stimulus_pct: 50, effective_gamma: 1.0 }];
+    render(<OverlayGammaChart measurementsA={measurementsA} measurementsB={[]} eotf="PQ (ST.2084)" />);
+    const target = lastChartProps.data.datasets.find(d => d.label.startsWith('Target'));
+    expect(target.label).toBe('Target 1.0 (PQ)');
+    expect(target.data).toEqual([1.0]);
   });
 });

--- a/frontend/src/pages/ComparisonPage.jsx
+++ b/frontend/src/pages/ComparisonPage.jsx
@@ -298,6 +298,8 @@ export function ComparisonPage({ profiles }) {
             <OverlayGammaChart
               measurementsA={repA?.gamma_measurements || []}
               measurementsB={repB?.gamma_measurements || []}
+              // Use either target's EOTF for the reference line; a meaningful gamma
+              // comparison assumes both sessions share an EOTF, so either is sufficient.
               eotf={repA?.target?.eotf || repB?.target?.eotf}
             />
           </Card>

--- a/frontend/src/pages/ComparisonPage.jsx
+++ b/frontend/src/pages/ComparisonPage.jsx
@@ -298,6 +298,7 @@ export function ComparisonPage({ profiles }) {
             <OverlayGammaChart
               measurementsA={repA?.gamma_measurements || []}
               measurementsB={repB?.gamma_measurements || []}
+              eotf={repA?.target?.eotf || repB?.target?.eotf}
             />
           </Card>
 

--- a/frontend/src/pages/Gamma.jsx
+++ b/frontend/src/pages/Gamma.jsx
@@ -46,7 +46,7 @@ export function Gamma({ session, onSetGammaWorkflow, onNext, onPrev, getPredicte
 
       {meas.length > 0 && (
         <Card title="Gamma Tracking">
-          <GammaChart measurements={meas} />
+          <GammaChart measurements={meas} eotf={session.target?.eotf} />
           <div className="mt-3">
             <CollapsibleSection title="Measurement Data" storageKey="gamma-measurements" summary={`${meas.length} point${meas.length !== 1 ? 's' : ''}`}>
               <MeasurementTable measurements={meas} includeGamma />

--- a/frontend/src/pages/Report.jsx
+++ b/frontend/src/pages/Report.jsx
@@ -123,7 +123,7 @@ export function Report({ session, onPrev }) {
           <Card title="Gamma Verification">
             {(report.gamma_measurements || []).length > 0 ? (
               <>
-                <GammaChart measurements={report.gamma_measurements} />
+                <GammaChart measurements={report.gamma_measurements} eotf={report.target?.eotf} />
                 <div className="mt-3"><MeasurementTable measurements={report.gamma_measurements} includeGamma /></div>
               </>
             ) : (

--- a/frontend/src/utils/fmt.js
+++ b/frontend/src/utils/fmt.js
@@ -35,3 +35,10 @@ export function measurementTimeSummary(startTs, endTs) {
   if (startTs && endTs && startTs !== endTs) return `${fmtTime(startTs)} to ${fmtTime(endTs)}`;
   return fmtTime(endTs || startTs);
 }
+
+// Mirrors calibrator/utils.py:is_pq_eotf — PQ does not follow a power law,
+// so gamma tracking must be compared against 1.0 instead of 2.2.
+export function isPqEotf(eotf) {
+  const e = (eotf || '').toLowerCase();
+  return e.includes('pq') || e.includes('2084');
+}

--- a/frontend/src/utils/fmt.js
+++ b/frontend/src/utils/fmt.js
@@ -36,8 +36,11 @@ export function measurementTimeSummary(startTs, endTs) {
   return fmtTime(endTs || startTs);
 }
 
-// Mirrors calibrator/utils.py:is_pq_eotf — PQ does not follow a power law,
-// so gamma tracking must be compared against 1.0 instead of 2.2.
+/**
+ * Check if EOTF denotes PQ / SMPTE ST.2084.
+ * Mirrors calibrator/utils.py:is_pq_eotf — PQ does not follow a power law,
+ * so gamma tracking must be compared against 1.0 instead of 2.2.
+ */
 export function isPqEotf(eotf) {
   const e = (eotf || '').toLowerCase();
   return e.includes('pq') || e.includes('2084');

--- a/tests/test_wb_hints.py
+++ b/tests/test_wb_hints.py
@@ -171,6 +171,31 @@ class TestMToDict:
         d = _m_to_dict(m, SDR_TARGET)
         assert d["effective_gamma"] is None
 
+    def test_effective_gamma_uses_pq_tracking_for_hdr10(self):
+        """HDR10/PQ sessions must report effective_gamma via PQ-relative tracking
+        (target 1.0), not the plain power-law gamma used for SDR.
+
+        Regression test: session.py historically called the non-EOTF-aware
+        gamma_from_luminance() unconditionally, ignoring target.eotf.
+        """
+        from calcore.models import HDR10_TARGET
+        from calibrator.utils import gamma_from_luminance
+
+        # PQ reference luminance at 50% stimulus, peak 1000 nits, is ~92.25 nits.
+        # A measurement landing exactly there should track at 1.0 under PQ.
+        m = Measurement(
+            x=0.3127, y=0.3290,
+            Y=92.25,
+            stimulus_rgb=(512, 512, 512),
+        )
+        d = _m_to_dict(m, HDR10_TARGET)
+        assert d["effective_gamma"] == pytest.approx(1.0, abs=0.05)
+
+        # The old, EOTF-unaware power law would have produced a very different
+        # (and meaningless) number for the same inputs.
+        plain_power_law = gamma_from_luminance(92.25, HDR10_TARGET.peak_luminance_nits, d["stimulus_pct"])
+        assert d["effective_gamma"] != pytest.approx(plain_power_law, abs=0.2)
+
     def test_delta_e_on_target_small(self):
         """D65 at the target peak luminance (120 nits) should have near-zero delta-E."""
         # SDR_TARGET: peak=120 nits, gamma=2.2.  100% stimulus → expected_Y = 120.


### PR DESCRIPTION
## 📺 Overview

Closes #505, Closes #507

These two issues describe the same defect from opposite ends of the stack, and #507 explicitly calls out that it should land alongside the #505 backend fix so both surfaces agree on which gamma-tracking scheme is in play for HDR10/PQ sessions. Grouping them avoids a window where one is fixed and the other still shows numbers that don't match.

### What does this PR do?
* **Type of change:** [x] Bug fix
* **Component(s) affected:** Backend measurement enrichment (`calibrator/session.py`), Gamma charts (`GammaChart`, `OverlayGammaChart`), pages that wire session/report data into those charts (`Gamma.jsx`, `Report.jsx`, `ComparisonPage.jsx`)

---

## 🛠️ Technical Context & Implementation

* **The Problem:** `calibrator/session.py`'s `m_to_dict()` computed every measurement's `effective_gamma` via the plain power-law `gamma_from_luminance()`, ignoring the session's EOTF. For PQ (HDR10) sessions this produces a meaningless number, since PQ doesn't follow a power law — `calibrator/guidance.py` already used the EOTF-aware `eotf_from_luminance()` for its own recommendations, so the two surfaces disagreed (#505). Compounding this, `GammaChart`/`OverlayGammaChart` always rendered a dashed "Target 2.2" reference line with no way to override it, even though PQ tracking should be compared against 1.0, not 2.2 (#507).
* **The Solution:** Make both the backend computation and the frontend display EOTF-aware and consistent with each other:
  - `session.py` now calls `eotf_from_luminance(m.Y, target.peak_luminance_nits, stim_pct, target.eotf)`, matching `guidance.py`'s existing call signature. For SDR/BT.1886 this is numerically identical to before (it falls through to the same power-law calculation); for PQ it now reports PQ-relative tracking where 1.0 = perfect.
  - `GammaChart` and `OverlayGammaChart` accept a new `eotf` prop. When the EOTF is PQ (via a new `isPqEotf()` helper in `frontend/src/utils/fmt.js`, mirroring `calibrator/utils.py:is_pq_eotf`), the reference dataset is relabeled "Target 1.0 (PQ)" with a value of `1.0` instead of `2.2`.
  - `session.target.eotf` / `report.target.eotf` are threaded down from `Gamma.jsx`, `Report.jsx`, and `ComparisonPage.jsx` (the latter falls back between Session A/B targets since either side of a comparison may carry the EOTF).
* **Impact on existing workflows/APIs:** None for SDR/BT.1886 sessions — output is unchanged. HDR10/PQ sessions now get correct, consistent gamma-tracking numbers and labels.

### Mathematical / Data Integrity Checks (If Applicable)
* [x] Floating-point precision or data truncation risks have been addressed — verified `eotf_from_luminance` produces ~1.0 for a measurement at the PQ reference luminance, matching its own docstring examples.

---

## 🧪 Testing & Validation

### Environment Details
* **OS / Target Display:** N/A — backend logic + chart unit tests, no physical display involved.
* **Hardware/Mock Used:** N/A

### Verification Steps
1. `python -m pytest tests/test_wb_hints.py tests/test_session.py tests/test_hdr_gamma_guidance.py tests/test_colour_science.py tests/test_server_api.py -q` — all pass, including a new regression test `test_effective_gamma_uses_pq_tracking_for_hdr10`.
2. Full backend suite: `python -m pytest tests/ -q` — all 804 tests pass.
3. `npx vitest run` (frontend) — all 89 tests pass, including new `GammaChart`/`OverlayGammaChart` cases asserting the reference dataset's label/value for both SDR and PQ.
4. `npm run build` — builds cleanly.

### Firmware / TV Settings
* N/A — this is a calculation/display fix, not a firmware-dependent change.

---

## 📸 Visual Evidence (UI / Plot Changes)
<details>
<summary><b>Click to expand Visuals</b></summary>

### Before
HDR10/PQ sessions showed a dashed "Target 2.2" line on the Gamma chart regardless of EOTF.

### After
HDR10/PQ sessions show "Target 1.0 (PQ)" instead, matching the now-correct `effective_gamma` values plotted against it.

</details>

---

## 🧼 Checklist
* [x] Code adheres to project style guidelines (ruff + eslint clean).
* [x] Unit tests added/updated and passing.
* [ ] Documentation (README, inline docstrings) updated to reflect changes — not applicable, no public API/doc changes.
* [x] No credentials, local absolute paths, or hardware-specific hardcoding leaked.
