### PR TITLE
Fix import routes blocking the event loop with sync disk I/O

### DIFF
--- a/server.py
+++ b/server.py
@@ -1434,6 +1434,10 @@ async def import_zro_csv(sid: str, file: UploadFile = File(...)):
             413, f"File too large: {len(contents)} bytes (max {_MAX_UPLOAD_BYTES})"
         )
 
+    # Offload blocking, lock-holding disk I/O to the threadpool: this route is
+    # `async def` (for `await file.read()`), so unlike plain `def` handlers it
+    # is not threadpooled automatically and would otherwise stall the event
+    # loop for the duration of the import (#504).
     session, import_meta = await run_in_threadpool(
         store.import_zro_bytes, sid, file.filename, contents
     )
@@ -1453,6 +1457,8 @@ async def import_generic_csv(sid: str, file: UploadFile = File(...)):
             413, f"File too large: {len(contents)} bytes (max {_MAX_UPLOAD_BYTES})"
         )
 
+    # See import_zro_csv above: offload to threadpool so this async route
+    # doesn't block the event loop with synchronous, lock-holding disk I/O.
     session, import_meta = await run_in_threadpool(
         store.import_generic_bytes, sid, file.filename, contents
     )

--- a/server.py
+++ b/server.py
@@ -27,6 +27,7 @@ from urllib.parse import urlparse
 import httpx
 
 from fastapi import FastAPI, File, HTTPException, UploadFile
+from fastapi.concurrency import run_in_threadpool
 from fastapi.middleware.cors import CORSMiddleware
 
 _MAX_UPLOAD_BYTES = 10 * 1024 * 1024  # 10 MB limit for CSV uploads
@@ -1433,7 +1434,9 @@ async def import_zro_csv(sid: str, file: UploadFile = File(...)):
             413, f"File too large: {len(contents)} bytes (max {_MAX_UPLOAD_BYTES})"
         )
 
-    session, import_meta = store.import_zro_bytes(sid, file.filename, contents)
+    session, import_meta = await run_in_threadpool(
+        store.import_zro_bytes, sid, file.filename, contents
+    )
     _maybe_trigger_llm(sid, session)
     return {"session": _session_view(session), "import_summary": import_meta}
 
@@ -1450,7 +1453,9 @@ async def import_generic_csv(sid: str, file: UploadFile = File(...)):
             413, f"File too large: {len(contents)} bytes (max {_MAX_UPLOAD_BYTES})"
         )
 
-    session, import_meta = store.import_generic_bytes(sid, file.filename, contents)
+    session, import_meta = await run_in_threadpool(
+        store.import_generic_bytes, sid, file.filename, contents
+    )
     _maybe_trigger_llm(sid, session)
     return {"session": _session_view(session), "import_summary": import_meta}
 

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -785,6 +785,38 @@ class TestZROImport:
         assert resp.status_code == 400
 
 
+class TestImportRoutesDoNotBlockEventLoop:
+    """Regression test for #504: the import routes must not run blocking,
+    lock-holding disk I/O directly on the asyncio event loop.
+
+    Either the handler is a plain `def` (FastAPI threadpools those
+    automatically), or it's `async def` and offloads the store call via
+    `run_in_threadpool` rather than calling it directly in its own frame.
+    """
+
+    @pytest.mark.parametrize(
+        "route_func, store_method_name",
+        [
+            (server_module.import_zro_csv, "import_zro_bytes"),
+            (server_module.import_generic_csv, "import_generic_bytes"),
+        ],
+    )
+    def test_route_offloads_blocking_store_call(self, route_func, store_method_name):
+        import inspect
+
+        if not inspect.iscoroutinefunction(route_func):
+            return  # plain `def` routes are threadpooled by FastAPI for free
+
+        source = inspect.getsource(route_func)
+        direct_call = f"store.{store_method_name}("
+        assert direct_call not in source, (
+            f"{route_func.__name__} is async but calls store.{store_method_name} "
+            "directly on the event loop instead of offloading via run_in_threadpool"
+        )
+        assert "run_in_threadpool" in source
+        assert f"store.{store_method_name}" in source
+
+
 # ── Step navigation ───────────────────────────────────────────────────────────
 
 class TestStepNavigation:


### PR DESCRIPTION
## 📺 Overview

Closes #504

### What does this PR do?
* **Type of change:** [x] Bug fix
* **Component(s) affected:** Backend (`server.py`) — CSV import API routes

---

## 🛠️ Technical Context & Implementation

* **The Problem:** `import_zro_csv` and `import_generic_csv` were the only two `async def` route handlers in `server.py`. Every other handler is a plain `def`, which FastAPI automatically runs in its threadpool. These two routes called `store.import_zro_bytes` / `store.import_generic_bytes` directly inside the coroutine — synchronous, lock-holding (`threading.RLock`), disk-writing code (`save_session()` → `path.write_text(...)`) — which ran straight on the asyncio event loop. A large/slow import would block the entire event loop, stalling SSE keep-alives and every other concurrent request for the duration of the import.
* **The Solution:** Wrapped the `store.import_zro_bytes` / `store.import_generic_bytes` calls in `await run_in_threadpool(...)` (via `fastapi.concurrency.run_in_threadpool`, re-exporting Starlette's helper) so the blocking work runs off the event loop, consistent with how FastAPI already threadpools every plain `def` handler in the file.
* **Impact on existing workflows/APIs:** None — request/response shape and behavior are unchanged; only the execution context of the blocking call moved off the event loop.

---

## 🧪 Testing & Validation

### Verification Steps
1. Ran the full existing suite: `python -m pytest tests/test_server_api.py -q --no-cov` — all 146 tests pass.
2. Ran `ruff check server.py tests/test_server_api.py` — clean.
3. Added a structural regression test (`TestImportRoutesDoNotBlockEventLoop` in `tests/test_server_api.py`) asserting that if `import_zro_csv`/`import_generic_csv` remain `async def`, they must offload the store call via `run_in_threadpool` rather than calling `store.import_*_bytes(...)` directly in their own frame. A tight latency assertion would be flaky in CI, so this is verified via `inspect.getsource` instead.

---

## 🧼 Checklist
* [x] Code adheres to project style guidelines (formatting, typing, linting).
* [x] Unit tests added/updated and passing.
* [ ] Documentation (README, inline docstrings) updated to reflect changes. (not applicable — internal implementation detail)
* [x] No credentials, local absolute paths, or hardware-specific hardcoding leaked.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xzy8Jajrew1GeV28z9dj5X)_