### PR TITLE
Add PR Feedback Protocol to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,14 @@ When I say **"audit QE"**, execute the QE Audit Protocol:
 - Design hardware mocking strategy for headless CI
 - Produce: ci.yml template, pytest structure with fixtures, prioritized roadmap
 
+When I say **"give PR feedback"**, **"review this PR"**, or **"PR feedback for [number/URL]"**, execute the PR Feedback Protocol:
+- Read the full PR diff and description before commenting — no partial reviews
+- Keep feedback **targeted on actionable items only**: correctness bugs, security issues, broken/missing tests, CI failures, and violations of conventions or recipes in this file
+- Skip stylistic nitpicks, subjective preferences, and restating what the diff already shows — every finding must require a concrete code change
+- Each finding cites file + line and states the fix, not just the problem
+- If nothing actionable is found, say so explicitly rather than inventing filler
+- **Post the findings as a comment on the PR** (GitHub MCP tools) — do not leave the review only in chat output. If there are zero actionable findings, post that too, so the PR has a record of the review
+
 ## Git Workflow
 1. `git checkout -b [feat|fix|chore]/[short-slug]`
 2. Atomic commits, imperative mood, <72 chars, no "fix"/"update"/"misc"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,12 +48,29 @@ When I say **"audit QE"**, execute the QE Audit Protocol:
 - Produce: ci.yml template, pytest structure with fixtures, prioritized roadmap
 
 When I say **"give PR feedback"**, **"review this PR"**, or **"PR feedback for [number/URL]"**, execute the PR Feedback Protocol:
-- Read the full PR diff and description before commenting — no partial reviews
-- Keep feedback **targeted on actionable items only**: correctness bugs, security issues, broken/missing tests, CI failures, and violations of conventions or recipes in this file
-- Skip stylistic nitpicks, subjective preferences, and restating what the diff already shows — every finding must require a concrete code change
-- Each finding cites file + line and states the fix, not just the problem
-- If nothing actionable is found, say so explicitly rather than inventing filler
-- **Post the findings as a comment on the PR** (GitHub MCP tools) — do not leave the review only in chat output. If there are zero actionable findings, post that too, so the PR has a record of the review
+- Read the full PR description and diff before commenting — no partial reviews
+- **Actionable** means: the finding identifies a defect that would reasonably justify delaying merge until it's fixed or consciously accepted. Prioritize in this order:
+  1. Incorrect behavior
+  2. Security
+  3. Data loss
+  4. Race conditions / concurrency
+  5. Missing or incorrect tests
+  6. CI failures
+  7. Violations of documented project conventions/recipes in this file
+- **No speculation.** Only report issues you can explain from the diff or repo context. If unsure whether something is actually a problem, ask a question instead of reporting a bug
+- Ignore purely stylistic preferences and subjective opinions — but treat style that impacts correctness or maintainability (swallowed errors/exceptions, ignored return values, inconsistent locking, unsafe optional handling) as actionable, not style
+- Before posting, check existing review comments/threads and skip duplicates unless you're adding materially new information
+- Format every finding as:
+  ```
+  Finding:
+  - Severity: blocker | high | medium
+  - File: path:line (reference the changed lines when available — exact line numbers may not survive a rebase)
+  - Problem:
+  - Why it matters:
+  - Suggested fix:
+  ```
+- **Never invent findings to satisfy the review.** If nothing actionable is found, explicitly say the PR was reviewed and no actionable issues were found
+- **Post the review as a comment on the PR** using the GitHub MCP tools — do not leave it only in chat output
 
 ## Git Workflow
 1. `git checkout -b [feat|fix|chore]/[short-slug]`


### PR DESCRIPTION
## 📺 Overview

Adds a **PR Feedback Protocol** to `AGENTS.md` so that requests like "give PR feedback" or "review this PR" produce reviews that stay targeted on actionable items and get posted as a PR comment instead of only appearing in chat.

Doc-only change; no issue created.

### What does this PR do?

-   **Type of change:** [ ] Bug fix | [ ] New feature | [ ] Refactoring | [x] CI/CD or Tooling (agent instructions)
-   **Component(s) affected:** `AGENTS.md`

---

## 🛠️ Technical Context & Implementation

-   **The Problem:** `AGENTS.md` defined protocols for bug fixes, feature implementation, codebase audits, and QE audits, but had no defined behavior for "give me PR feedback" requests. Without explicit guidance, reviews could drift into unfocused commentary and stay only in chat, with no record left on the PR.
-   **The Solution:** Added a new **PR Feedback Protocol** block, following the same trigger-phrase pattern as the existing protocols (`resolve issue`, `implement feature`, `audit codebase`, `audit QE`). It instructs the agent to:
    -   Read the full PR diff and description before commenting
    -   Keep feedback limited to actionable items (correctness bugs, security issues, broken/missing tests, CI failures, convention violations) and skip nitpicks/restating the diff
    -   Cite file + line and state the concrete fix for each finding
    -   Post the findings as a comment on the PR via the GitHub MCP tools, including an explicit "no actionable findings" comment when the review is clean
-   **Impact on existing workflows/APIs:** None — this only adds guidance to `AGENTS.md`; no application code changed.

---

## 🧪 Testing & Validation

N/A — documentation-only change to agent instructions.

---

## 🧼 Checklist

-    Code adheres to project style guidelines (formatting, typing, linting). — N/A, doc-only
-    Unit tests added/updated and passing. — N/A, doc-only
-    Documentation (README, inline docstrings) updated to reflect changes.
-    No credentials, local absolute paths, or hardware-specific hardcoding leaked.


---
_Generated by [Claude Code](https://claude.ai/code/session_014Xneb3KTpgFBpqaguivPCa)_