### PR TITLE
Fix query_pass_decision TypeError on non-numeric measurement fields

### DIFF
--- a/calcore/llm.py
+++ b/calcore/llm.py
@@ -52,6 +52,16 @@ def _extract_json(text: str) -> str:
     return text[start:]
 
 
+def _safe_float(value: Any) -> Optional[float]:
+    """Coerce a client-supplied value to float, or None if it isn't numeric."""
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
 def _top_offenders(summary: Summary) -> Dict[str, Any]:
     """Extract worst-N patches by ΔE for compact LLM context (no raw XYZ)."""
     result: Dict[str, Any] = {}
@@ -888,7 +898,7 @@ def query_pass_decision(
     colors: Dict[str, List[Dict[str, Any]]] = {}
     for m in measurements:
         label = (m.get("label") or "").strip()
-        de = m.get("delta_e")
+        de = _safe_float(m.get("delta_e"))
         if de is None:
             continue
         stim_pct = m.get("stimulus_pct", 0)
@@ -908,12 +918,15 @@ def query_pass_decision(
                 "label": label,
                 "dE": round(de, 2),
                 "stimulus_pct": stim_pct,
-                "effective_gamma": m.get("effective_gamma"),
+                "effective_gamma": _safe_float(m.get("effective_gamma")),
                 "x": m.get("x"),
                 "y": m.get("y"),
                 "Y": m.get("Y"),
-                "cct": m.get("cct"),
+                "cct": _safe_float(m.get("cct")),
             })
+
+    if not grayscale and not colors:
+        return None
 
     # Compute per-region stats
     def _region_stats(items: List[Dict]) -> Optional[Dict]:

--- a/tests/test_adaptive_loop.py
+++ b/tests/test_adaptive_loop.py
@@ -262,6 +262,78 @@ class TestQueryPassDecision:
         assert result is not None
         assert result.action == "accept"  # falls back
 
+    def test_non_numeric_delta_e_returns_none_not_raise(self):
+        """Non-numeric delta_e values must degrade to None, never raise."""
+        llm = MagicMock()
+        llm.endpoint = "http://localhost:4000"
+        llm.model = "test-model"
+        llm.api_key = ""
+        llm.timeout = 30.0
+
+        result = query_pass_decision(
+            measurements=[{"label": "White 50%", "delta_e": "bad"}],
+            phase="pre_grayscale",
+            signal_range="full",
+            code_scale="8bit",
+            target_gamma=2.2,
+            target_peak_nits=120.0,
+            target_white_point=[0.3127, 0.3290],
+            target_gamut="bt709",
+            llm=llm,
+        )
+
+        assert result is None
+
+    def test_non_numeric_effective_gamma_and_cct_do_not_raise(self):
+        """Non-numeric effective_gamma/cct on an otherwise-valid measurement must not raise."""
+        llm = MagicMock()
+        llm.endpoint = "http://localhost:4000"
+        llm.model = "test-model"
+        llm.api_key = ""
+        llm.timeout = 30.0
+
+        mock_response = {
+            "choices": [{
+                "message": {
+                    "content": json.dumps({
+                        "action": "accept",
+                        "patches": [],
+                        "reason": "test",
+                        "confidence": 0.9,
+                        "repass_count": 0,
+                        "ceiling_reason": None,
+                    })
+                }
+            }]
+        }
+
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_resp = MagicMock()
+            mock_resp.read.return_value = json.dumps(mock_response).encode()
+            mock_urlopen.return_value.__enter__ = lambda s: mock_resp
+            mock_urlopen.return_value.__exit__ = lambda s, *a: None
+
+            result = query_pass_decision(
+                measurements=[{
+                    "label": "White 50%",
+                    "delta_e": 1.2,
+                    "stimulus_pct": 50,
+                    "effective_gamma": "bad",
+                    "cct": "bad",
+                }],
+                phase="pre_grayscale",
+                signal_range="full",
+                code_scale="8bit",
+                target_gamma=2.2,
+                target_peak_nits=120.0,
+                target_white_point=[0.3127, 0.3290],
+                target_gamut="bt709",
+                llm=llm,
+            )
+
+        assert result is not None
+        assert result.action == "accept"
+
 
 class TestTVProfileThresholds:
     """Quality gate thresholds in TV profiles."""

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -1698,6 +1698,22 @@ class TestLLMIntegration:
         server_module._llm_unsubscribe(session_id, q)
 
 
