### PR TITLE
fix: wrap config setters + repass() under SessionStore._lock to close TOCTOU race (#503)

### DIFF
--- a/.pr_body.md
+++ b/.pr_body.md
@@ -1,0 +1,59 @@
+## 📺 Overview
+
+Fixes OverlayGammaChart positional indexing bug where Session A data was mapped to Session B's stimulus positions, causing truncated and mis-positioned charts when ramp step counts differ between calibration passes.
+
+Closes [#492](https://github.com/jweber93/tv-calibration/issues/492)
+
+### What does this PR do?
+
+-   **Type of change:** [x] Bug fix | [ ] New feature | [ ] Refactoring | [ ] CI/CD or Tooling
+-   **Component(s) affected:** frontend/src/charts/OverlayGammaChart.jsx, frontend/src/charts/OverlayGammaChart.test.jsx
+
+---
+
+## 🛠️ Technical Context & Implementation
+
+-   **The Problem:** OverlayGammaChart built x-axis labels from Session B's measurement array (`ptsB`) but plotted Session A's gamma values from a separate array (`ptsA`). Chart.js aligned data strictly by array index. When the two sessions used different grayscale ramp step counts (e.g., Session A = 21 steps, Session B = 11 steps), Session A's points were mapped to Session B's stimulus positions and extra Session A points were silently dropped. The Target 2.2 reference line also had only 11 points, further mis-representing the ideal curve.
+-   **The Solution:** Replaced positional index approach with union-label + keyed-lookup pattern matching OverlayDeChart:
+    -   Compute `allStimuli` as sorted union of stimulus_pct values from both sessions
+    -   Generate labels array from allStimuli (e.g., `['0%', '5%', '10%', ..., '100%']`)
+    -   Map each dataset using `find()` lookup by stimulus_pct with null fallback for missing points
+    -   Target 2.2 line uses same allStimuli array length for consistent x-axis
+-   **Impact on existing workflows/APIs:** No API changes. Only affects frontend chart rendering — both pre- and post-calibration passes now display correctly regardless of differing ramp step counts.
+
+---
+
+## 🧪 Testing & Validation
+
+### Environment Details
+
+-   **OS / Target Display:** macOS (CI) / Hisense U8G (production)
+-   **Hardware/Mock Used:** Simulated measurement arrays with differing ramp counts
+
+### Verification Steps
+
+1.  Run `npm run lint` — no errors
+2.  Run `npm run test:unit` — all 80 tests pass including new regression test
+3.  Verify new test renders 21 distinct x-axis tick labels when Session A has 21 steps and Session B has 11 steps
+
+### Firmware / TV Settings
+
+-    Verified against target display firmware version
+-    Local Dimming set to Medium during test runs
+-    Correct white point mode used (Warm1 for HDR, Warm2 for SDR)
+
+---
+
+## 📸 Visual Evidence (UI / Plot Changes)
+
+-   Chart now displays all measurement points from both sessions at correct stimulus positions
+-   No more silent data truncation when ramp counts differ
+
+---
+
+## 🧼 Checklist
+
+-    Code adheres to project style guidelines (formatting, typing, linting).
+-    Unit tests added/updated and passing.
+-    Documentation (README, inline docstrings) updated to reflect changes.
+-    No credentials, local absolute paths, or hardware-specific hardcoding leaked.

--- a/calibrator/session.py
+++ b/calibrator/session.py
@@ -1820,84 +1820,90 @@ class SessionStore:
         return session
 
     def set_gamma_workflow(self, sid: str, workflow: str) -> Dict[str, Any]:
-        session = self.get(sid)
-        tv = TV_PROFILES[session["tv_key"]]
-        available = set(getattr(tv, "GAMMA_WORKFLOWS", ["quick"]))
-        if workflow not in available:
-            raise HTTPException(400, f"Unsupported gamma workflow: {workflow}")
-        session["gamma_workflow"] = workflow
-        self.save_session(sid)
-        return session
+        with self._lock:
+            session = self.get(sid)
+            tv = TV_PROFILES[session["tv_key"]]
+            available = set(getattr(tv, "GAMMA_WORKFLOWS", ["quick"]))
+            if workflow not in available:
+                raise HTTPException(400, f"Unsupported gamma workflow: {workflow}")
+            session["gamma_workflow"] = workflow
+            self.save_session(sid)
+            return session
 
     def set_signal_range(self, sid: str, signal_range: str) -> Dict[str, Any]:
-        session = self.get(sid)
-        if signal_range not in ("limited", "full"):
-            raise HTTPException(400, "signal_range must be 'limited' or 'full'")
-        session["signal_range"] = signal_range
-        session["code_scale"] = recommended_code_scale(
-            session.get("pattern_generator", "lightspace_connect"),
-            signal_range,
-            session.get("mode"),
-        )
-        self.save_session(sid)
-        return session
+        with self._lock:
+            session = self.get(sid)
+            if signal_range not in ("limited", "full"):
+                raise HTTPException(400, "signal_range must be 'limited' or 'full'")
+            session["signal_range"] = signal_range
+            session["code_scale"] = recommended_code_scale(
+                session.get("pattern_generator", "lightspace_connect"),
+                signal_range,
+                session.get("mode"),
+            )
+            self.save_session(sid)
+            return session
 
     def set_pattern_generator(self, sid: str, pattern_generator: str) -> Dict[str, Any]:
-        session = self.get(sid)
-        if pattern_generator not in PATTERN_GENERATOR_OPTIONS:
-            raise HTTPException(
-                400,
-                f"pattern_generator must be one of {sorted(PATTERN_GENERATOR_OPTIONS)}",
+        with self._lock:
+            session = self.get(sid)
+            if pattern_generator not in PATTERN_GENERATOR_OPTIONS:
+                raise HTTPException(
+                    400,
+                    f"pattern_generator must be one of {sorted(PATTERN_GENERATOR_OPTIONS)}",
+                )
+            session["pattern_generator"] = pattern_generator
+            session["code_scale"] = recommended_code_scale(
+                pattern_generator,
+                session.get("signal_range", "limited"),
+                session.get("mode"),
             )
-        session["pattern_generator"] = pattern_generator
-        session["code_scale"] = recommended_code_scale(
-            pattern_generator,
-            session.get("signal_range", "limited"),
-            session.get("mode"),
-        )
-        self.save_session(sid)
-        return session
+            self.save_session(sid)
+            return session
 
     def set_code_scale(self, sid: str, code_scale: str) -> Dict[str, Any]:
-        session = self.get(sid)
-        if code_scale not in ("8bit", "10bit"):
-            raise HTTPException(400, "code_scale must be '8bit' or '10bit'")
-        if code_scale == "10bit" and session.get("signal_range") != "full":
-            raise HTTPException(
-                400, "10bit code_scale currently requires Full signal range"
-            )
-        session["code_scale"] = code_scale
-        self.save_session(sid)
-        return session
+        with self._lock:
+            session = self.get(sid)
+            if code_scale not in ("8bit", "10bit"):
+                raise HTTPException(400, "code_scale must be '8bit' or '10bit'")
+            if code_scale == "10bit" and session.get("signal_range") != "full":
+                raise HTTPException(
+                    400, "10bit code_scale currently requires Full signal range"
+                )
+            session["code_scale"] = code_scale
+            self.save_session(sid)
+            return session
 
     def set_lightspace_tier(
         self, sid: str, tier: str, ramp_steps: int
     ) -> Dict[str, Any]:
-        session = self.get(sid)
-        if tier not in ("free", "paid"):
-            raise HTTPException(400, "tier must be 'free' or 'paid'")
-        if ramp_steps not in GRAYSCALE_RAMP_OPTIONS:
-            raise HTTPException(
-                400, f"ramp_steps must be one of {sorted(GRAYSCALE_RAMP_OPTIONS)}"
-            )
-        if GRAYSCALE_RAMP_OPTIONS[ramp_steps]["requires_paid"] and tier != "paid":
-            raise HTTPException(
-                400, f"{ramp_steps}-step ramp requires the paid LightSpace Connect tier"
-            )
-        session["lightspace_tier"] = tier
-        session["grayscale_ramp_steps"] = ramp_steps
-        self.save_session(sid)
-        return session
+        with self._lock:
+            session = self.get(sid)
+            if tier not in ("free", "paid"):
+                raise HTTPException(400, "tier must be 'free' or 'paid'")
+            if ramp_steps not in GRAYSCALE_RAMP_OPTIONS:
+                raise HTTPException(
+                    400, f"ramp_steps must be one of {sorted(GRAYSCALE_RAMP_OPTIONS)}"
+                )
+            if GRAYSCALE_RAMP_OPTIONS[ramp_steps]["requires_paid"] and tier != "paid":
+                raise HTTPException(
+                    400, f"{ramp_steps}-step ramp requires the paid LightSpace Connect tier"
+                )
+            session["lightspace_tier"] = tier
+            session["grayscale_ramp_steps"] = ramp_steps
+            self.save_session(sid)
+            return session
 
     def set_grayscale_ramp(self, sid: str, ramp_steps: int) -> Dict[str, Any]:
-        session = self.get(sid)
-        if ramp_steps not in GRAYSCALE_RAMP_OPTIONS:
-            raise HTTPException(
-                400, f"ramp_steps must be one of {sorted(GRAYSCALE_RAMP_OPTIONS)}"
-            )
-        session["grayscale_ramp_steps"] = ramp_steps
-        self.save_session(sid)
-        return session
+        with self._lock:
+            session = self.get(sid)
+            if ramp_steps not in GRAYSCALE_RAMP_OPTIONS:
+                raise HTTPException(
+                    400, f"ramp_steps must be one of {sorted(GRAYSCALE_RAMP_OPTIONS)}"
+                )
+            session["grayscale_ramp_steps"] = ramp_steps
+            self.save_session(sid)
+            return session
 
     def next_step(self, sid: str, luminance_threshold_pct: float) -> Dict[str, Any]:
         with self._lock:
@@ -2020,42 +2026,43 @@ class SessionStore:
         Increments repass_count, checks against REPATCH_MAX_PASSES, and
         jumps the session back to the relevant measurement step.
         """
-        session = self.get(sid)
-        current_step = session["step"]
+        with self._lock:
+            session = self.get(sid)
+            current_step = session["step"]
 
-        if action == "ceiling":
-            session.setdefault("repass_decision", {})
-            session["repass_decision"]["action"] = "ceiling"
-            session["repass_decision"]["reason"] = reason
-            session["repass_decision"]["ceiling_reason"] = ceiling_reason
-            session["repass_decision"]["timestamp"] = now().isoformat()
-            self.save_session(sid)
-            return session
-
-        if action == "repatch":
-            session["repass_count"] = session.get("repass_count", 0) + 1
-            if session["repass_count"] > REPATCH_MAX_PASSES:
+            if action == "ceiling":
                 session.setdefault("repass_decision", {})
                 session["repass_decision"]["action"] = "ceiling"
-                session["repass_decision"]["reason"] = (
-                    f"Max repass limit ({REPATCH_MAX_PASSES}) reached"
-                )
-                session["repass_decision"]["ceiling_reason"] = ceiling_reason or "Exceeded maximum repass count"
+                session["repass_decision"]["reason"] = reason
+                session["repass_decision"]["ceiling_reason"] = ceiling_reason
                 session["repass_decision"]["timestamp"] = now().isoformat()
-                session["step"] = "report"
                 self.save_session(sid)
                 return session
 
-        session.setdefault("repass_decision", {})
-        session["repass_decision"]["action"] = action
-        session["repass_decision"]["reason"] = reason
-        session["repass_decision"]["patches"] = patches or []
-        session["repass_decision"]["timestamp"] = now().isoformat()
+            if action == "repatch":
+                session["repass_count"] = session.get("repass_count", 0) + 1
+                if session["repass_count"] > REPATCH_MAX_PASSES:
+                    session.setdefault("repass_decision", {})
+                    session["repass_decision"]["action"] = "ceiling"
+                    session["repass_decision"]["reason"] = (
+                        f"Max repass limit ({REPATCH_MAX_PASSES}) reached"
+                    )
+                    session["repass_decision"]["ceiling_reason"] = ceiling_reason or "Exceeded maximum repass count"
+                    session["repass_decision"]["timestamp"] = now().isoformat()
+                    session["step"] = "report"
+                    self.save_session(sid)
+                    return session
 
-        step_to_remeasure = _repass_target_step(current_step)
-        session["step"] = step_to_remeasure
-        self.save_session(sid)
-        return session
+            session.setdefault("repass_decision", {})
+            session["repass_decision"]["action"] = action
+            session["repass_decision"]["reason"] = reason
+            session["repass_decision"]["patches"] = patches or []
+            session["repass_decision"]["timestamp"] = now().isoformat()
+
+            step_to_remeasure = _repass_target_step(current_step)
+            session["step"] = step_to_remeasure
+            self.save_session(sid)
+            return session
 
     def record_adjustment_round(
         self,

--- a/calibrator/session.py
+++ b/calibrator/session.py
@@ -1820,6 +1820,11 @@ class SessionStore:
         return session
 
     def set_gamma_workflow(self, sid: str, workflow: str) -> Dict[str, Any]:
+        """Set the gamma calibration workflow for this session.
+
+        Atomic: held under ``SessionStore._lock`` to prevent TOCTOU races
+        with concurrent delete/eviction (#503).
+        """
         with self._lock:
             session = self.get(sid)
             tv = TV_PROFILES[session["tv_key"]]
@@ -1831,6 +1836,11 @@ class SessionStore:
             return session
 
     def set_signal_range(self, sid: str, signal_range: str) -> Dict[str, Any]:
+        """Set the HDMI signal range (limited or full).
+
+        Atomic: held under ``SessionStore._lock`` to prevent TOCTOU races
+        with concurrent delete/eviction (#503).
+        """
         with self._lock:
             session = self.get(sid)
             if signal_range not in ("limited", "full"):
@@ -1845,6 +1855,11 @@ class SessionStore:
             return session
 
     def set_pattern_generator(self, sid: str, pattern_generator: str) -> Dict[str, Any]:
+        """Set the pattern generator source for this session.
+
+        Atomic: held under ``SessionStore._lock`` to prevent TOCTOU races
+        with concurrent delete/eviction (#503).
+        """
         with self._lock:
             session = self.get(sid)
             if pattern_generator not in PATTERN_GENERATOR_OPTIONS:
@@ -1862,6 +1877,11 @@ class SessionStore:
             return session
 
     def set_code_scale(self, sid: str, code_scale: str) -> Dict[str, Any]:
+        """Set the ADC code scale (8bit or 10bit).
+
+        Atomic: held under ``SessionStore._lock`` to prevent TOCTOU races
+        with concurrent delete/eviction (#503).
+        """
         with self._lock:
             session = self.get(sid)
             if code_scale not in ("8bit", "10bit"):
@@ -1877,6 +1897,11 @@ class SessionStore:
     def set_lightspace_tier(
         self, sid: str, tier: str, ramp_steps: int
     ) -> Dict[str, Any]:
+        """Set the LightSpace Connect tier and grayscale ramp step count.
+
+        Atomic: held under ``SessionStore._lock`` to prevent TOCTOU races
+        with concurrent delete/eviction (#503).
+        """
         with self._lock:
             session = self.get(sid)
             if tier not in ("free", "paid"):
@@ -1895,6 +1920,11 @@ class SessionStore:
             return session
 
     def set_grayscale_ramp(self, sid: str, ramp_steps: int) -> Dict[str, Any]:
+        """Set the grayscale ramp step count for this session.
+
+        Atomic: held under ``SessionStore._lock`` to prevent TOCTOU races
+        with concurrent delete/eviction (#503).
+        """
         with self._lock:
             session = self.get(sid)
             if ramp_steps not in GRAYSCALE_RAMP_OPTIONS:
@@ -2025,6 +2055,9 @@ class SessionStore:
 
         Increments repass_count, checks against REPATCH_MAX_PASSES, and
         jumps the session back to the relevant measurement step.
+
+        Atomic: held under ``SessionStore._lock`` to prevent TOCTOU races
+        with concurrent delete/eviction (#503).
         """
         with self._lock:
             session = self.get(sid)

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -813,3 +813,256 @@ class TestStepTransitionTOCTOU:
         assert final["step"] == "luminance", (
             f"jump_to_step left session at wrong step: {final['step']}, results={results}"
         )
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# TOCTOU regression tests — config setters + repass hold the RLock (#503)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestConfigSetterTOCTOU:
+    """Verify that config setters and repass() serialise under the RLock.
+
+    Before the fix these methods released the lock after get() and reacquired
+    it only in save_session(), leaving a window where a concurrent delete or
+    eviction could resurrect the session or silently discard the write while
+    still reporting success to the client.
+
+    After the fix each method holds ``with self._lock:`` across get→mutate→save,
+    matching the pattern already used by step-transition methods (#490).
+
+    As with ``TestConcurrentEviction``, one side of the race will get a 404 —
+    that is an acceptable graceful failure.  What matters is no crash, no
+    resurrection of a deleted session, and consistency when the session
+    survives.
+    """
+
+    def _run_setter_vs_delete(self, store, sid, setter_fn, expected_key,
+                              expected_value):
+        """Generic helper: race a config setter against delete."""
+        errors = []
+        barrier = threading.Barrier(2)
+
+        def setter():
+            try:
+                barrier.wait()
+                setter_fn()
+            except Exception as e:
+                errors.append(f"setter: {type(e).__name__}: {e}")
+
+        def deleter():
+            try:
+                barrier.wait()
+                store.delete(sid)
+            except Exception as e:
+                errors.append(f"delete: {type(e).__name__}: {e}")
+
+        t1 = threading.Thread(target=setter)
+        t2 = threading.Thread(target=deleter)
+        t1.start()
+        t2.start()
+        t1.join(timeout=10.0)
+        t2.join(timeout=10.0)
+
+        assert not t1.is_alive() and not t2.is_alive(), "Thread(s) hung"
+        # Both must complete without crashing — 404 from the loser is fine.
+        crash_errors = [e for e in errors if "TypeError" in str(type(e))]
+        assert not crash_errors, f"Crashes during race: {errors}"
+
+        # Session must be either fully updated OR completely gone.
+        remaining = store.sessions.get(sid)
+        if remaining is not None:
+            assert remaining[expected_key] == expected_value, (
+                f"Session survived but setting not applied: "
+                f"{expected_key}={remaining.get(expected_key)}"
+            )
+
+    def test_set_code_scale_concurrent_delete_no_resurrection(self, store):
+        """set_code_scale concurrent with delete — no resurrection."""
+        sid = store.create_session("u8g")["id"]
+        store.select_mode(sid, "SDR", sdr_peak_nits=120)
+        store.confirm_prepared(sid)
+        self._run_setter_vs_delete(
+            store, sid, lambda: store.set_code_scale(sid, "10bit"),
+            "code_scale", "10bit"
+        )
+
+    def test_set_signal_range_concurrent_delete_no_resurrection(self, store):
+        """set_signal_range concurrent with delete — no resurrection."""
+        sid = store.create_session("u8g")["id"]
+        store.select_mode(sid, "SDR", sdr_peak_nits=120)
+        store.confirm_prepared(sid)
+        self._run_setter_vs_delete(
+            store, sid, lambda: store.set_signal_range(sid, "full"),
+            "signal_range", "full"
+        )
+
+    def test_set_pattern_generator_concurrent_delete_no_resurrection(self, store):
+        """set_pattern_generator concurrent with delete — no resurrection."""
+        sid = store.create_session("u8g")["id"]
+        store.select_mode(sid, "SDR", sdr_peak_nits=120)
+        store.confirm_prepared(sid)
+        self._run_setter_vs_delete(
+            store, sid, lambda: store.set_pattern_generator(sid, "dogegen"),
+            "pattern_generator", "dogegen"
+        )
+
+    def test_set_grayscale_ramp_concurrent_delete_no_resurrection(self, store):
+        """set_grayscale_ramp concurrent with delete — no resurrection."""
+        sid = store.create_session("u8g")["id"]
+        store.select_mode(sid, "SDR", sdr_peak_nits=120)
+        store.confirm_prepared(sid)
+        self._run_setter_vs_delete(
+            store, sid, lambda: store.set_grayscale_ramp(sid, 11),
+            "grayscale_ramp_steps", 11
+        )
+
+    def test_set_lightspace_tier_concurrent_delete_no_resurrection(self, store):
+        """set_lightspace_tier concurrent with delete — no resurrection."""
+        sid = store.create_session("u8g")["id"]
+        store.select_mode(sid, "SDR", sdr_peak_nits=120)
+        store.confirm_prepared(sid)
+        self._run_setter_vs_delete(
+            store, sid, lambda: store.set_lightspace_tier(sid, "free", 11),
+            "lightspace_tier", "free"
+        )
+
+    def test_set_gamma_workflow_concurrent_delete_no_resurrection(self, store):
+        """set_gamma_workflow concurrent with delete — no resurrection."""
+        sid = store.create_session("u8g")["id"]
+        store.select_mode(sid, "SDR", sdr_peak_nits=120)
+        store.confirm_prepared(sid)
+        self._run_setter_vs_delete(
+            store, sid, lambda: store.set_gamma_workflow(sid, "quick"),
+            "gamma_workflow", "quick"
+        )
+
+    def test_repass_concurrent_delete_no_resurrection(self, store):
+        """repass concurrent with delete — no resurrection."""
+        sid = store.create_session("u8g")["id"]
+        store.select_mode(sid, "SDR", sdr_peak_nits=120)
+        store.confirm_prepared(sid)
+
+        errors = []
+        barrier = threading.Barrier(2)
+
+        def repasser():
+            try:
+                barrier.wait()
+                store.repass(sid, "repatch")
+            except Exception as e:
+                errors.append(f"repass: {type(e).__name__}: {e}")
+
+        def deleter():
+            try:
+                barrier.wait()
+                store.delete(sid)
+            except Exception as e:
+                errors.append(f"delete: {type(e).__name__}: {e}")
+
+        t1 = threading.Thread(target=repasser)
+        t2 = threading.Thread(target=deleter)
+        t1.start()
+        t2.start()
+        t1.join(timeout=10.0)
+        t2.join(timeout=10.0)
+
+        assert not t1.is_alive() and not t2.is_alive(), "Thread(s) hung"
+        remaining = store.sessions.get(sid)
+        if remaining is not None:
+            assert remaining["repass_count"] == 1
+
+    def test_concurrent_setters_serialise(self, store):
+        """Two concurrent setters on the same field — only one value wins.
+
+        Without the lock both threads could read a stale session, each apply
+        their own value, and save — the second save wins but both clients
+        reported success.  With the lock they serialise: exactly one value is
+        persisted and both calls complete without error.
+        """
+        sid = store.create_session("u8g")["id"]
+        store.select_mode(sid, "SDR", sdr_peak_nits=120)
+        store.confirm_prepared(sid)
+
+        errors = []
+        barrier = threading.Barrier(2)
+
+        def setter_a():
+            try:
+                barrier.wait()
+                store.set_code_scale(sid, "8bit")
+            except Exception as e:
+                errors.append(f"A: {type(e).__name__}: {e}")
+
+        def setter_b():
+            try:
+                barrier.wait()
+                store.set_code_scale(sid, "10bit")
+            except Exception as e:
+                errors.append(f"B: {type(e).__name__}: {e}")
+
+        t1 = threading.Thread(target=setter_a)
+        t2 = threading.Thread(target=setter_b)
+        t1.start()
+        t2.start()
+        t1.join(timeout=10.0)
+        t2.join(timeout=10.0)
+
+        assert not errors, f"Errors during concurrent setters: {errors}"
+        final = store.get(sid)
+        assert final["code_scale"] in ("8bit", "10bit"), (
+            f"Unexpected code_scale: {final['code_scale']}"
+        )
+
+    def test_setter_holds_lock_across_get_mutate_save(self, store):
+        """set_code_scale must hold the RLock for the full get→mutate→save span.
+
+        We monkeypatch get() to block after returning, then verify that
+        save_session cannot proceed from outside the setter until get()
+        unblocks.  This proves the lock wraps both endpoints of the
+        read-modify-write, not just get().
+        """
+        sid = store.create_session("u8g")["id"]
+        store.select_mode(sid, "SDR", sdr_peak_nits=120)
+        store.confirm_prepared(sid)
+
+        lock_held = threading.Event()
+        proceed = threading.Event()
+        original_get = store.get
+
+        def delaying_get(*args, **kwargs):
+            result = original_get(*args, **kwargs)
+            lock_held.set()
+            proceed.wait(timeout=5.0)
+            return result
+
+        with patch.object(store, "get", delaying_get):
+            def do_setter():
+                store.set_code_scale(sid, "10bit")
+
+            t = threading.Thread(target=do_setter)
+            t.start()
+
+            assert lock_held.wait(timeout=5.0), (
+                "Lock should be held during setter execution"
+            )
+
+            # While the lock is held, verify another thread blocks on it.
+            acquired = threading.Event()
+
+            def try_acquire():
+                with store._lock:
+                    acquired.set()
+
+            acquire_t = threading.Thread(target=try_acquire)
+            acquire_t.start()
+
+            # Give the acquiring thread a moment to try and block.
+            time.sleep(0.1)
+            assert not acquired.is_set(), (
+                "External thread should be blocked on the lock"
+            )
+
+            proceed.set()
+            t.join(timeout=5.0)
+            acquired.wait(timeout=5.0)

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -1066,3 +1066,60 @@ class TestConfigSetterTOCTOU:
             proceed.set()
             t.join(timeout=5.0)
             acquired.wait(timeout=5.0)
+
+    def test_setter_concurrent_with_ttl_eviction_no_resurrection(self, store):
+        """Setter called concurrently with background TTL eviction — no resurrection.
+
+        This test verifies the fix against the real-world eviction path
+        (``evict_expired_sessions`` called by the file-watcher watchdog), not
+        just explicit ``delete()`` calls.  We manually push the session's
+        ``last_accessed_at`` into the past to simulate an expired session,
+        then race eviction against a setter.  The RLock must prevent the
+        setter from resurrecting the session after eviction removes it.
+        """
+        sid = store.create_session("u8g")["id"]
+        store.select_mode(sid, "SDR", sdr_peak_nits=120)
+        store.confirm_prepared(sid)
+
+        # Push last_accessed_at far into the past so eviction treats it as expired.
+        with store._lock:
+            store.sessions[sid]["last_accessed_at"] = (
+                datetime.now(timezone.utc) - timedelta(days=30)
+            ).isoformat()
+
+        errors = []
+        barrier = threading.Barrier(2)
+
+        def setter():
+            try:
+                barrier.wait()
+                store.set_code_scale(sid, "10bit")
+            except Exception as e:
+                errors.append(f"setter: {type(e).__name__}: {e}")
+
+        def evictor():
+            try:
+                barrier.wait()
+                store.evict_expired_sessions()
+            except Exception as e:
+                errors.append(f"evict: {type(e).__name__}: {e}")
+
+        t1 = threading.Thread(target=setter)
+        t2 = threading.Thread(target=evictor)
+        t1.start()
+        t2.start()
+        t1.join(timeout=10.0)
+        t2.join(timeout=10.0)
+
+        assert not t1.is_alive() and not t2.is_alive(), "Thread(s) hung"
+        # No crashes — 404 from the loser is acceptable.
+        crash_errors = [e for e in errors if "TypeError" in str(type(e))]
+        assert not crash_errors, f"Crashes during race: {errors}"
+
+        # Session must be either fully updated OR completely gone.
+        remaining = store.sessions.get(sid)
+        if remaining is not None:
+            assert remaining["code_scale"] == "10bit", (
+                f"Session survived but setting not applied: "
+                f"{remaining.get('code_scale')}"
+            )


### PR DESCRIPTION
## 📺 Overview

Six session config setters and `repass()` in `calibrator/session.py` performed unguarded get→mutate→save, reintroducing the TOCTOU race fixed in #490 for step-transition methods. A concurrent delete or eviction could resurrect a deleted session mid-write, or silently discard the setter's write while reporting success.

Closes #503

### What does this PR do?
* **Type of change:** [x] Bug fix | [ ] New feature | [ ] Refactoring | [ ] CI/CD or Tooling
* **Component(s) affected:** Python data orchestration (SessionStore)

---

## 🛠️ Technical Context & Implementation

* **The Problem:** `set_gamma_workflow`, `set_signal_range`, `set_pattern_generator`, `set_code_scale`, `set_lightspace_tier`, `set_grayscale_ramp`, and `repass` each called `self.get(sid)` (which acquires/releases the RLock), mutated the session dict, then called `self.save_session(sid)` — leaving a window where a concurrent `delete()` or TTL eviction could remove the session between get and save. The setter would then re-write the deleted session to disk and in-memory store, resurrecting it.
* **The Solution:** Wrap each method body in `with self._lock:` across the full get→mutate→save sequence, matching the pattern already used by `next_step`, `record_adjustment_round`, and other step-transition methods (#490).
* **Impact on existing workflows/APIs:** No API surface changes. Setters now block briefly while holding the RLock, which may increase latency under extreme contention but eliminates session resurrection and silent data loss.

### Mathematical / Data Integrity Checks (If Applicable)
* [ ] Matrix transformations or LUT calculations have been validated.
* [ ] Floating-point precision or data truncation risks have been addressed.

---

## 🧪 Testing & Validation

### Environment Details
* **OS / Target Display:** macOS (CI: Linux)
* **Hardware/Mock Used:** Simulated — no hardware required

### Verification Steps
1. Run `python -m pytest tests/test_concurrency.py::TestConfigSetterTOCTOU -v` — 9 new tests covering each setter + repass concurrent with delete
2. Run `python -m pytest tests/test_concurrency.py -v` — all 26 concurrency tests pass
3. Run `python -m pytest tests/ --no-cov -q` — all repo tests pass

### Firmware / TV Settings
* [ ] Verified against target display firmware version
* [x] No hardware required — pure concurrency/unit tests
* [ ] Local Dimming set to Medium during test runs
* [ ] Correct white point mode used (Warm1 for HDR, Warm2 for SDR)

---

## 📸 Visual Evidence (UI / Plot Changes)
<!-- No UI changes in this PR. -->

---

## 🧼 Checklist
* [x] Code adheres to project style guidelines (formatting, typing, linting).
* [x] Unit tests added/updated and passing.
* [ ] Documentation (README, inline docstrings) updated to reflect changes.
* [x] No credentials, local absolute paths, or hardware-specific hardcoding leaked.