### PR TITLE
OverlayDeChart sort by stimulus_pct instead of parseInt(label) (#552)

### DIFF
--- a/frontend/src/charts/OverlayDeChart.jsx
+++ b/frontend/src/charts/OverlayDeChart.jsx
@@ -7,20 +7,21 @@ export function OverlayDeChart({ measurementsA, measurementsB }) {
 
   const labelFor = m => m.label ?? (m.stimulus_pct != null ? `${m.stimulus_pct}%` : '');
 
-  const toNum = s => {
-    const n = parseInt(s, 10);
-    return Number.isFinite(n) ? n : null;
-  };
+  const stimFor = new Map();
+  for (const m of [...(measurementsA || []), ...(measurementsB || [])]) {
+    const lbl = labelFor(m);
+    if (!stimFor.has(lbl)) stimFor.set(lbl, m.stimulus_pct);
+  }
 
   const allLabels = Array.from(new Set([
     ...(measurementsA || []).map(labelFor),
     ...(measurementsB || []).map(labelFor),
   ])).sort((a, b) => {
-    const pa = toNum(a);
-    const pb = toNum(b);
-    if (pa === null && pb === null) return a.localeCompare(b);
-    if (pa === null) return 1;
-    if (pb === null) return -1;
+    const pa = stimFor.get(a);
+    const pb = stimFor.get(b);
+    if (pa == null && pb == null) return a.localeCompare(b);
+    if (pa == null) return 1;
+    if (pb == null) return -1;
     return pa - pb;
   });
 

--- a/frontend/src/charts/OverlayDeChart.test.jsx
+++ b/frontend/src/charts/OverlayDeChart.test.jsx
@@ -143,6 +143,16 @@ describe('OverlayDeChart', () => {
     expect(colorsB).toEqual([C.amber]);
   });
 
+  it('sorts "Black (0%)" and "White (100%)" by stimulus_pct instead of parseInt label', () => {
+    const measurementsA = [
+      { stimulus_pct: 50, label: '50% Gray', delta_e: 1.0 },
+      { stimulus_pct: 100, label: 'White (100%)', delta_e: 2.5 },
+      { stimulus_pct: 0, label: 'Black (0%)', delta_e: 0.5 },
+    ];
+    render(<OverlayDeChart measurementsA={measurementsA} measurementsB={[]} />);
+    expect(lastChartProps.data.labels).toEqual(['Black (0%)', '50% Gray', 'White (100%)']);
+  });
+
   it('matches Session A and Session B severity coloring for the same dE values', () => {
     const measurementsA = [
       { stimulus_pct: 10, delta_e: 1.0 },


### PR DESCRIPTION
## 📺 Overview

Fixes OverlayDeChart sort order where 'Black (0%)' and 'White (100%)' appeared after all numeric percentage labels because parseInt returned NaN for those labels, pushing them to the localeCompare tail.

Closes [#552](https://github.com/jweber93/tv-calibration/issues/552)

### What does this PR do?

- **Type of change:** [x] Bug fix | [ ] New feature | [ ] Refactoring | [ ] CI/CD or Tooling
- **Component(s) affected:** frontend/src/charts/OverlayDeChart.jsx, frontend/src/charts/OverlayDeChart.test.jsx

---

## 🛠️ Technical Context & Implementation

- **The Problem:** `OverlayDeChart` sorted x-axis labels with `parseInt(label)`, which returns NaN for 'Black (0%)' and 'White (100%)'. NaN values fell to the non-numeric tail and were sorted by `localeCompare`, placing ramp endpoints at the wrong end of the axis exactly where clipping/crush shows up.
- **The Solution:** Build a label-to-stimulus_pct lookup map from both measurement sets, then sort by stimulus_pct (mirroring `DeChart.jsx:8-15`). Labels with non-numeric text like 'Black (0%)' now sort by their true stimulus position (0) instead of falling to the end.
- **Impact on existing workflows/APIs:** No API or data model changes. Chart rendering order is corrected for comparison views.

---

## 🧪 Testing & Validation

### Environment Details

- **OS / Target Display:** macOS (CI) / Hisense U8G (production)
- **Hardware/Mock Used:** Unit test with simulated measurement arrays containing grayscale labels

### Verification Steps

1. Run `npm run test:unit` — all 18 tests pass including new regression test
2. Verify new test asserts labels ['Black (0%)', '50% Gray', 'White (100%)'] render in stimulus_pct order [0, 50, 100]

### Firmware / TV Settings

- N/A — chart-only change, no hardware interaction

---

## 📸 Visual Evidence (UI / Plot Changes)

- 'Black (0%)' and 'White (100%)' now appear at the correct ends of the x-axis instead of being sorted after all numeric labels

---

## 🧼 Checklist

- [x] Code adheres to project style guidelines (formatting, typing, linting).
- [x] Unit tests added/updated and passing.
- [ ] Documentation updated (not applicable — chart internals only).
- [x] No credentials, local absolute paths, or hardware-specific hardcoding leaked.