### PR TITLE
Fix trailing unclassifiable rows misclassified as grayscale pass in ZRO import

### DIFF
--- a/calibrator/zro_import.py
+++ b/calibrator/zro_import.py
@@ -325,12 +325,20 @@ def _group_into_sessions(rows: List[_Row]) -> List[List[_Row]]:
 
 
 def _session_type(group: List[_Row]) -> str:
-    """Infer whether a session group is primarily 'colour' or 'grayscale'."""
+    """Infer whether a session group is 'colour', 'grayscale', or 'unknown'.
+
+    'unknown' covers groups where no row matches any recognized colour or
+    grayscale patch signature (e.g. a trailing block of intermediate-
+    saturation CMS check patches) — these must not be treated as a real
+    grayscale pass, or they'd silently displace the genuine post-cal ramp.
+    """
     types = [_classify(r.r, r.g, r.b) for r in group]
     colour_count = sum(
         1 for t in types if t in {"red", "green", "blue", "cyan", "magenta", "yellow"}
     )
     gray_count = sum(1 for t in types if t in {"grayscale", "black", "white"})
+    if colour_count == 0 and gray_count == 0:
+        return "unknown"
     if colour_count > gray_count:
         return "colour"
     return "grayscale"
@@ -456,7 +464,7 @@ def parse_zro_csv(source: str | bytes | io.IOBase) -> ZROImportResult:
     # ── classify each session group ──────────────────────────────────────────
     # We need to know the total number of grayscale passes before processing
     # so we can distinguish pre, mid, and post.
-    grayscale_groups = [g for g in groups if _session_type(g) != "colour"]
+    grayscale_groups = [g for g in groups if _session_type(g) == "grayscale"]
     n_grayscale = len(grayscale_groups)
     result.grayscale_sessions = n_grayscale
 
@@ -468,7 +476,7 @@ def parse_zro_csv(source: str | bytes | io.IOBase) -> ZROImportResult:
             result.colour_sessions += 1
             _process_colour_group(group, result)
 
-        else:  # grayscale (or mixed — treat as grayscale)
+        elif stype == "grayscale":  # includes mixed groups won by grayscale
             is_last = (grayscale_group_index == n_grayscale - 1)
             _process_grayscale_group(group, result, grayscale_group_index, is_last)
             grayscale_group_index += 1
@@ -476,6 +484,11 @@ def parse_zro_csv(source: str | bytes | io.IOBase) -> ZROImportResult:
             # that is dominated by grayscale rows from previous steps.  Always
             # extract any colour-type rows so they reach cms_measurements.
             _extract_colour_rows(group, result)
+
+        else:  # "unknown" — no recognizable patch in this group; don't
+            # consume a pre/mid/post pass slot, just count the rows as
+            # unclassifiable.
+            result.unknown_rows += len(group)
 
     return result
 

--- a/tests/test_zro_import.py
+++ b/tests/test_zro_import.py
@@ -407,6 +407,25 @@ class TestParseZroCsv:
         r = parse_zro_csv(TWO_GRAYSCALE_CSV)
         assert len(r.post_measurements) == 11
 
+    def test_unknown_trailing_group_does_not_consume_pass_slot(self):
+        # Pre-cal ramp, post-cal ramp, then a trailing group of
+        # intermediate-saturation CMS check patches (e.g. a "relax CMS
+        # target to 75%" verification step) that don't match any
+        # primary/secondary/grayscale patch signature. This trailing group
+        # must not be misclassified as a third grayscale pass, which would
+        # bump the real post-cal ramp into mid_measurements.
+        csv_bytes = (
+            TWO_GRAYSCALE_CSV
+            + b"\n"
+            + b"15/03/2026 11:04:20\t235\t80\t80\t20.0\t0.45\t0.35\t 360ms\n"
+            + b"15/03/2026 11:04:23\t80\t235\t80\t40.0\t0.30\t0.55\t 360ms\n"
+            + b"15/03/2026 11:04:26\t80\t80\t235\t15.0\t0.20\t0.10\t 360ms"
+        )
+        r = parse_zro_csv(csv_bytes)
+        assert r.grayscale_sessions == 2
+        assert len(r.post_measurements) == 11
+        assert len(r.mid_measurements) == 0
+
     # ── Input format variants ───────────────────────────────────────────────
 
     def test_accepts_bytes(self):


### PR DESCRIPTION
## 📺 Overview

Closes #502

### What does this PR do?
* **Type of change:** [x] Bug fix
* **Component(s) affected:** ZRO CSV import (`calibrator/zro_import.py`)

---

## 🛠️ Technical Context & Implementation

* **The Problem:** `_session_type()` decides whether a session group is a "colour" or "grayscale" pass by comparing counts, but ties defaulted to `"grayscale"` — including the degenerate `0 colour, 0 grayscale` tie (a group where every row is unclassifiable, e.g. trailing intermediate-saturation CMS check patches like `R=235,G=80,B=80`). This inflated `n_grayscale` and bumped the genuine post-calibration ramp out of `post_measurements` into `mid_measurements`.
* **The Solution:** `_session_type()` now returns a distinct `"unknown"` classification when `colour_count == 0 and gray_count == 0`. `parse_zro_csv()` excludes `"unknown"` groups from the grayscale-group count (`n_grayscale`) and from pre/mid/post pass routing entirely — their rows are counted in `unknown_rows` instead of silently consuming a pass slot.
* **Impact on existing workflows/APIs:** None for well-formed exports (pre/post grayscale ramps with any number of mixed passes are unaffected). Only trailing/interior groups with zero recognizable colour or grayscale rows change behavior, from being wrongly treated as a real grayscale pass to being excluded and counted as unknown.

---

## 🧪 Testing & Validation

### Verification Steps
1. `python -m pytest tests/test_zro_import.py` — added `test_unknown_trailing_group_does_not_consume_pass_slot`, which reproduces the bug (pre-cal ramp + post-cal ramp + 3 trailing unclassifiable rows with a >45s gap) and asserts `grayscale_sessions == 2`, `post_measurements` has the real post-cal data, and `mid_measurements` is empty.
2. Ran the full suite: `python -m pytest tests/` — 1259 passed, 2 skipped.

---

## 🧼 Checklist
* [x] Code adheres to project style guidelines (formatting, typing, linting).
* [x] Unit tests added/updated and passing.
* [ ] Documentation (README, inline docstrings) updated to reflect changes. — N/A, internal parsing logic only.
* [x] No credentials, local absolute paths, or hardware-specific hardcoding leaked.


---
_Generated by [Claude Code](https://claude.ai/code/session_013JWvvr1rY1kAymKgmAmXmy)_