### PR TITLE
fix: correct ESM import style in LlmConnectionCard and LlmHistoryCard

### DIFF
--- a/frontend/src/components/LlmConnectionCard.jsx
+++ b/frontend/src/components/LlmConnectionCard.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Button } from './Button';
-import * as api from '../api/client';
+import { api } from '../api/client';
 
 export function LlmConnectionCard({ sid, onConfigureLlm }) {
   const [endpoint, setEndpoint] = useState('');

--- a/frontend/src/components/LlmConnectionCard.test.jsx
+++ b/frontend/src/components/LlmConnectionCard.test.jsx
@@ -139,12 +139,3 @@ describe('LlmConnectionCard', () => {
     expect(api.configureLlm).not.toHaveBeenCalled();
   });
 });
-
-describe('LlmConnectionCard — integration', () => {
-  it('real api/client.js export shape is consumed correctly (namespace-vs-named import guard)', () => {
-    expect(api).toBeDefined();
-    expect(typeof api.getLlmStatus).toBe('function');
-    expect(typeof api.configureLlm).toBe('function');
-    expect(typeof api.probeLlm).toBe('function');
-  });
-});

--- a/frontend/src/components/LlmConnectionCard.test.jsx
+++ b/frontend/src/components/LlmConnectionCard.test.jsx
@@ -2,12 +2,14 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { LlmConnectionCard } from './LlmConnectionCard';
-import * as client from '../api/client';
+import { api } from '../api/client';
 
 vi.mock('../api/client', () => ({
-  getLlmStatus: vi.fn(),
-  configureLlm: vi.fn(),
-  probeLlm: vi.fn(),
+  api: {
+    getLlmStatus: vi.fn(),
+    configureLlm: vi.fn(),
+    probeLlm: vi.fn(),
+  },
 }));
 
 const sid = 'test-session-123';
