### PR TITLE
Add format query param to /import/generic with xyY plausibility validation (#549)

### DIFF
--- a/calcore/csv_import.py
+++ b/calcore/csv_import.py
@@ -33,12 +33,20 @@ def _classify_headerless_row(
 
     *explicit_format* must be provided by the caller; auto-detection is disabled
     because it can misclassify low-luminance XYZ as xyY.
+
+    Raises ValueError if chromaticities are outside the plausible range
+    (x, y ∈ (0, 0.85)), which catches headerless XYZ data mislabelled as xyY.
     """
     if explicit_format == "XYZ":
         return (v4, v5, v6), None
 
     # explicit_format == "xyY"
     Y, x, y = v4, v5, v6
+    if not (0.0 <= x < 0.85) or not (0.0 <= y < 0.85):
+        raise ValueError(
+            f"Row has chromaticity x={x}, y={y} — outside plausible range [0, 0.85). "
+            "Did you mean to use format=XYZ?"
+        )
     return xyY_to_xyz(x, y, Y), (Y, x, y)
 
 

--- a/calcore/csv_import.py
+++ b/calcore/csv_import.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import csv
 import io
+import math
 import os
 import re
 from typing import List, Literal
@@ -26,6 +27,11 @@ def is_number(s: str) -> bool:
         return False
 
 
+def _is_finite(v: float) -> bool:
+    """Return True if *v* is a finite (non-NaN, non-inf) float."""
+    return math.isfinite(v)
+
+
 def _classify_headerless_row(
     v4: float, v5: float, v6: float, explicit_format: Literal["xyY", "XYZ"],
 ) -> tuple[tuple[float, float, float], tuple[float, float, float] | None]:
@@ -34,9 +40,16 @@ def _classify_headerless_row(
     *explicit_format* must be provided by the caller; auto-detection is disabled
     because it can misclassify low-luminance XYZ as xyY.
 
-    Raises ValueError if chromaticities are outside the plausible range
-    (x, y ∈ (0, 0.85)), which catches headerless XYZ data mislabelled as xyY.
+    Raises ValueError if:
+    - *explicit_format* is ``"xyY"`` and chromaticities are outside the
+      plausible range [0, 0.85).  The CIE 1931 spectral locus fits within
+      (0, 0.85); values above that threshold indicate XYZ data being
+      misinterpreted as xyY (issue #549).
+    - any coordinate is NaN or infinite.
     """
+    if not (_is_finite(v4) and _is_finite(v5) and _is_finite(v6)):
+        raise ValueError(f"Row contains non-finite value (v4={v4}, v5={v5}, v6={v6})")
+
     if explicit_format == "XYZ":
         return (v4, v5, v6), None
 
@@ -45,7 +58,8 @@ def _classify_headerless_row(
     if not (0.0 <= x < 0.85) or not (0.0 <= y < 0.85):
         raise ValueError(
             f"Row has chromaticity x={x}, y={y} — outside plausible range [0, 0.85). "
-            "Did you mean to use format=XYZ?"
+            "Did you mean to use format=XYZ (query parameter)? "
+            f"Allowed format values: xyY, XYZ."
         )
     return xyY_to_xyz(x, y, Y), (Y, x, y)
 

--- a/calibrator/session.py
+++ b/calibrator/session.py
@@ -2238,13 +2238,27 @@ class SessionStore:
         sid: str,
         filename: Optional[str],
         contents: bytes,
-        fmt: str = "xyY",
+        format_: str = "xyY",
     ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+        """Parse and import a generic (non-ZRO) CSV file.
+
+        Parameters
+        ----------
+        sid : str
+            Session ID.
+        filename : Optional[str]
+            Original filename (for import tracking).
+        contents : bytes
+            Raw CSV content.
+        format_ : str, optional
+            Headerless CSV column format — ``"xyY"`` (default) or ``"XYZ"``.
+            Passed as ``format=`` to :func:`parse_measurement_csv`.
+        """
         from .csv_adapter import patches_to_session_buckets
         from calcore.csv_import import parse_measurement_csv
 
         try:
-            patches = parse_measurement_csv(contents, format=fmt)
+            patches = parse_measurement_csv(contents, format=format_)
         except Exception as exc:
             raise HTTPException(400, f"Generic CSV parse error: {exc}") from exc
 

--- a/calibrator/session.py
+++ b/calibrator/session.py
@@ -2238,12 +2238,13 @@ class SessionStore:
         sid: str,
         filename: Optional[str],
         contents: bytes,
+        fmt: str = "xyY",
     ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
         from .csv_adapter import patches_to_session_buckets
         from calcore.csv_import import parse_measurement_csv
 
         try:
-            patches = parse_measurement_csv(contents, format="xyY")
+            patches = parse_measurement_csv(contents, format=fmt)
         except Exception as exc:
             raise HTTPException(400, f"Generic CSV parse error: {exc}") from exc
 

--- a/server.py
+++ b/server.py
@@ -26,7 +26,7 @@ from urllib.parse import urlparse
 
 import httpx
 
-from fastapi import FastAPI, File, HTTPException, UploadFile
+from fastapi import FastAPI, File, HTTPException, Query, UploadFile
 from fastapi.concurrency import run_in_threadpool
 from fastapi.middleware.cors import CORSMiddleware
 
@@ -1446,7 +1446,14 @@ async def import_zro_csv(sid: str, file: UploadFile = File(...)):
 
 
 @app.post("/api/session/{sid}/import/generic")
-async def import_generic_csv(sid: str, file: UploadFile = File(...)):
+async def import_generic_csv(
+    sid: str,
+    file: UploadFile = File(...),
+    format: str = Query("xyY", alias="format"),
+):
+    if format not in ("xyY", "XYZ"):
+        raise HTTPException(400, f"Invalid format '{format}'; must be 'xyY' or 'XYZ'")
+
     try:
         contents = await file.read()
     except Exception as exc:
@@ -1460,7 +1467,7 @@ async def import_generic_csv(sid: str, file: UploadFile = File(...)):
     # See import_zro_csv above: offload to threadpool so this async route
     # doesn't block the event loop with synchronous, lock-holding disk I/O.
     session, import_meta = await run_in_threadpool(
-        store.import_generic_bytes, sid, file.filename, contents
+        store.import_generic_bytes, sid, file.filename, contents, format
     )
     _maybe_trigger_llm(sid, session)
     return {"session": _session_view(session), "import_summary": import_meta}

--- a/server.py
+++ b/server.py
@@ -1445,14 +1445,26 @@ async def import_zro_csv(sid: str, file: UploadFile = File(...)):
     return {"session": _session_view(session), "import_summary": import_meta}
 
 
+_ALLOWED_FORMATS = frozenset({"xyY", "XYZ"})
+
+_FORMAT_NORMALIZE = {
+    "xyy": "xyY",
+    "xyz": "XYZ",
+}
+
+
 @app.post("/api/session/{sid}/import/generic")
 async def import_generic_csv(
     sid: str,
     file: UploadFile = File(...),
-    format: str = Query("xyY", alias="format"),
+    format_: str = Query("xyY", alias="format"),
 ):
-    if format not in ("xyY", "XYZ"):
-        raise HTTPException(400, f"Invalid format '{format}'; must be 'xyY' or 'XYZ'")
+    fmt = _FORMAT_NORMALIZE.get(format_.strip().lower(), format_.strip())
+    if fmt not in _ALLOWED_FORMATS:
+        raise HTTPException(
+            400,
+            f"Invalid format '{format_}'; must be 'xyY' or 'XYZ'",
+        )
 
     try:
         contents = await file.read()
@@ -1467,7 +1479,7 @@ async def import_generic_csv(
     # See import_zro_csv above: offload to threadpool so this async route
     # doesn't block the event loop with synchronous, lock-holding disk I/O.
     session, import_meta = await run_in_threadpool(
-        store.import_generic_bytes, sid, file.filename, contents, format
+        store.import_generic_bytes, sid, file.filename, contents, fmt
     )
     _maybe_trigger_llm(sid, session)
     return {"session": _session_view(session), "import_summary": import_meta}

--- a/tests/test_import_generic.py
+++ b/tests/test_import_generic.py
@@ -63,11 +63,15 @@ def session_id(client):
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
-def _upload_generic(client, sid, csv_bytes):
+def _upload_generic(client, sid, csv_bytes, fmt=None):
     """Upload a generic CSV via the /import/generic endpoint."""
+    params = {}
+    if fmt is not None:
+        params["format"] = fmt
     return client.post(
         f"/api/session/{sid}/import/generic",
         files={"file": ("test.csv", csv_bytes, "text/csv")},
+        params=params,
     )
 
 
@@ -321,18 +325,74 @@ class TestGenericImportPeakLuminance:
 
 
 class TestGenericImportHeaderlessFormat:
-    def test_headerless_csv_parsed(self, client, session_id):
-        """Headerless CSV format should also be supported."""
+    def test_headerless_xyz_csv_requires_format_param(self, client, session_id):
+        """Headerless XYZ CSV without format=XYZ → 400 (plausibility check catches it)."""
         _advance_to_pre_grayscale(client, session_id)
 
-        # Headerless format: index,R,G,B,X,Y,Z
+        # Headerless format: index,R,G,B,X,Y,Z — X=100, Z=60 are way outside xyY range
         csv = _grayscale_csv([
             (0, 128, 128, 128, 5.0, 6.0, 4.0),
             (1, 235, 235, 235, 80.0, 100.0, 60.0),
         ])
 
         resp = _upload_generic(client, session_id, csv.encode())
+        assert resp.status_code == 400
+        assert "chromaticity" in resp.json()["detail"].lower()
+
+    def test_headerless_xyz_csv_with_format_param(self, client, session_id):
+        """Headerless XYZ CSV with format=XYZ parses correctly."""
+        _advance_to_pre_grayscale(client, session_id)
+
+        csv = _grayscale_csv([
+            (0, 128, 128, 128, 5.0, 6.0, 4.0),
+            (1, 235, 235, 235, 80.0, 100.0, 60.0),
+        ])
+
+        resp = _upload_generic(client, session_id, csv.encode(), fmt="XYZ")
         assert resp.status_code == 200
 
         summary = resp.json()["import_summary"]
         assert summary["total_rows"] == 2
+
+    def test_headerless_xyY_csv_with_default_format(self, client, session_id):
+        """Headerless xyY CSV works with default format (xyY)."""
+        _advance_to_pre_grayscale(client, session_id)
+
+        # xyY format: index,R,G,B,Y,x,y
+        lines = [
+            "0,128,128,128,5.0,0.3127,0.3290",
+            "1,235,235,235,100.0,0.3127,0.3290",
+        ]
+        csv = "\n".join(lines)
+
+        resp = _upload_generic(client, session_id, csv.encode())
+        assert resp.status_code == 200
+
+        summary = resp.json()["import_summary"]
+        assert summary["total_rows"] == 2
+
+    def test_headerless_xyY_csv_explicit_format(self, client, session_id):
+        """Headerless xyY CSV with format=xyY also works."""
+        _advance_to_pre_grayscale(client, session_id)
+
+        lines = [
+            "0,128,128,128,5.0,0.3127,0.3290",
+            "1,235,235,235,100.0,0.3127,0.3290",
+        ]
+        csv = "\n".join(lines)
+
+        resp = _upload_generic(client, session_id, csv.encode(), fmt="xyY")
+        assert resp.status_code == 200
+
+        summary = resp.json()["import_summary"]
+        assert summary["total_rows"] == 2
+
+    def test_invalid_format_param_returns_400(self, client, session_id):
+        """Invalid format parameter value returns 400."""
+        _advance_to_pre_grayscale(client, session_id)
+
+        csv = _grayscale_csv([(0, 128, 128, 128, 5.0, 6.0, 4.0)])
+
+        resp = _upload_generic(client, session_id, csv.encode(), fmt="invalid")
+        assert resp.status_code == 400
+        assert "format" in resp.json()["detail"].lower()

--- a/tests/test_import_generic.py
+++ b/tests/test_import_generic.py
@@ -337,7 +337,9 @@ class TestGenericImportHeaderlessFormat:
 
         resp = _upload_generic(client, session_id, csv.encode())
         assert resp.status_code == 400
-        assert "chromaticity" in resp.json()["detail"].lower()
+        detail = resp.json()["detail"]
+        assert "chromaticity" in detail.lower()
+        assert "xyY, XYZ" in detail
 
     def test_headerless_xyz_csv_with_format_param(self, client, session_id):
         """Headerless XYZ CSV with format=XYZ parses correctly."""
@@ -353,6 +355,17 @@ class TestGenericImportHeaderlessFormat:
 
         summary = resp.json()["import_summary"]
         assert summary["total_rows"] == 2
+
+    def test_headerless_xyz_csv_case_insensitive_format(self, client, session_id):
+        """format param is case-insensitive — 'xyz', 'Xyz', 'XYZ' all work."""
+        _advance_to_pre_grayscale(client, session_id)
+
+        csv = _grayscale_csv([(0, 128, 128, 128, 5.0, 6.0, 4.0)])
+
+        for case in ("xyz", "Xyz", "XYZ"):
+            resp = _upload_generic(client, session_id, csv.encode(), fmt=case)
+            assert resp.status_code == 200, f"failed for fmt={case!r}"
+            assert resp.json()["import_summary"]["total_rows"] == 1
 
     def test_headerless_xyY_csv_with_default_format(self, client, session_id):
         """Headerless xyY CSV works with default format (xyY)."""
@@ -396,3 +409,24 @@ class TestGenericImportHeaderlessFormat:
         resp = _upload_generic(client, session_id, csv.encode(), fmt="invalid")
         assert resp.status_code == 400
         assert "format" in resp.json()["detail"].lower()
+
+    def test_chromaticity_boundary_at_0_85_rejected(self, client, session_id):
+        """x=0.85 is outside the plausible range and should be rejected."""
+        _advance_to_pre_grayscale(client, session_id)
+
+        # xyY: Y=100, x=0.85, y=0.33 — x at the boundary is rejected (exclusive upper bound)
+        csv = "0,128,128,128,100.0,0.85,0.33\n"
+        resp = _upload_generic(client, session_id, csv.encode())
+        assert resp.status_code == 400
+        assert "chromaticity" in resp.json()["detail"].lower()
+
+    def test_chromaticity_boundary_at_0_84_accepted(self, client, session_id):
+        """x=0.84 is inside the plausible range and should be accepted."""
+        _advance_to_pre_grayscale(client, session_id)
+
+        csv = "0,128,128,128,100.0,0.84,0.33\n"
+        resp = _upload_generic(client, session_id, csv.encode())
+        assert resp.status_code == 200
+        assert resp.json()["import_summary"]["total_rows"] == 1
+
+


### PR DESCRIPTION
## 📺 Overview

Fixes generic CSV import silently misclassifying headerless XYZ data as xyY, producing impossible chromaticities with no warning.

Closes #549

### What does this PR do?

- **Type of change:** [x] Bug fix | [ ] New feature | [ ] Refactoring | [ ] CI/CD or Tooling
- **Component(s) affected:** server.py, calibrator/session.py, calcore/csv_import.py, tests/test_import_generic.py

---

## 🛠️ Technical Context & Implementation

- **The Problem:** `import_generic_bytes` hardcoded `format="xyY"` when calling `parse_measurement_csv`. Headerless XYZ CSVs (label,R,G,B,X,Y,Z) were silently interpreted as xyY, storing impossible chromaticities like x=100.0, y=108.883. Every downstream ΔE/CCT computed from them was garbage with no warning.
- **The Solution:** 
  - Added `format` query parameter to `POST /api/session/{sid}/import/generic` (default `xyY` for ZRO compatibility)
  - Plumbed it through `import_generic_bytes` → `parse_measurement_csv`
  - Added plausibility validation in `_classify_headerless_row`: reject x,y outside [0, 0.85) — the CIE spectral locus fits within this range, so any value above 0.85 is an impossible chromaticity (catches XYZ↔xyY misclassification)
- **Impact on existing workflows/APIs:** Backward compatible — default `xyY` matches previous behavior. Headerless XYZ uploads that previously silently corrupted data now return 400 with a clear error suggesting `format=XYZ`.

---

## 🧪 Testing & Validation

### Environment Details
- **OS / Target Display:** macOS (CI)
- **Hardware/Mock Used:** TestClient with in-memory test sessions

### Verification Steps
1. Run `python3 -m pytest tests/test_import_generic.py -v` — all 18 tests pass
2. Run `python3 -m pytest tests/test_csv_headerless_explicit_format.py -v` — all 5 pass
3. Run `python3 -m pytest tests/test_csv_headerless_xyz_vs_xyY.py -v` — all 9 pass

### Tests Added
- `test_headerless_xyz_csv_requires_format_param` — XYZ data without `format=XYZ` → 400
- `test_headerless_xyz_csv_with_format_param` — XYZ data with `format=XYZ` → 200, correct parse
- `test_headerless_xyY_csv_with_default_format` — xyY data without explicit format → 200
- `test_headerless_xyY_csv_explicit_format` — xyY data with `format=xyY` → 200
- `test_invalid_format_param_returns_400` — invalid format value → 400

---

## 🧼 Checklist

- [x] Code adheres to project style guidelines (formatting, typing, linting).
- [x] Unit tests added/updated and passing.
- [x] No credentials, local absolute paths, or hardware-specific hardcoding leaked.
- [x] PR body includes `Closes #[issue-number]`