+class TestPassDecisionEndpoint:
+    def test_non_numeric_delta_e_returns_200_not_500(self, client, session_id):
+        """Malformed measurement payloads must degrade gracefully, never 500 (#501)."""
+        client.post(f"/api/session/{session_id}/llm/configure",
+                    json={"endpoint": "http://localhost:4000", "model": "gpt-4o"})
+        resp = client.post(
+            f"/api/session/{session_id}/pass-decision",
+            json={"measurements": [
+                {"label": "White 50%", "delta_e": "bad", "stimulus_pct": 50}
+            ]},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["action"] == "accept"
+
+
 # ── Issue #188: Periodic session TTL eviction ──────────────────────────────────
 
 class TestSessionTTLCleanup:


### PR DESCRIPTION
## 📺 Overview

Closes #501

### What does this PR do?
* **Type of change:** [x] Bug fix
* **Component(s) affected:** `calcore/llm.py` (`query_pass_decision`), `/api/session/{sid}/pass-decision` endpoint in `server.py`

---

## 🛠️ Technical Context & Implementation

* **The Problem:** `query_pass_decision()` aggregated client-supplied measurement fields (`delta_e`, `effective_gamma`, `cct`) and called `round()`/arithmetic on them *before* entering its `try`/`except` block. A non-numeric value (e.g. `delta_e: "bad"`) raised an uncaught `TypeError`, which propagated through `post_pass_decision` in `server.py` as an HTTP 500 instead of degrading gracefully, violating the project convention that `query_*` functions never raise.
* **The Solution:** Added a `_safe_float()` helper that coerces `delta_e`, `effective_gamma`, and `cct` to `float`, returning `None` when a value isn't numeric. Measurements whose `delta_e` doesn't coerce are skipped (same as the existing "missing `delta_e`" path). Also added a check so that if no measurement has a usable `delta_e`, the function returns `None` immediately rather than making a pointless LLM call with empty data.
* **Impact on existing workflows/APIs:** None for well-formed requests. Malformed/corrupted measurement payloads now cause `/api/session/{sid}/pass-decision` to return its existing graceful fallback (`{"action": "accept", "reason": "LLM unavailable", ...}`, HTTP 200) instead of a 500.

### Mathematical / Data Integrity Checks (If Applicable)
* [x] Floating-point precision or data truncation risks have been addressed (non-numeric values are safely coerced/dropped rather than crashing).

---

## 🧪 Testing & Validation

### Environment Details
* N/A — this is a pure backend/API fix, no display hardware involved.

### Verification Steps
1. Run `python -m pytest tests/test_adaptive_loop.py tests/test_server_api.py -q`
2. Added `test_non_numeric_delta_e_returns_none_not_raise` and `test_non_numeric_effective_gamma_and_cct_do_not_raise` in `tests/test_adaptive_loop.py`, verifying `query_pass_decision` returns `None`/a valid decision instead of raising.
3. Added `test_non_numeric_delta_e_returns_200_not_500` in `tests/test_server_api.py`, posting a malformed measurement to `/api/session/{sid}/pass-decision` via `TestClient` and asserting HTTP 200.
4. Confirmed all three new tests fail with the original code (reproducing the bug) and pass with the fix. Full test suite (`python -m pytest -q`) passes.

### Firmware / TV Settings
* N/A

---

## 🧼 Checklist
* [x] Code adheres to project style guidelines (formatting, typing, linting).
* [x] Unit tests added/updated and passing.
* [ ] Documentation (README, inline docstrings) updated to reflect changes. (not needed — internal bug fix, no public API/behavior change)
* [x] No credentials, local absolute paths, or hardware-specific hardcoding leaked.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VXCppHZqJ9Z3AL9nfvjsat)_