@@ -18,20 +20,20 @@ describe('LlmConnectionCard', () => {
   });
 
   it('shows "Not configured" when getLlmStatus returns configured:false', async () => {
-    client.getLlmStatus.mockResolvedValue({ configured: false });
+    api.getLlmStatus.mockResolvedValue({ configured: false });
     render(<LlmConnectionCard sid={sid} />);
     expect(await screen.findByText('Not configured')).toBeInTheDocument();
   });
 
   it('shows green reachable badge with model when reachable', async () => {
-    client.getLlmStatus.mockResolvedValue({ configured: true, reachable: true, model: 'llama3' });
+    api.getLlmStatus.mockResolvedValue({ configured: true, reachable: true, model: 'llama3' });
     render(<LlmConnectionCard sid={sid} />);
     expect(await screen.findByText('Reachable (llama3)')).toBeInTheDocument();
   });
 
   it('shows error when configured but unreachable', async () => {
-    client.getLlmStatus.mockResolvedValue({ configured: true, reachable: false, error: 'HTTP 401: Unauthorized' });
-    client.probeLlm.mockResolvedValue({ configured: true, reachable: false, error: 'HTTP 401: Unauthorized' });
+    api.getLlmStatus.mockResolvedValue({ configured: true, reachable: false, error: 'HTTP 401: Unauthorized' });
+    api.probeLlm.mockResolvedValue({ configured: true, reachable: false, error: 'HTTP 401: Unauthorized' });
     render(<LlmConnectionCard sid={sid} />);
     await screen.findByText('Not configured');
     await userEvent.click(screen.getByText('Test connection'));
@@ -39,8 +41,8 @@ describe('LlmConnectionCard', () => {
   });
 
   it('clicking Save calls configureLlm with entered field values', async () => {
-    client.getLlmStatus.mockResolvedValue({ configured: false });
-    client.configureLlm.mockResolvedValue({ configured: true, model: 'llama3' });
+    api.getLlmStatus.mockResolvedValue({ configured: false });
+    api.configureLlm.mockResolvedValue({ configured: true, model: 'llama3' });
     render(<LlmConnectionCard sid={sid} />);
     await screen.findByText('Not configured');
 
@@ -48,12 +50,12 @@ describe('LlmConnectionCard', () => {
     await userEvent.type(screen.getByPlaceholderText('llama3'), 'llama3');
     await userEvent.click(screen.getByText('Save'));
 
-    expect(client.configureLlm).toHaveBeenCalledOnce();
-    expect(client.configureLlm).toHaveBeenCalledWith(sid, { endpoint: 'http://localhost:11434/v1', model: 'llama3' });
+    expect(api.configureLlm).toHaveBeenCalledOnce();
+    expect(api.configureLlm).toHaveBeenCalledWith(sid, { endpoint: 'http://localhost:11434/v1', model: 'llama3' });
   });
 
   it('prefills endpoint and model from status on mount when already configured', async () => {
-    client.getLlmStatus.mockResolvedValue({ configured: true, reachable: true, model: 'gpt-4', endpoint: 'https://api.openai.com/v1' });
+    api.getLlmStatus.mockResolvedValue({ configured: true, reachable: true, model: 'gpt-4', endpoint: 'https://api.openai.com/v1' });
     render(<LlmConnectionCard sid={sid} />);
     const endpointInput = await screen.findByDisplayValue('https://api.openai.com/v1');
     expect(endpointInput).toBeInTheDocument();
@@ -61,9 +63,9 @@ describe('LlmConnectionCard', () => {
   });
 
   it('disables buttons while saving', async () => {
-    client.getLlmStatus.mockResolvedValue({ configured: false });
+    api.getLlmStatus.mockResolvedValue({ configured: false });
     let resolveConfigure;
-    client.configureLlm.mockImplementation(() => new Promise(r => { resolveConfigure = r; }));
+    api.configureLlm.mockImplementation(() => new Promise(r => { resolveConfigure = r; }));
     render(<LlmConnectionCard sid={sid} />);
     await screen.findByText('Not configured');
 
@@ -83,7 +85,7 @@ describe('LlmConnectionCard', () => {
 
   it('calls onConfigureLlm callback when provided instead of raw API', async () => {
     const onConfigureLlm = vi.fn().mockResolvedValue({ configured: true, model: 'llama3' });
-    client.getLlmStatus.mockResolvedValue({ configured: false });
+    api.getLlmStatus.mockResolvedValue({ configured: false });
     render(<LlmConnectionCard sid={sid} onConfigureLlm={onConfigureLlm} />);
     await screen.findByText('Not configured');
 
@@ -93,12 +95,12 @@ describe('LlmConnectionCard', () => {
 
     expect(onConfigureLlm).toHaveBeenCalledOnce();
     expect(onConfigureLlm).toHaveBeenCalledWith({ endpoint: 'http://localhost:11434/v1', model: 'llama3' });
-    expect(client.configureLlm).not.toHaveBeenCalled();
+    expect(api.configureLlm).not.toHaveBeenCalled();
   });
 
   it('trims whitespace from endpoint, model, and api_key on save', async () => {
-    client.getLlmStatus.mockResolvedValue({ configured: false });
-    client.configureLlm.mockResolvedValue({ configured: true, model: 'llama3' });
+    api.getLlmStatus.mockResolvedValue({ configured: false });
+    api.configureLlm.mockResolvedValue({ configured: true, model: 'llama3' });
     render(<LlmConnectionCard sid={sid} />);
     await screen.findByText('Not configured');
 
@@ -106,12 +108,12 @@ describe('LlmConnectionCard', () => {
     await userEvent.type(screen.getByPlaceholderText('llama3'), '  llama3  ');
     await userEvent.click(screen.getByText('Save'));
 
-    expect(client.configureLlm).toHaveBeenCalledWith(sid, { endpoint: 'http://localhost:11434/v1', model: 'llama3' });
+    expect(api.configureLlm).toHaveBeenCalledWith(sid, { endpoint: 'http://localhost:11434/v1', model: 'llama3' });
   });
 
   it('clicking Test connection probes current field values, not saved config', async () => {
-    client.getLlmStatus.mockResolvedValue({ configured: false });
-    client.probeLlm.mockResolvedValue({ configured: true, reachable: true, model: 'llama3' });
+    api.getLlmStatus.mockResolvedValue({ configured: false });
+    api.probeLlm.mockResolvedValue({ configured: true, reachable: true, model: 'llama3' });
     render(<LlmConnectionCard sid={sid} />);
     await screen.findByText('Not configured');
 
@@ -119,14 +121,14 @@ describe('LlmConnectionCard', () => {
     await userEvent.type(screen.getByPlaceholderText('llama3'), 'llama3');
     await userEvent.click(screen.getByText('Test connection'));
 
-    expect(client.probeLlm).toHaveBeenCalledOnce();
-    expect(client.probeLlm).toHaveBeenCalledWith(sid, { endpoint: 'http://localhost:11434/v1', model: 'llama3' });
+    expect(api.probeLlm).toHaveBeenCalledOnce();
+    expect(api.probeLlm).toHaveBeenCalledWith(sid, { endpoint: 'http://localhost:11434/v1', model: 'llama3' });
     expect(await screen.findByText('Reachable (llama3)')).toBeInTheDocument();
   });
 
   it('Test connection does not call configureLlm', async () => {
-    client.getLlmStatus.mockResolvedValue({ configured: false });
-    client.probeLlm.mockResolvedValue({ configured: true, reachable: true, model: 'llama3' });
+    api.getLlmStatus.mockResolvedValue({ configured: false });
+    api.probeLlm.mockResolvedValue({ configured: true, reachable: true, model: 'llama3' });
     render(<LlmConnectionCard sid={sid} />);
     await screen.findByText('Not configured');
 
@@ -134,6 +136,15 @@ describe('LlmConnectionCard', () => {
     await userEvent.type(screen.getByPlaceholderText('llama3'), 'llama3');
     await userEvent.click(screen.getByText('Test connection'));
 
-    expect(client.configureLlm).not.toHaveBeenCalled();
+    expect(api.configureLlm).not.toHaveBeenCalled();
+  });
+});
+
+describe('LlmConnectionCard — integration', () => {
+  it('real api/client.js export shape is consumed correctly (namespace-vs-named import guard)', () => {
+    expect(api).toBeDefined();
+    expect(typeof api.getLlmStatus).toBe('function');
+    expect(typeof api.configureLlm).toBe('function');
+    expect(typeof api.probeLlm).toBe('function');
   });
 });

--- a/frontend/src/components/LlmHistoryCard.jsx
+++ b/frontend/src/components/LlmHistoryCard.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import * as api from '../api/client';
+import { api } from '../api/client';
 
 export function LlmHistoryCard({ sid }) {
   const [data, setData] = useState(null);

--- a/frontend/src/components/LlmHistoryCard.test.jsx
+++ b/frontend/src/components/LlmHistoryCard.test.jsx
@@ -1,10 +1,12 @@
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { LlmHistoryCard } from './LlmHistoryCard';
-import * as client from '../api/client';
+import { api } from '../api/client';
 
 vi.mock('../api/client', () => ({
-  getLlmHistorySummary: vi.fn(),
+  api: {
+    getLlmHistorySummary: vi.fn(),
+  },
 }));
 
 const sid = 'test-session-123';
@@ -15,13 +17,13 @@ describe('LlmHistoryCard', () => {
   });
 
   it('renders nothing while loading', () => {
-    client.getLlmHistorySummary.mockImplementation(() => new Promise(() => {}));
+    api.getLlmHistorySummary.mockImplementation(() => new Promise(() => {}));
     const { container } = render(<LlmHistoryCard sid={sid} />);
     expect(container).toBeEmptyDOMElement();
   });
 
   it('renders first-calibration message when session_count is 0', async () => {
-    client.getLlmHistorySummary.mockResolvedValue({
+    api.getLlmHistorySummary.mockResolvedValue({
       tv_key: 'u8g',
       session_count: 0,
       has_final_settings: false,
@@ -31,7 +33,7 @@ describe('LlmHistoryCard', () => {
   });
 
   it('renders prior-session count when session_count is greater than 0', async () => {
-    client.getLlmHistorySummary.mockResolvedValue({
+    api.getLlmHistorySummary.mockResolvedValue({
       tv_key: 'u8g',
       session_count: 3,
       has_final_settings: true,
@@ -41,7 +43,7 @@ describe('LlmHistoryCard', () => {
   });
 
   it('renders muted line when prior runs have no saved settings', async () => {
-    client.getLlmHistorySummary.mockResolvedValue({
+    api.getLlmHistorySummary.mockResolvedValue({
       tv_key: 'u8g',
       session_count: 2,
       has_final_settings: false,
@@ -51,7 +53,7 @@ describe('LlmHistoryCard', () => {
   });
 
   it('does not render muted line when has_final_settings is true', async () => {
-    client.getLlmHistorySummary.mockResolvedValue({
+    api.getLlmHistorySummary.mockResolvedValue({
       tv_key: 'u8g',
       session_count: 1,
       has_final_settings: true,
@@ -62,8 +64,15 @@ describe('LlmHistoryCard', () => {
   });
 
   it('renders subtle error message when API call rejects', async () => {
-    client.getLlmHistorySummary.mockRejectedValue(new Error('network error'));
+    api.getLlmHistorySummary.mockRejectedValue(new Error('network error'));
     render(<LlmHistoryCard sid={sid} />);
     expect(await screen.findByText('Unable to load history.')).toBeInTheDocument();
+  });
+});
+
+describe('LlmHistoryCard — integration', () => {
+  it('real api/client.js export shape is consumed correctly (namespace-vs-named import guard)', () => {
+    expect(api).toBeDefined();
+    expect(typeof api.getLlmHistorySummary).toBe('function');
   });
 });

--- a/frontend/src/components/LlmHistoryCard.test.jsx
+++ b/frontend/src/components/LlmHistoryCard.test.jsx
@@ -69,10 +69,3 @@ describe('LlmHistoryCard', () => {
     expect(await screen.findByText('Unable to load history.')).toBeInTheDocument();
   });
 });
-
-describe('LlmHistoryCard — integration', () => {
-  it('real api/client.js export shape is consumed correctly (namespace-vs-named import guard)', () => {
-    expect(api).toBeDefined();
-    expect(typeof api.getLlmHistorySummary).toBe('function');
-  });
-});

--- a/frontend/src/components/api-client-shape.test.jsx
+++ b/frontend/src/components/api-client-shape.test.jsx
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+
+describe('api/client.js — real export shape', () => {
+  it('exposes api as a named export with all LLM methods callable', async () => {
+    const mod = await import('../api/client');
+    expect(mod.api).toBeDefined();
+    expect(typeof mod.api.getLlmStatus).toBe('function');
+    expect(typeof mod.api.configureLlm).toBe('function');
+    expect(typeof mod.api.probeLlm).toBe('function');
+    expect(typeof mod.api.getLlmHistorySummary).toBe('function');
+  });
+
+  it('api object has no unexpected top-level exports (regression guard)', async () => {
+    const mod = await import('../api/client');
+    const keys = Object.keys(mod);
+    expect(keys).toEqual(['api']);
+  });
+});


### PR DESCRIPTION
## 📺 Overview

`frontend/src/api/client.js` exports a single named binding (`export const api = {...}`). Both `LlmConnectionCard.jsx` and `LlmHistoryCard.jsx` used namespace import (`import * as api from ...`) which wraps the module into `api.api`, making every `api.getLlmStatus(...)` call throw `TypeError: api.getLlmStatus is not a function` on mount. This crashes the entire Prepare step via `StepErrorBoundary`.

Closes #[506](https://github.com/jweber93/tv-calibration/issues/506)

### What does this PR do?

-   **Type of change:** [x] Bug fix | [ ] New feature | [ ] Refactoring | [ ] CI/CD or Tooling
-   **Component(s) affected:** frontend/src/components/LlmConnectionCard.jsx, frontend/src/components/LlmHistoryCard.jsx, frontend/src/components/LlmConnectionCard.test.jsx, frontend/src/components/LlmHistoryCard.test.jsx

---

## 🛠️ Technical Context & Implementation

-   **The Problem:** Both card files used `import * as api from '../api/client'` (namespace import). Since `client.js` exports a single named export (`export const api = {...}`), the namespace object puts the real client at `api.api`, not `api`. Every call like `api.getLlmStatus(sid)` resolves to `undefined` and throws synchronously in the mount `useEffect`, crashing the Prepare step.
-   **The Solution:** Changed both files to named import (`import { api } from '../api/client'`), matching the pattern used by every other consumer in the codebase (`useSession.js`, `Report.jsx`, `ComparisonPage.jsx`, `CombinedInsightCard.jsx`).
-   **Test mock alignment:** The existing test mocks used flat shape (`{ getLlmStatus: vi.fn(), ... }`) which happened to work with namespace import but did not match the real module shape. Updated mocks to `{ api: { getLlmStatus: vi.fn(), ... } }` so the test contract matches production reality.
-   **Integration guard:** Added shape-checking integration tests that assert the real `api/client.js` exports are callable functions, preventing future import-style regressions.
-   **Impact on existing workflows/APIs:** No API changes. Only affects frontend component import resolution — the LLM coaching panel (connection, history) is now fully functional.

---

## 🧪 Testing & Validation

### Environment Details

-   **OS / Target Display:** macOS (CI)
-   **Hardware/Mock Used:** Vitest + jsdom

### Verification Steps

1.  Run `npm run test:unit` — all 91 tests pass across 8 test files
2.  Verify `LlmConnectionCard` and `LlmHistoryCard` mount without TypeError
3.  Verify mock shape matches real module (namespace import would now fail tests)

### Firmware / TV Settings

-   N/A — frontend-only fix, no hardware interaction

---

## 📸 Visual Evidence (UI / Plot Changes)

-   LlmConnectionCard no longer crashes the Prepare step on mount
-   Save and Test Connection buttons now function correctly

---

## 🧼 Checklist

-    Code adheres to project style guidelines (formatting, typing, linting).
-    Unit tests added/updated and passing.
-    Documentation (README, inline docstrings) updated to reflect changes.
-    No credentials, local absolute paths, or hardware-specific hardcoding leaked.