### PR TITLE
Fix OverlayDeChart Session A bars using red for both passing and failing dE

### DIFF
--- a/frontend/src/charts/OverlayDeChart.jsx
+++ b/frontend/src/charts/OverlayDeChart.jsx
@@ -29,6 +29,7 @@ export function OverlayDeChart({ measurementsA, measurementsB }) {
     return match ? match.delta_e : null;
   }
 
+  // Severity mapping: <=2 green, <=3 amber, >3 red — must match colorsB and tokens.js deColor().
   const colorsA = allLabels.map(l => {
     const v = getDelta(measurementsA, l);
     if (v == null) return C.redFillMissing;

--- a/frontend/src/charts/OverlayDeChart.jsx
+++ b/frontend/src/charts/OverlayDeChart.jsx
@@ -32,7 +32,7 @@ export function OverlayDeChart({ measurementsA, measurementsB }) {
   const colorsA = allLabels.map(l => {
     const v = getDelta(measurementsA, l);
     if (v == null) return C.redFillMissing;
-    return v <= 2 ? C.red : v <= 3 ? C.amber : C.red;
+    return v <= 2 ? C.green : v <= 3 ? C.amber : C.red;
   });
 
   const colorsB = allLabels.map(l => {

--- a/frontend/src/charts/OverlayDeChart.test.jsx
+++ b/frontend/src/charts/OverlayDeChart.test.jsx
@@ -127,6 +127,22 @@ describe('OverlayDeChart', () => {
     expect(passColor).not.toBe(failColor);
   });
 
+  it('colors the dE === 2 boundary green (passing) for both sessions', () => {
+    const measurements = [{ stimulus_pct: 10, delta_e: 2 }];
+    render(<OverlayDeChart measurementsA={measurements} measurementsB={measurements} />);
+    const [colorsA, colorsB] = lastChartProps.data.datasets.map(d => d.backgroundColor);
+    expect(colorsA).toEqual([C.green]);
+    expect(colorsB).toEqual([C.green]);
+  });
+
+  it('colors the dE === 3 boundary amber (borderline) for both sessions', () => {
+    const measurements = [{ stimulus_pct: 10, delta_e: 3 }];
+    render(<OverlayDeChart measurementsA={measurements} measurementsB={measurements} />);
+    const [colorsA, colorsB] = lastChartProps.data.datasets.map(d => d.backgroundColor);
+    expect(colorsA).toEqual([C.amber]);
+    expect(colorsB).toEqual([C.amber]);
+  });
+
   it('matches Session A and Session B severity coloring for the same dE values', () => {
     const measurementsA = [
       { stimulus_pct: 10, delta_e: 1.0 },

--- a/frontend/src/charts/OverlayDeChart.test.jsx
+++ b/frontend/src/charts/OverlayDeChart.test.jsx
@@ -1,6 +1,15 @@
 import { render, screen } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { OverlayDeChart } from './OverlayDeChart';
+import { C } from './tokens.js';
+
+let lastChartProps = null;
+vi.mock('react-chartjs-2', () => ({
+  Bar: (props) => {
+    lastChartProps = props;
+    return <canvas />;
+  },
+}));
 
 describe('OverlayDeChart', () => {
   it('renders nothing when both measurement sets are empty', () => {
@@ -104,5 +113,34 @@ describe('OverlayDeChart', () => {
   it('renders nothing when both sets are undefined', () => {
     const { container } = render(<OverlayDeChart measurementsA={undefined} measurementsB={undefined} />);
     expect(container).toBeEmptyDOMElement();
+  });
+
+  it('colors Session A passing patches (dE <= 2) differently from failing patches (dE > 3)', () => {
+    const measurementsA = [
+      { stimulus_pct: 10, delta_e: 0.5 },
+      { stimulus_pct: 50, delta_e: 8.0 },
+    ];
+    render(<OverlayDeChart measurementsA={measurementsA} measurementsB={[]} />);
+    const [passColor, failColor] = lastChartProps.data.datasets[0].backgroundColor;
+    expect(passColor).toBe(C.green);
+    expect(failColor).toBe(C.red);
+    expect(passColor).not.toBe(failColor);
+  });
+
+  it('matches Session A and Session B severity coloring for the same dE values', () => {
+    const measurementsA = [
+      { stimulus_pct: 10, delta_e: 1.0 },
+      { stimulus_pct: 50, delta_e: 2.5 },
+      { stimulus_pct: 90, delta_e: 5.0 },
+    ];
+    const measurementsB = [
+      { stimulus_pct: 10, delta_e: 1.0 },
+      { stimulus_pct: 50, delta_e: 2.5 },
+      { stimulus_pct: 90, delta_e: 5.0 },
+    ];
+    render(<OverlayDeChart measurementsA={measurementsA} measurementsB={measurementsB} />);
+    const [colorsA, colorsB] = lastChartProps.data.datasets.map(d => d.backgroundColor);
+    expect(colorsA).toEqual(colorsB);
+    expect(colorsA).toEqual([C.green, C.amber, C.red]);
   });
 });


### PR DESCRIPTION
## 📺 Overview

Closes #495

### What does this PR do?
* **Type of change:** [x] Bug fix
* **Component(s) affected:** Frontend / comparison charts (`OverlayDeChart`)

---

## 🛠️ Technical Context & Implementation

* **The Problem:** `colorsA` in `OverlayDeChart.jsx` mapped both passing (dE ≤ 2) and failing (dE > 3) Session A bars to `C.red`, only using `C.amber` for the borderline case. An operator couldn't tell from the "before" bars whether a pre-calibration patch was already within spec — a dE of 0.5 and a dE of 8.0 rendered identically.
* **The Solution:** Traced the history of this file: the pre-`tokens.js` version used two distinct red shades (`#e74c3c` for pass, `#c0392b` for fail) to encode severity within Session A's "before" bars. The commit that introduced `tokens.js` (and its `deColor()` helper, explicitly documented as encoding "≤2/≤3/>3 green/amber/red tolerance bands in one place") collapsed both shades into the single `C.red` token, but the substitution was wrong for the passing arm. Session B's `colorsB` already uses the correct `green`/`amber`/`red` severity mapping — this change makes `colorsA` match it, so severity coding is now consistent between both sessions' bars.
* **Impact on existing workflows/APIs:** Frontend-only visual fix; no backend/API changes.

### Mathematical / Data Integrity Checks (If Applicable)
* [ ] Matrix transformations or LUT calculations have been validated. — N/A
* [ ] Floating-point precision or data truncation risks have been addressed. — N/A

---

## 🧪 Testing & Validation

### Environment Details
* **OS / Target Display:** N/A (frontend unit test only)
* **Hardware/Mock Used:** N/A

### Verification Steps
1. `npm run test:unit` — all 93 tests pass, including two new regression tests for `OverlayDeChart` asserting Session A's pass/fail bars use distinct colors and match Session B's severity scheme for identical dE values.
2. `npm run lint` — clean.

### Firmware / TV Settings
* [ ] Verified against target display firmware version — N/A
* [ ] Local Dimming set to Medium during test runs — N/A
* [ ] Correct white point mode used (Warm1 for HDR, Warm2 for SDR) — N/A

---

## 📸 Visual Evidence (UI / Plot Changes)
<details>
<summary><b>Click to expand Visuals</b></summary>

### Before
Session A bars: passing (dE ≤ 2) and failing (dE > 3) patches both rendered in the same red.

### After
Session A bars: passing patches render green, borderline amber, failing red — matching Session B.

</details>

---

## 🧼 Checklist
* [x] Code adheres to project style guidelines (formatting, typing, linting).
* [x] Unit tests added/updated and passing.
* [ ] Documentation (README, inline docstrings) updated to reflect changes. — N/A, no doc changes needed.
* [x] No credentials, local absolute paths, or hardware-specific hardcoding leaked.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XTsdzouJb3xHe7pYXZhjVw)_