### PR TITLE
Autocal: loop abstractions, CMS controller, orchestrator, API + prefs (1a–1d, 1g)

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,6 +474,24 @@ For supported TVs, the app can apply color management settings directly over And
 
 ADB must be installed and your TV must have ADB debugging enabled over the network. The ADB status card appears on measurement steps when a compatible device is detected.
 
+### Autocal (Guided CMS Loop)
+
+A Calman-style closed loop that automates Color Tuner convergence: measure → compute the correction → apply it → re-measure, iterating per primary until each is within tolerance (ΔE < 3.0) or the iteration cap is hit.
+
+- **Manual apply** (works on every TV): the loop tells you exactly which CMS control to change and by how much; you make the change on the TV and the loop re-measures.
+- **Auto apply** (ADB-capable TVs): the loop pushes the correction directly via ADB with read-back verification.
+- The correction step is a damped, oscillation-safe controller (`calibrator/autocal.py`) — not a raw proportional gain — so it converges instead of hunting back and forth across the target.
+
+**API:**
+
+```
+POST /api/session/{sid}/autocal/run    { colours?, apply_mode?, damping?, max_iterations?, device? }
+POST /api/session/{sid}/autocal/stop
+GET  /api/session/{sid}/autocal/stream  → SSE: autocal_start, autocal_iteration, autocal_colour_done, autocal_done, autocal_error
+```
+
+`apply_mode`, `damping`, and `max_iterations` default to the values saved in `.prefs.json` (`autocal.apply_mode`, `autocal.damping`, `autocal.max_iterations`) when omitted from the request; set them via `POST /api/prefs` with `autocal_apply_mode` / `autocal_damping` / `autocal_max_iterations`.
+
 ### Server Logs Panel
 
 A live server log stream is available in the UI for debugging. The panel tails the FastAPI process log in real time via `GET /api/logs/stream` (SSE). Log entries include CSV import events, LLM trigger attempts, Dogegen process lifecycle, and any server-side errors. The panel is collapsed by default; expand it from the header bar.
@@ -652,8 +670,9 @@ tests/                API, unit, and integration tests
 tools/                Reference CSV sequences for ZRO workflows
 
 .prefs.json           Persisted user preferences — watch path, LLM endpoint, Dogegen
-                      config, ZRO bridge URL. Auto-created; gitignored. Written
-                      atomically on every UI change; loaded at server startup.
+                      config, ZRO bridge URL, autocal apply mode/damping/iteration
+                      cap. Auto-created; gitignored. Written atomically on every
+                      UI change; loaded at server startup.
 
 .calibration-history/ Per-TV session history (auto-created; gitignored)
   {tv_key}/
@@ -787,6 +806,9 @@ The LLM prompt contains **only pre-aggregated data** — no raw per-patch XYZ ar
 | `POST` | `/api/report/compare/delta_summary?a={id}&b={id}` | LLM-authored plain-English delta summary |
 | `GET` | `/api/session/{sid}/suggested-patches?budget=30` | LLM-optimized patch list from residual analysis |
 | `POST` | `/api/session/{sid}/suggested-patches/run` | Forward suggested patches to the ZRO Bridge |
+| `POST` | `/api/session/{sid}/autocal/run` | Start the guided CMS autocal loop (measure → correct → apply → re-measure) |
+| `POST` | `/api/session/{sid}/autocal/stop` | Cooperatively cancel a running autocal loop |
+| `GET` | `/api/session/{sid}/autocal/stream` | SSE stream of per-iteration autocal progress |
 
 SSE stream (`GET /api/session/{sid}/llm/stream`) now emits two event types:
 

--- a/README.md
+++ b/README.md
@@ -481,16 +481,24 @@ A Calman-style closed loop that automates Color Tuner convergence: measure → c
 - **Manual apply** (works on every TV): the loop tells you exactly which CMS control to change and by how much; you make the change on the TV and the loop re-measures.
 - **Auto apply** (ADB-capable TVs): the loop pushes the correction directly via ADB with read-back verification.
 - The correction step is a damped, oscillation-safe controller (`calibrator/autocal.py`) — not a raw proportional gain — so it converges instead of hunting back and forth across the target.
+- `skip_stalled_controls` (opt-in): once a control saturates at its ±10 boundary without resolving its error, stop spending iterations on it so the remaining controls converge faster.
 
 **API:**
 
 ```
-POST /api/session/{sid}/autocal/run    { colours?, apply_mode?, damping?, max_iterations?, device? }
+POST /api/session/{sid}/autocal/run      { colours?, apply_mode?, damping?, max_iterations?,
+                                            skip_stalled_controls?, bridge_timeout?,
+                                            bridge_poll_interval?, device? }
 POST /api/session/{sid}/autocal/stop
-GET  /api/session/{sid}/autocal/stream  → SSE: autocal_start, autocal_iteration, autocal_colour_done, autocal_done, autocal_error
+GET  /api/session/{sid}/autocal/history  → full per-primary iteration history for the most recently
+                                            completed run (error, damping, gain source, oscillation/
+                                            stall flags) — useful for tuning damping or diagnosing why
+                                            a loop converged, stalled, or oscillated
+GET  /api/session/{sid}/autocal/stream   → SSE: autocal_start, autocal_iteration, autocal_colour_done,
+                                            autocal_done, autocal_error
 ```
 
-`apply_mode`, `damping`, and `max_iterations` default to the values saved in `.prefs.json` (`autocal.apply_mode`, `autocal.damping`, `autocal.max_iterations`) when omitted from the request; set them via `POST /api/prefs` with `autocal_apply_mode` / `autocal_damping` / `autocal_max_iterations`.
+`apply_mode`, `damping`, `max_iterations`, `skip_stalled_controls`, `bridge_timeout` (seconds, how long to wait for a triggered measurement to land before giving up), and `bridge_poll_interval` (seconds, how often to check) all default to the values saved in `.prefs.json` (`autocal.*`) when omitted from the request; set them via `POST /api/prefs` with `autocal_apply_mode` / `autocal_damping` / `autocal_max_iterations` / `autocal_skip_stalled_controls` / `autocal_bridge_timeout` / `autocal_bridge_poll_interval`.
 
 ### Server Logs Panel
 
@@ -808,6 +816,7 @@ The LLM prompt contains **only pre-aggregated data** — no raw per-patch XYZ ar
 | `POST` | `/api/session/{sid}/suggested-patches/run` | Forward suggested patches to the ZRO Bridge |
 | `POST` | `/api/session/{sid}/autocal/run` | Start the guided CMS autocal loop (measure → correct → apply → re-measure) |
 | `POST` | `/api/session/{sid}/autocal/stop` | Cooperatively cancel a running autocal loop |
+| `GET` | `/api/session/{sid}/autocal/history` | Full per-primary iteration history for the most recently completed autocal run |
 | `GET` | `/api/session/{sid}/autocal/stream` | SSE stream of per-iteration autocal progress |
 
 SSE stream (`GET /api/session/{sid}/llm/stream`) now emits two event types:

--- a/calibrator/autocal.py
+++ b/calibrator/autocal.py
@@ -44,6 +44,10 @@ class ControllerConfig:
     )
     # Bounds how far a learned secant gain may deviate (multiplicatively) from the
     # assumed gain in one step, so a single noisy Δerror can't size an absurd step.
+    # Tighter (closer to 1.0) makes gain learning slower to adapt to a TV's real
+    # response but more resistant to a single noisy reading; looser risks one bad
+    # measurement sizing a wild step. 8.0 was chosen empirically as the point
+    # where the synthetic-model tests converge reliably without either failure mode.
     secant_gain_clamp: float = 8.0
 
 

--- a/calibrator/autocal.py
+++ b/calibrator/autocal.py
@@ -1,0 +1,246 @@
+"""Damped, oscillation-safe CMS correction controller (autocal roadmap Item 1b)."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+# Mirror of adb_control.CMS_MIN / CMS_MAX. Duplicated rather than imported so the
+# controller stays pure control-theory math with no dependency on the ADB module
+# (roadmap design principle: "the controller never references ADB directly").
+CMS_MIN = -10
+CMS_MAX = 10
+
+CMS_CONTROLS = ("Hue", "Saturation", "Brightness")
+
+
+@dataclass(frozen=True)
+class ControllerConfig:
+    damping: float = 0.6
+    # 0.5 is the binary-search contraction ratio: once an error is bracketed by a
+    # sign flip, halving the effective step guarantees the bracket keeps shrinking.
+    oscillation_backoff: float = 0.5
+    # Never let damping collapse to 0, or the loop stalls before it converges.
+    min_damping: float = 0.05
+    control_min: int = CMS_MIN
+    control_max: int = CMS_MAX
+    # Best-effort secant gain learning; disable to run the pure damped-proportional
+    # core (used to prove the proportional path is itself oscillation-safe).
+    use_secant: bool = True
+    # Assumed |Δerror / Δstep| per control, in cms_hints units (hue: radians,
+    # saturation: xy-radius, brightness: nits). These are deliberately rough
+    # a-priori guesses — the true per-TV response is nonlinear and unknown, so the
+    # secant estimator overrides them as soon as one real (step, Δerror) pair exists.
+    error_per_step: Dict[str, float] = field(
+        default_factory=lambda: {"Hue": 0.010, "Saturation": 0.004, "Brightness": 3.0}
+    )
+    # Error magnitude at/below which a control is on-target. Hue/saturation mirror
+    # the "is close" bands in guidance.cms_hints; brightness there is a 10% relative
+    # band, so this absolute-nits default is a placeholder the orchestrator may
+    # override per primary luminance.
+    deadband: Dict[str, float] = field(
+        default_factory=lambda: {"Hue": 0.03, "Saturation": 0.003, "Brightness": 2.0}
+    )
+    # Bounds how far a learned secant gain may deviate (multiplicatively) from the
+    # assumed gain in one step, so a single noisy Δerror can't size an absurd step.
+    secant_gain_clamp: float = 8.0
+
+
+DEFAULT_CONFIG = ControllerConfig()
+
+
+@dataclass(frozen=True)
+class Observation:
+    error: float
+    step: int
+
+
+@dataclass(frozen=True)
+class CorrectionResult:
+    control: str
+    step: int
+    new_value: int
+    error: float
+    damping: float
+    gain: float
+    gain_source: str
+    converged: bool
+    oscillating: bool
+    stalled: bool
+    out_of_range: bool
+    reason: str
+
+
+def _sign(value: float) -> int:
+    return (value > 0) - (value < 0)
+
+
+def _round_step(value: float) -> int:
+    # Round half away from zero so a sub-unit correction still makes progress
+    # rather than silently truncating to a no-op step of 0.
+    if value >= 0:
+        return int(math.floor(value + 0.5))
+    return int(math.ceil(value - 0.5))
+
+
+def _count_overshoots(history: List[Observation], error: float, deadband: float) -> int:
+    # Overshoot == the error crossed zero between iterations. Counting every such
+    # crossing (not just the latest) makes the effective damping a deterministic
+    # function of history alone, so the controller needs no hidden mutable state.
+    errors = [obs.error for obs in history] + [error]
+    flips = 0
+    for prev, curr in zip(errors, errors[1:]):
+        if abs(prev) <= deadband or abs(curr) <= deadband:
+            continue
+        if _sign(prev) != _sign(curr):
+            flips += 1
+    return flips
+
+
+def _secant_gain(
+    history: List[Observation],
+    error: float,
+    assumed_gain: float,
+    clamp: float,
+) -> Optional[float]:
+    if not history:
+        return None
+    last = history[-1]
+    if last.step == 0:
+        return None
+    realized = (error - last.error) / last.step
+    if not math.isfinite(realized) or abs(realized) <= 1e-9:
+        return None
+    lo = assumed_gain / clamp
+    hi = assumed_gain * clamp
+    magnitude = min(max(abs(realized), lo), hi)
+    # Keep the realized sign: if a TV's control responds with inverted polarity the
+    # secant estimate flips the step direction automatically.
+    return math.copysign(magnitude, realized)
+
+
+def compute_correction(
+    control: str,
+    current_value: int,
+    error: float,
+    *,
+    config: ControllerConfig = DEFAULT_CONFIG,
+    history: Optional[List[Observation]] = None,
+) -> CorrectionResult:
+    """Return a bounded, damped correction step for one CMS control.
+
+    ``error`` is the signed measured error in cms_hints units for this control
+    (positive == attribute too high, matching guidance.cms_hints). The returned
+    ``step`` is an integer in control units; ``new_value`` is ``current_value +
+    step`` clamped to [control_min, control_max]. ``history`` is the prior
+    (error, step) observations for this control, oldest first — supply it to
+    enable overshoot backoff and secant gain learning.
+    """
+    history = list(history or [])
+    if control not in config.error_per_step or control not in config.deadband:
+        raise ValueError(f"No gain/deadband configured for control {control!r}")
+
+    assumed_gain = config.error_per_step[control]
+    deadband = config.deadband[control]
+
+    if abs(error) <= deadband:
+        return CorrectionResult(
+            control=control,
+            step=0,
+            new_value=current_value,
+            error=error,
+            damping=config.damping,
+            gain=assumed_gain,
+            gain_source="assumed",
+            converged=True,
+            oscillating=False,
+            stalled=False,
+            out_of_range=False,
+            reason="within deadband",
+        )
+
+    gain = assumed_gain
+    gain_source = "assumed"
+    if config.use_secant:
+        learned = _secant_gain(history, error, assumed_gain, config.secant_gain_clamp)
+        if learned is not None:
+            gain = learned
+            gain_source = "secant"
+
+    overshoots = _count_overshoots(history, error, deadband)
+    effective_damping = max(
+        config.min_damping, config.damping * (config.oscillation_backoff ** overshoots)
+    )
+
+    step_float = -effective_damping * error / gain
+    step = _round_step(step_float)
+    oscillating = overshoots > 0
+
+    # Limit-cycle guard: if the proposed move reverses the previous move and is at
+    # least as large, we would ping-pong across the target. Contract toward the
+    # midpoint instead of repeating an equal-and-opposite overshoot.
+    if history and history[-1].step != 0:
+        last_step = history[-1].step
+        if _sign(step) == -_sign(last_step) and abs(step) >= abs(last_step):
+            step = _round_step(step_float * config.oscillation_backoff)
+            oscillating = True
+
+    max_up = config.control_max - current_value
+    max_down = config.control_min - current_value
+    clamped = min(max(step, max_down), max_up)
+    out_of_range = clamped != step
+    step = clamped
+    new_value = current_value + step
+
+    stalled = step == 0 and abs(error) > deadband
+    if stalled and out_of_range:
+        reason = f"control saturated at {new_value}; cannot correct further"
+    elif stalled:
+        reason = "sub-unit correction rounds to no step; cannot improve on integer control"
+    elif out_of_range:
+        reason = f"step clamped to control range at {new_value}"
+    elif oscillating:
+        reason = f"overshoot detected; step reduced (damping {effective_damping:.3f})"
+    else:
+        reason = f"{gain_source} damped step (damping {effective_damping:.3f})"
+
+    return CorrectionResult(
+        control=control,
+        step=step,
+        new_value=new_value,
+        error=error,
+        damping=effective_damping,
+        gain=gain,
+        gain_source=gain_source,
+        converged=False,
+        oscillating=oscillating,
+        stalled=stalled,
+        out_of_range=out_of_range,
+        reason=reason,
+    )
+
+
+class CmsCorrectionController:
+    """Stateful per-control wrapper that accumulates history for :func:`compute_correction`."""
+
+    def __init__(self, config: ControllerConfig = DEFAULT_CONFIG) -> None:
+        self.config = config
+        self._history: Dict[str, List[Observation]] = {}
+
+    def history(self, control: str) -> List[Observation]:
+        return list(self._history.get(control, []))
+
+    def reset(self, control: Optional[str] = None) -> None:
+        if control is None:
+            self._history.clear()
+        else:
+            self._history.pop(control, None)
+
+    def step(self, control: str, current_value: int, error: float) -> CorrectionResult:
+        history = self._history.setdefault(control, [])
+        result = compute_correction(
+            control, current_value, error, config=self.config, history=history
+        )
+        history.append(Observation(error=error, step=result.step))
+        return result

--- a/calibrator/autocal_apply.py
+++ b/calibrator/autocal_apply.py
@@ -1,0 +1,149 @@
+"""Pluggable measurement/apply abstractions for the autocal loop (roadmap Item 1a).
+
+`MeasurementSource` and `ApplyTarget` are the two seams that keep the autocal
+loop (`calibrator/autocal_loop.py`) independent of any one TV or measurement
+backend. The loop orchestrator only ever calls these interfaces, never ADB or
+the ZRO Bridge directly.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+from calcore.models import Measurement, Patch
+
+from . import adb_control
+from .autocal import CorrectionResult
+
+
+class MeasurementSource(ABC):
+    """Triggers a measurement and returns the resulting reading."""
+
+    @abstractmethod
+    def measure(self, patch: Patch) -> Measurement:
+        ...
+
+
+class CallableMeasurementSource(MeasurementSource):
+    """Adapts any zero-arg measurement trigger into a MeasurementSource.
+
+    Today's ZRO Bridge (and Argyll's ``spotread``) read back whatever pattern
+    is currently displayed rather than accepting patch RGB directly — see
+    `docs/autocal-roadmap.md` Item 3's note on `/measure/sequence` ignoring
+    RGB. This adapter is deliberately patch-agnostic so it matches that
+    real-world behavior instead of pretending the trigger can set the patch.
+    """
+
+    def __init__(self, trigger: Callable[[], Measurement]) -> None:
+        self._trigger = trigger
+
+    def measure(self, patch: Patch) -> Measurement:
+        return self._trigger()
+
+
+@dataclass
+class ApplyResult:
+    ok: bool
+    control: str
+    step: int
+    new_value: int
+    message: str
+    requires_user_action: bool = False
+
+
+class ApplyTarget(ABC):
+    """Applies a CorrectionResult to one CMS colour's control."""
+
+    @abstractmethod
+    def apply(self, correction: CorrectionResult, *, colour: str) -> ApplyResult:
+        ...
+
+
+class ManualApplyTarget(ApplyTarget):
+    """Universal apply path: describe the change; the user makes it on the TV.
+
+    Never touches the TV — the loop orchestrator advances only after the
+    caller confirms the user re-measured (see `calibrator/autocal_loop.py`).
+    """
+
+    def apply(self, correction: CorrectionResult, *, colour: str) -> ApplyResult:
+        if correction.step == 0:
+            message = f"{colour} {correction.control}: no change needed ({correction.reason})"
+        else:
+            verb = "Raise" if correction.step > 0 else "Lower"
+            message = f"{colour}: {verb} {correction.control} to {correction.new_value}"
+        return ApplyResult(
+            ok=True,
+            control=correction.control,
+            step=correction.step,
+            new_value=correction.new_value,
+            message=message,
+            requires_user_action=correction.step != 0,
+        )
+
+
+class AdbApplyTarget(ApplyTarget):
+    """Auto-apply path: push the correction via ADB with read-back verification.
+
+    Falling back to manual mode on ADB failure is Item 1f's job, not this
+    interface's — this class only reports success/failure honestly.
+    """
+
+    def __init__(self, device: Optional[str] = None) -> None:
+        self.device = device
+
+    def apply(self, correction: CorrectionResult, *, colour: str) -> ApplyResult:
+        if colour not in adb_control.CMS_CHANNELS:
+            return ApplyResult(
+                ok=False,
+                control=correction.control,
+                step=0,
+                new_value=correction.new_value,
+                message=f"Unknown CMS colour {colour!r}",
+            )
+        if correction.step == 0:
+            return ApplyResult(
+                ok=True,
+                control=correction.control,
+                step=0,
+                new_value=correction.new_value,
+                message="No change needed",
+            )
+        try:
+            set_result = adb_control.set_cms_value(
+                colour, correction.control, correction.new_value, device=self.device
+            )
+        except ValueError as exc:
+            return ApplyResult(
+                ok=False,
+                control=correction.control,
+                step=correction.step,
+                new_value=correction.new_value,
+                message=str(exc),
+            )
+        if not set_result["ok"]:
+            return ApplyResult(
+                ok=False,
+                control=correction.control,
+                step=correction.step,
+                new_value=correction.new_value,
+                message=f"ADB set failed: {set_result['stderr'] or set_result['stdout']}",
+            )
+        readback = adb_control.get_cms_value(colour, correction.control, device=self.device)
+        if not readback["ok"] or readback["value"] != correction.new_value:
+            return ApplyResult(
+                ok=False,
+                control=correction.control,
+                step=correction.step,
+                new_value=correction.new_value,
+                message=f"Read-back mismatch: expected {correction.new_value}, got {readback.get('value')}",
+            )
+        return ApplyResult(
+            ok=True,
+            control=correction.control,
+            step=correction.step,
+            new_value=correction.new_value,
+            message=f"Applied {correction.control}={correction.new_value} on {colour} (verified)",
+        )

--- a/calibrator/autocal_loop.py
+++ b/calibrator/autocal_loop.py
@@ -1,0 +1,149 @@
+"""Per-primary measure -> correct -> apply -> re-measure orchestrator (roadmap Item 1c)."""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass, field, replace
+from typing import Callable, Dict, List, Optional
+
+from calcore.models import CalibrationTarget, Measurement, Patch
+
+from .autocal import CmsCorrectionController, ControllerConfig, DEFAULT_CONFIG, CorrectionResult
+from .autocal_apply import ApplyResult, ApplyTarget, MeasurementSource
+from .guidance import cms_hints
+from .quality import QG_CMS_DE_THRESHOLD
+from .session import m_to_dict
+
+# Maps CMS control labels to the corresponding cms_hints() error key. Some TV
+# profiles use "Luminance" instead of "Brightness" for the same control.
+CONTROL_ERROR_KEY: Dict[str, str] = {
+    "Hue": "hue",
+    "Saturation": "saturation",
+    "Brightness": "brightness",
+    "Luminance": "brightness",
+}
+
+
+@dataclass
+class IterationEvent:
+    colour: str
+    control: str
+    iteration: int
+    error: float
+    correction: CorrectionResult
+    apply_result: ApplyResult
+
+
+@dataclass
+class ColourResult:
+    colour: str
+    iterations: int
+    converged: bool
+    stopped_reason: str
+    delta_e: Optional[float] = None
+    history: List[IterationEvent] = field(default_factory=list)
+
+
+@dataclass
+class AutocalRunResult:
+    colours: Dict[str, ColourResult]
+    cancelled: bool
+
+
+class AutocalLoop:
+    """Drives the CMS autocal loop for a set of primaries.
+
+    Depends only on `MeasurementSource` / `ApplyTarget`, never on ADB or the
+    ZRO Bridge directly (roadmap design principle). `cancel()` is safe to call
+    from another thread; the loop checks it between measurements so a running
+    autocal run can be stopped cooperatively.
+    """
+
+    def __init__(
+        self,
+        measurement_source: MeasurementSource,
+        apply_target: ApplyTarget,
+        target: CalibrationTarget,
+        cms_controls: List[str],
+        *,
+        signal_range: str = "auto",
+        code_scale: str = "8bit",
+        config: ControllerConfig = DEFAULT_CONFIG,
+        max_iterations: int = 8,
+        on_iteration: Optional[Callable[[IterationEvent], None]] = None,
+    ) -> None:
+        self.measurement_source = measurement_source
+        self.apply_target = apply_target
+        self.target = target
+        self.cms_controls = [c for c in cms_controls if c in CONTROL_ERROR_KEY]
+        self.signal_range = signal_range
+        self.code_scale = code_scale
+        self.config = config
+        self.max_iterations = max_iterations
+        self.on_iteration = on_iteration
+        self._cancel = threading.Event()
+
+    def cancel(self) -> None:
+        self._cancel.set()
+
+    @property
+    def cancelled(self) -> bool:
+        return self._cancel.is_set()
+
+    def run(
+        self,
+        colours: List[str],
+        patch_for_colour: Callable[[str], Patch],
+        initial_values: Optional[Dict[str, Dict[str, int]]] = None,
+    ) -> AutocalRunResult:
+        results: Dict[str, ColourResult] = {}
+        values = initial_values if initial_values is not None else {}
+        for colour in colours:
+            if self._cancel.is_set():
+                break
+            colour_values = values.setdefault(colour, dict.fromkeys(self.cms_controls, 0))
+            results[colour] = self._run_colour(colour, patch_for_colour(colour), colour_values)
+        return AutocalRunResult(colours=results, cancelled=self._cancel.is_set())
+
+    def _run_colour(self, colour: str, patch: Patch, values: Dict[str, int]) -> ColourResult:
+        controller = CmsCorrectionController(self.config)
+        history: List[IterationEvent] = []
+        last_de: Optional[float] = None
+
+        for iteration in range(1, self.max_iterations + 1):
+            if self._cancel.is_set():
+                return ColourResult(colour, iteration - 1, False, "cancelled", last_de, history)
+
+            measurement: Measurement = self.measurement_source.measure(patch)
+            last_de = self._delta_e(measurement, colour)
+            if last_de is not None and last_de < QG_CMS_DE_THRESHOLD:
+                return ColourResult(colour, iteration - 1, True, "quality gate met", last_de, history)
+
+            hints = cms_hints(measurement, self.target, colour)
+            for control in self.cms_controls:
+                key = CONTROL_ERROR_KEY[control]
+                if key not in hints:
+                    continue
+                error = float(hints[key]["value"])
+                current_value = values[control]
+                result = controller.step(control, current_value, error)
+                apply_result = self.apply_target.apply(result, colour=colour)
+                if apply_result.ok:
+                    values[control] = result.new_value
+                event = IterationEvent(colour, control, iteration, error, result, apply_result)
+                history.append(event)
+                if self.on_iteration:
+                    self.on_iteration(event)
+
+        # One final measurement to report the ΔE the loop actually ended on.
+        final_measurement = self.measurement_source.measure(patch)
+        last_de = self._delta_e(final_measurement, colour)
+        converged = last_de is not None and last_de < QG_CMS_DE_THRESHOLD
+        reason = "quality gate met" if converged else "max_iterations reached"
+        return ColourResult(colour, self.max_iterations, converged, reason, last_de, history)
+
+    def _delta_e(self, measurement: Measurement, colour: str) -> Optional[float]:
+        # m_to_dict() only matches a measurement to its CMS target when the
+        # label equals the colour name, matching quality.py's own gate logic.
+        labeled = measurement if measurement.label == colour else replace(measurement, label=colour)
+        return m_to_dict(labeled, self.target, self.signal_range, self.code_scale)["delta_e"]

--- a/calibrator/autocal_loop.py
+++ b/calibrator/autocal_loop.py
@@ -70,6 +70,7 @@ class AutocalLoop:
         code_scale: str = "8bit",
         config: ControllerConfig = DEFAULT_CONFIG,
         max_iterations: int = 8,
+        skip_stalled_controls: bool = False,
         on_iteration: Optional[Callable[[IterationEvent], None]] = None,
     ) -> None:
         self.measurement_source = measurement_source
@@ -80,6 +81,11 @@ class AutocalLoop:
         self.code_scale = code_scale
         self.config = config
         self.max_iterations = max_iterations
+        # Opt-in: once a control reports stalled=True (saturated at its control
+        # range with error still outside the deadband), stop spending iterations
+        # on it so the remaining controls converge faster. Off by default so
+        # existing callers keep iterating all controls every pass.
+        self.skip_stalled_controls = skip_stalled_controls
         self.on_iteration = on_iteration
         self._cancel = threading.Event()
 
@@ -109,6 +115,7 @@ class AutocalLoop:
         controller = CmsCorrectionController(self.config)
         history: List[IterationEvent] = []
         last_de: Optional[float] = None
+        stalled_controls: set = set()
 
         for iteration in range(1, self.max_iterations + 1):
             if self._cancel.is_set():
@@ -120,7 +127,11 @@ class AutocalLoop:
                 return ColourResult(colour, iteration - 1, True, "quality gate met", last_de, history)
 
             hints = cms_hints(measurement, self.target, colour)
-            for control in self.cms_controls:
+            active_controls = [c for c in self.cms_controls if c not in stalled_controls]
+            if self.skip_stalled_controls and not active_controls:
+                return ColourResult(colour, iteration - 1, False, "all controls stalled", last_de, history)
+
+            for control in active_controls:
                 key = CONTROL_ERROR_KEY[control]
                 if key not in hints:
                     continue
@@ -130,6 +141,8 @@ class AutocalLoop:
                 apply_result = self.apply_target.apply(result, colour=colour)
                 if apply_result.ok:
                     values[control] = result.new_value
+                if self.skip_stalled_controls and result.stalled:
+                    stalled_controls.add(control)
                 event = IterationEvent(colour, control, iteration, error, result, apply_result)
                 history.append(event)
                 if self.on_iteration:

--- a/server.py
+++ b/server.py
@@ -94,6 +94,7 @@ from calibrator.reports import (
 from calibrator.osd import translate_from_adjustment_plan as _osd_translate
 from calibrator.session import (
     CMS_PATCHES,
+    cms_patches as _cms_patches,
     cv as _cv,
     MODE_OPTIONS,
     PATTERN_GENERATOR_OPTIONS,
@@ -114,6 +115,14 @@ from calibrator.session import (
 )
 from calibrator.utils import get_all_measurements as _get_all_measurements
 import calibrator.adb_control as _adb
+from calibrator.autocal import ControllerConfig
+from calibrator.autocal_apply import (
+    AdbApplyTarget,
+    ApplyTarget,
+    MeasurementSource,
+    ManualApplyTarget,
+)
+from calibrator.autocal_loop import AutocalLoop
 
 logger = logging.getLogger(__name__)
 
@@ -362,6 +371,14 @@ _dogegen_config: Dict[str, Any] = {
 _llm_queues: Dict[str, List[queue.Queue]] = {}
 _llm_queues_lock = threading.Lock()
 
+# Per-session autocal run state + SSE subscriber queues
+_autocal_loops: Dict[str, AutocalLoop] = {}
+_autocal_loops_lock = threading.Lock()
+_autocal_queues: Dict[str, List[queue.Queue]] = {}
+_autocal_queues_lock = threading.Lock()
+_AUTOCAL_BRIDGE_TIMEOUT = 30.0
+_AUTOCAL_POLL_INTERVAL = 0.5
+
 store = SessionStore(
     session_dir_getter=lambda: SESSION_STORE_DIR,
     ttl_getter=lambda: SESSION_TTL,
@@ -375,6 +392,12 @@ _sessions = store.sessions
 # Preferences — persisted to .prefs.json, loaded on startup
 # ---------------------------------------------------------------------------
 _PREFS_PATH = Path(__file__).parent / ".prefs.json"
+_AUTOCAL_DEFAULTS: Dict[str, Any] = {
+    "apply_mode": "manual",
+    "damping": ControllerConfig().damping,
+    "max_iterations": 8,
+}
+
 _prefs: Dict[str, Any] = {
     "dogegen": {},
     "bridge_url": "",
@@ -385,6 +408,7 @@ _prefs: Dict[str, Any] = {
         "code_scale": "8bit",
         "pattern_generator": "dogegen",
     },
+    "autocal": dict(_AUTOCAL_DEFAULTS),
 }
 
 
@@ -401,6 +425,10 @@ def _load_prefs() -> None:
     for key in ("dogegen", "bridge_url", "watch_folder", "llm", "session_defaults"):
         if key in saved:
             _prefs[key] = saved[key]
+    if "autocal" in saved:
+        # Merge onto defaults so a prefs file saved before a new autocal field
+        # was added doesn't silently drop the field for the rest of the run.
+        _prefs["autocal"] = {**_AUTOCAL_DEFAULTS, **saved["autocal"]}
     for field in ("path", "resolve_host", "window_pct", "maxcll"):
         if field in _prefs.get("dogegen", {}):
             _dogegen_config[field] = _prefs["dogegen"][field]
@@ -478,6 +506,17 @@ class PrefsReq(BaseModel):
     llm_endpoint: Optional[str] = None
     llm_model: Optional[str] = None
     watch_folder: Optional[str] = None
+    autocal_apply_mode: Optional[str] = None
+    autocal_damping: Optional[float] = None
+    autocal_max_iterations: Optional[int] = None
+
+
+class AutocalRunReq(BaseModel):
+    colours: Optional[List[str]] = None
+    apply_mode: Optional[str] = None
+    damping: Optional[float] = None
+    max_iterations: Optional[int] = None
+    device: Optional[str] = None
 
 
 class AdbCmsSetReq(BaseModel):
@@ -742,6 +781,75 @@ def _llm_broadcast(sid: str, payload: Dict[str, Any]) -> None:
             q.put_nowait(payload)
         except queue.Full:
             logger.warning("LLM event queue full for session %s; dropping event", sid)
+
+
+def _autocal_subscribe(sid: str) -> "queue.Queue[Dict[str, Any]]":
+    q: queue.Queue = queue.Queue(maxsize=200)
+    with _autocal_queues_lock:
+        _autocal_queues.setdefault(sid, []).append(q)
+    return q
+
+
+def _autocal_unsubscribe(sid: str, q: "queue.Queue[Dict[str, Any]]") -> None:
+    with _autocal_queues_lock:
+        listeners = _autocal_queues.get(sid, [])
+        try:
+            listeners.remove(q)
+        except ValueError:
+            pass
+        if not listeners:
+            _autocal_queues.pop(sid, None)
+
+
+def _autocal_broadcast(sid: str, payload: Dict[str, Any]) -> None:
+    with _autocal_queues_lock:
+        listeners = list(_autocal_queues.get(sid, []))
+    for q in listeners:
+        try:
+            q.put_nowait(payload)
+        except queue.Full:
+            logger.warning("Autocal event queue full for session %s; dropping event", sid)
+
+
+class _SessionCmsMeasurementSource(MeasurementSource):
+    """Triggers a ZRO Bridge measurement, then waits for the watch-folder
+    import pipeline to land a new CMS measurement for this colour on the
+    session — the bridge itself only fires the meter, it does not return
+    a parsed reading synchronously (see docs/autocal-roadmap.md Item 3's
+    note on RGB-ignored `/measure/sequence` for the same limitation)."""
+
+    def __init__(
+        self,
+        sid: str,
+        timeout: float = _AUTOCAL_BRIDGE_TIMEOUT,
+        poll_interval: float = _AUTOCAL_POLL_INTERVAL,
+    ) -> None:
+        self.sid = sid
+        self.timeout = timeout
+        self.poll_interval = poll_interval
+
+    def measure(self, patch: Patch) -> Any:
+        import time as _time
+
+        colour = patch.label
+        session = store.get(self.sid)
+        seen_before = len(session.get("cms_measurements", []))
+        zro_trigger()
+        deadline = _time.monotonic() + self.timeout
+        while _time.monotonic() < deadline:
+            session = store.get(self.sid)
+            cms = session.get("cms_measurements", [])
+            if len(cms) > seen_before:
+                candidate = cms[-1]
+                candidate_colour = (candidate.label or "").replace(" 100%", "")
+                if candidate_colour == colour:
+                    return candidate
+                seen_before = len(cms)
+            _time.sleep(self.poll_interval)
+        raise TimeoutError(
+            f"No new {colour} measurement arrived within {self.timeout}s "
+            "— check the watch folder is configured and the meter is connected."
+        )
 
 
 def _measurement_to_patch(m: Any) -> Patch:
@@ -2282,6 +2390,19 @@ def save_prefs_endpoint(req: PrefsReq):
         _prefs["llm"]["model"] = req.llm_model.strip()
     if req.watch_folder is not None:
         _prefs["watch_folder"] = req.watch_folder.strip()
+    autocal_prefs = _prefs.setdefault("autocal", dict(_AUTOCAL_DEFAULTS))
+    if req.autocal_apply_mode is not None:
+        if req.autocal_apply_mode not in ("manual", "adb"):
+            raise HTTPException(400, "autocal_apply_mode must be 'manual' or 'adb'")
+        autocal_prefs["apply_mode"] = req.autocal_apply_mode
+    if req.autocal_damping is not None:
+        if not (0.0 < req.autocal_damping <= 1.0):
+            raise HTTPException(400, "autocal_damping must be in (0, 1]")
+        autocal_prefs["damping"] = req.autocal_damping
+    if req.autocal_max_iterations is not None:
+        if not (1 <= req.autocal_max_iterations <= 50):
+            raise HTTPException(400, "autocal_max_iterations must be between 1 and 50")
+        autocal_prefs["max_iterations"] = req.autocal_max_iterations
     _save_prefs()
     return {"ok": True, **_prefs}
 
@@ -2308,6 +2429,181 @@ def zro_trigger():
         raise HTTPException(502, f"ZRO Bridge error: {exc.response.text}")
     except Exception as exc:
         raise HTTPException(500, f"ZRO Bridge proxy error: {exc}")
+
+
+# ── Autocal: guided closed-loop measure → correct → apply → re-measure ───────
+
+
+def _run_autocal_background(
+    sid: str,
+    loop: AutocalLoop,
+    colours: List[str],
+    patch_for_colour: Any,
+) -> None:
+    def on_iteration(event: Any) -> None:
+        _autocal_broadcast(
+            sid,
+            {
+                "event": "autocal_iteration",
+                "data": {
+                    "colour": event.colour,
+                    "control": event.control,
+                    "iteration": event.iteration,
+                    "error": event.error,
+                    "step": event.correction.step,
+                    "new_value": event.correction.new_value,
+                    "damping": event.correction.damping,
+                    "oscillating": event.correction.oscillating,
+                    "reason": event.correction.reason,
+                    "apply_ok": event.apply_result.ok,
+                    "apply_message": event.apply_result.message,
+                },
+            },
+        )
+
+    loop.on_iteration = on_iteration
+    _autocal_broadcast(sid, {"event": "autocal_start", "data": {"colours": colours}})
+    try:
+        result = loop.run(colours, patch_for_colour)
+        for colour, cr in result.colours.items():
+            _autocal_broadcast(
+                sid,
+                {
+                    "event": "autocal_colour_done",
+                    "data": {
+                        "colour": colour,
+                        "converged": cr.converged,
+                        "reason": cr.stopped_reason,
+                        "delta_e": cr.delta_e,
+                        "iterations": cr.iterations,
+                    },
+                },
+            )
+        _autocal_broadcast(sid, {"event": "autocal_done", "data": {"cancelled": result.cancelled}})
+    except Exception as exc:
+        logger.error("Autocal run failed  sid=%s error=%s", sid, exc, exc_info=True)
+        _autocal_broadcast(sid, {"event": "autocal_error", "data": str(exc)})
+    finally:
+        with _autocal_loops_lock:
+            _autocal_loops.pop(sid, None)
+
+
+@app.post("/api/session/{sid}/autocal/run")
+def autocal_run(sid: str, req: AutocalRunReq):
+    session = store.get(sid)
+    target = session.get("target")
+    if not target:
+        raise HTTPException(400, "Session has no calibration target set.")
+    tv_key = session.get("tv_key", "")
+    tv = _get_tv_profile(tv_key) if tv_key else None
+    if not tv:
+        raise HTTPException(400, "No TV profile selected for this session.")
+
+    with _autocal_loops_lock:
+        if sid in _autocal_loops:
+            raise HTTPException(409, "Autocal is already running for this session.")
+
+    colours = req.colours or list(tv.CMS_COLOURS)
+    unknown = [c for c in colours if c not in tv.CMS_COLOURS]
+    if unknown:
+        raise HTTPException(400, f"Unknown CMS colours for {tv_key}: {unknown}")
+
+    autocal_prefs = _prefs.get("autocal", _AUTOCAL_DEFAULTS)
+    apply_mode = req.apply_mode or autocal_prefs.get("apply_mode", "manual")
+    if apply_mode not in ("manual", "adb"):
+        raise HTTPException(400, "apply_mode must be 'manual' or 'adb'.")
+    damping = req.damping if req.damping is not None else autocal_prefs.get("damping", ControllerConfig().damping)
+    if not (0.0 < damping <= 1.0):
+        raise HTTPException(400, "damping must be in (0, 1].")
+    max_iterations = (
+        req.max_iterations
+        if req.max_iterations is not None
+        else autocal_prefs.get("max_iterations", 8)
+    )
+    if not (1 <= max_iterations <= 50):
+        raise HTTPException(400, "max_iterations must be between 1 and 50.")
+
+    apply_target: ApplyTarget = (
+        ManualApplyTarget() if apply_mode == "manual" else AdbApplyTarget(device=req.device)
+    )
+    config = ControllerConfig(damping=damping)
+    measurement_source = _SessionCmsMeasurementSource(sid)
+    loop = AutocalLoop(
+        measurement_source,
+        apply_target,
+        target,
+        list(tv.CMS_CONTROLS),
+        signal_range=session.get("signal_range", "auto"),
+        code_scale=session.get("code_scale", "8bit"),
+        config=config,
+        max_iterations=max_iterations,
+    )
+    with _autocal_loops_lock:
+        _autocal_loops[sid] = loop
+
+    signal_range = session.get("signal_range", "auto")
+    code_scale = session.get("code_scale", "8bit")
+    patch_rgb = _cms_patches(signal_range, code_scale)
+
+    def patch_for_colour(colour: str) -> Patch:
+        rgb = patch_rgb.get(colour, (235, 235, 235))
+        return Patch(
+            label=colour, r_target=rgb[0], g_target=rgb[1], b_target=rgb[2], meas_xyz=(0, 0, 0), kind="color"
+        )
+
+    t = threading.Thread(
+        target=_run_autocal_background,
+        args=(sid, loop, colours, patch_for_colour),
+        daemon=True,
+    )
+    t.start()
+    return {
+        "status": "running",
+        "colours": colours,
+        "apply_mode": apply_mode,
+        "damping": damping,
+        "max_iterations": max_iterations,
+    }
+
+
+@app.post("/api/session/{sid}/autocal/stop")
+def autocal_stop(sid: str):
+    store.get(sid)  # raises 404 if session doesn't exist
+    with _autocal_loops_lock:
+        loop = _autocal_loops.get(sid)
+    if not loop:
+        return {"status": "not_running"}
+    loop.cancel()
+    return {"status": "stopping"}
+
+
+@app.get("/api/session/{sid}/autocal/stream")
+def autocal_stream(sid: str):
+    store.get(sid)  # raises 404 if session doesn't exist
+    ev_queue = _autocal_subscribe(sid)
+
+    def _generator():
+        try:
+            while True:
+                try:
+                    payload = ev_queue.get(timeout=20.0)
+                    event_type = payload.get("event", "autocal_iteration")
+                    data = json.dumps(payload.get("data", {}))
+                    yield f"event: {event_type}\ndata: {data}\n\n"
+                except queue.Empty:
+                    yield ": keep-alive\n\n"
+        finally:
+            _autocal_unsubscribe(sid, ev_queue)
+
+    return StreamingResponse(
+        _generator(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )
 
 
 @app.post("/api/session/{sid}/watch")

--- a/server.py
+++ b/server.py
@@ -376,6 +376,10 @@ _autocal_loops: Dict[str, AutocalLoop] = {}
 _autocal_loops_lock = threading.Lock()
 _autocal_queues: Dict[str, List[queue.Queue]] = {}
 _autocal_queues_lock = threading.Lock()
+# Full history of the most recently completed run per session, for
+# GET /api/session/{sid}/autocal/history — cleared only by a new run starting.
+_autocal_last_run: Dict[str, Dict[str, Any]] = {}
+_autocal_history_lock = threading.Lock()
 _AUTOCAL_BRIDGE_TIMEOUT = 30.0
 _AUTOCAL_POLL_INTERVAL = 0.5
 
@@ -396,6 +400,9 @@ _AUTOCAL_DEFAULTS: Dict[str, Any] = {
     "apply_mode": "manual",
     "damping": ControllerConfig().damping,
     "max_iterations": 8,
+    "skip_stalled_controls": False,
+    "bridge_timeout": _AUTOCAL_BRIDGE_TIMEOUT,
+    "bridge_poll_interval": _AUTOCAL_POLL_INTERVAL,
 }
 
 _prefs: Dict[str, Any] = {
@@ -509,6 +516,9 @@ class PrefsReq(BaseModel):
     autocal_apply_mode: Optional[str] = None
     autocal_damping: Optional[float] = None
     autocal_max_iterations: Optional[int] = None
+    autocal_skip_stalled_controls: Optional[bool] = None
+    autocal_bridge_timeout: Optional[float] = None
+    autocal_bridge_poll_interval: Optional[float] = None
 
 
 class AutocalRunReq(BaseModel):
@@ -516,6 +526,9 @@ class AutocalRunReq(BaseModel):
     apply_mode: Optional[str] = None
     damping: Optional[float] = None
     max_iterations: Optional[int] = None
+    skip_stalled_controls: Optional[bool] = None
+    bridge_timeout: Optional[float] = None
+    bridge_poll_interval: Optional[float] = None
     device: Optional[str] = None
 
 
@@ -2422,6 +2435,16 @@ def save_prefs_endpoint(req: PrefsReq):
         if not (1 <= req.autocal_max_iterations <= 50):
             raise HTTPException(400, "autocal_max_iterations must be between 1 and 50")
         autocal_prefs["max_iterations"] = req.autocal_max_iterations
+    if req.autocal_skip_stalled_controls is not None:
+        autocal_prefs["skip_stalled_controls"] = req.autocal_skip_stalled_controls
+    if req.autocal_bridge_timeout is not None:
+        if not (1.0 <= req.autocal_bridge_timeout <= 120.0):
+            raise HTTPException(400, "autocal_bridge_timeout must be between 1 and 120 seconds")
+        autocal_prefs["bridge_timeout"] = req.autocal_bridge_timeout
+    if req.autocal_bridge_poll_interval is not None:
+        if not (0.05 <= req.autocal_bridge_poll_interval <= 5.0):
+            raise HTTPException(400, "autocal_bridge_poll_interval must be between 0.05 and 5 seconds")
+        autocal_prefs["bridge_poll_interval"] = req.autocal_bridge_poll_interval
     _save_prefs()
     return {"ok": True, **_prefs}
 
@@ -2453,6 +2476,26 @@ def zro_trigger():
 # ── Autocal: guided closed-loop measure → correct → apply → re-measure ───────
 
 
+def _iteration_event_to_dict(event: Any) -> Dict[str, Any]:
+    return {
+        "colour": event.colour,
+        "control": event.control,
+        "iteration": event.iteration,
+        "error": event.error,
+        "step": event.correction.step,
+        "new_value": event.correction.new_value,
+        "damping": event.correction.damping,
+        "gain": event.correction.gain,
+        "gain_source": event.correction.gain_source,
+        "oscillating": event.correction.oscillating,
+        "stalled": event.correction.stalled,
+        "out_of_range": event.correction.out_of_range,
+        "reason": event.correction.reason,
+        "apply_ok": event.apply_result.ok,
+        "apply_message": event.apply_result.message,
+    }
+
+
 def _run_autocal_background(
     sid: str,
     loop: AutocalLoop,
@@ -2460,31 +2503,21 @@ def _run_autocal_background(
     patch_for_colour: Any,
 ) -> None:
     def on_iteration(event: Any) -> None:
-        _autocal_broadcast(
-            sid,
-            {
-                "event": "autocal_iteration",
-                "data": {
-                    "colour": event.colour,
-                    "control": event.control,
-                    "iteration": event.iteration,
-                    "error": event.error,
-                    "step": event.correction.step,
-                    "new_value": event.correction.new_value,
-                    "damping": event.correction.damping,
-                    "oscillating": event.correction.oscillating,
-                    "reason": event.correction.reason,
-                    "apply_ok": event.apply_result.ok,
-                    "apply_message": event.apply_result.message,
-                },
-            },
-        )
+        _autocal_broadcast(sid, {"event": "autocal_iteration", "data": _iteration_event_to_dict(event)})
 
     loop.on_iteration = on_iteration
     _autocal_broadcast(sid, {"event": "autocal_start", "data": {"colours": colours}})
     try:
         result = loop.run(colours, patch_for_colour)
+        history_payload: Dict[str, Any] = {"colours": {}, "cancelled": result.cancelled}
         for colour, cr in result.colours.items():
+            history_payload["colours"][colour] = {
+                "converged": cr.converged,
+                "reason": cr.stopped_reason,
+                "delta_e": cr.delta_e,
+                "iterations": cr.iterations,
+                "history": [_iteration_event_to_dict(e) for e in cr.history],
+            }
             _autocal_broadcast(
                 sid,
                 {
@@ -2498,6 +2531,8 @@ def _run_autocal_background(
                     },
                 },
             )
+        with _autocal_history_lock:
+            _autocal_last_run[sid] = history_payload
         _autocal_broadcast(sid, {"event": "autocal_done", "data": {"cancelled": result.cancelled}})
     except Exception as exc:
         logger.error("Autocal run failed  sid=%s error=%s", sid, exc, exc_info=True)
@@ -2541,12 +2576,33 @@ def autocal_run(sid: str, req: AutocalRunReq):
     )
     if not (1 <= max_iterations <= 50):
         raise HTTPException(400, "max_iterations must be between 1 and 50.")
+    skip_stalled_controls = (
+        req.skip_stalled_controls
+        if req.skip_stalled_controls is not None
+        else autocal_prefs.get("skip_stalled_controls", False)
+    )
+    bridge_timeout = (
+        req.bridge_timeout
+        if req.bridge_timeout is not None
+        else autocal_prefs.get("bridge_timeout", _AUTOCAL_BRIDGE_TIMEOUT)
+    )
+    if not (1.0 <= bridge_timeout <= 120.0):
+        raise HTTPException(400, "bridge_timeout must be between 1 and 120 seconds.")
+    bridge_poll_interval = (
+        req.bridge_poll_interval
+        if req.bridge_poll_interval is not None
+        else autocal_prefs.get("bridge_poll_interval", _AUTOCAL_POLL_INTERVAL)
+    )
+    if not (0.05 <= bridge_poll_interval <= 5.0):
+        raise HTTPException(400, "bridge_poll_interval must be between 0.05 and 5 seconds.")
 
     apply_target: ApplyTarget = (
         ManualApplyTarget() if apply_mode == "manual" else AdbApplyTarget(device=req.device)
     )
     config = ControllerConfig(damping=damping)
-    measurement_source = _SessionCmsMeasurementSource(sid)
+    measurement_source = _SessionCmsMeasurementSource(
+        sid, timeout=bridge_timeout, poll_interval=bridge_poll_interval
+    )
     loop = AutocalLoop(
         measurement_source,
         apply_target,
@@ -2556,9 +2612,12 @@ def autocal_run(sid: str, req: AutocalRunReq):
         code_scale=session.get("code_scale", "8bit"),
         config=config,
         max_iterations=max_iterations,
+        skip_stalled_controls=skip_stalled_controls,
     )
     with _autocal_loops_lock:
         _autocal_loops[sid] = loop
+    with _autocal_history_lock:
+        _autocal_last_run.pop(sid, None)
 
     signal_range = session.get("signal_range", "auto")
     code_scale = session.get("code_scale", "8bit")
@@ -2582,6 +2641,9 @@ def autocal_run(sid: str, req: AutocalRunReq):
         "apply_mode": apply_mode,
         "damping": damping,
         "max_iterations": max_iterations,
+        "skip_stalled_controls": skip_stalled_controls,
+        "bridge_timeout": bridge_timeout,
+        "bridge_poll_interval": bridge_poll_interval,
     }
 
 
@@ -2594,6 +2656,16 @@ def autocal_stop(sid: str):
         return {"status": "not_running"}
     loop.cancel()
     return {"status": "stopping"}
+
+
+@app.get("/api/session/{sid}/autocal/history")
+def autocal_history(sid: str):
+    store.get(sid)  # raises 404 if session doesn't exist
+    with _autocal_history_lock:
+        recorded = _autocal_last_run.get(sid)
+    if recorded is None:
+        return {"available": False}
+    return {"available": True, **recorded}
 
 
 @app.get("/api/session/{sid}/autocal/stream")

--- a/tests/test_autocal_api.py
+++ b/tests/test_autocal_api.py
@@ -6,6 +6,8 @@ from unittest.mock import patch
 import pytest
 from fastapi.testclient import TestClient
 
+from calcore.models import Measurement
+from calibrator.guidance import target_nits_for_colour, target_xy_for_colour
 import server as server_module
 from server import app, _sessions
 
@@ -82,6 +84,18 @@ class TestAutocalRunValidation:
         resp = client.post("/api/session/does-not-exist/autocal/run", json={})
         assert resp.status_code == 404
 
+    def test_bridge_timeout_out_of_range_rejected(self, client, session_id):
+        resp = client.post(
+            f"/api/session/{session_id}/autocal/run", json={"bridge_timeout": 200}
+        )
+        assert resp.status_code == 400
+
+    def test_bridge_poll_interval_out_of_range_rejected(self, client, session_id):
+        resp = client.post(
+            f"/api/session/{session_id}/autocal/run", json={"bridge_poll_interval": 10}
+        )
+        assert resp.status_code == 400
+
 
 class TestAutocalRunLifecycle:
     def test_run_starts_and_rejects_concurrent_run(self, client, session_id):
@@ -139,6 +153,35 @@ class TestAutocalRunLifecycle:
             assert loop is None or loop.cancelled
             block.set()
 
+    def test_run_response_echoes_and_passes_through_new_fields(self, client, session_id):
+        block = threading.Event()
+
+        def fake_measure(self, patch_obj):
+            block.wait(timeout=5.0)
+            raise TimeoutError("stopped")
+
+        with patch("server._SessionCmsMeasurementSource.measure", fake_measure):
+            resp = client.post(
+                f"/api/session/{session_id}/autocal/run",
+                json={
+                    "colours": ["Red"],
+                    "skip_stalled_controls": True,
+                    "bridge_timeout": 15.0,
+                    "bridge_poll_interval": 1.0,
+                },
+            )
+            body = resp.json()
+            assert body["skip_stalled_controls"] is True
+            assert body["bridge_timeout"] == 15.0
+            assert body["bridge_poll_interval"] == 1.0
+
+            assert _wait_until(lambda: session_id in server_module._autocal_loops)
+            loop = server_module._autocal_loops[session_id]
+            assert loop.skip_stalled_controls is True
+
+            block.set()
+            _wait_until(lambda: session_id not in server_module._autocal_loops)
+
 
 class TestAutocalStream:
     def test_unknown_session_404s(self, client):
@@ -147,6 +190,44 @@ class TestAutocalStream:
         # which likewise only cover the 404-before-streaming-starts path.
         resp = client.get("/api/session/does-not-exist/autocal/stream")
         assert resp.status_code == 404
+
+
+class TestAutocalHistory:
+    def test_no_history_before_any_run(self, client, session_id):
+        resp = client.get(f"/api/session/{session_id}/autocal/history")
+        assert resp.status_code == 200
+        assert resp.json() == {"available": False}
+
+    def test_unknown_session_404s(self, client):
+        resp = client.get("/api/session/does-not-exist/autocal/history")
+        assert resp.status_code == 404
+
+    def test_history_recorded_after_converged_run(self, client, session_id):
+        session = server_module.store.get(session_id)
+        target = session["target"]
+        target_xy = target_xy_for_colour(target, "Red")
+        target_nits = target_nits_for_colour(target, "Red")
+
+        def fake_measure(self, patch_obj):
+            return Measurement(
+                x=target_xy[0], y=target_xy[1], Y=target_nits, label="Red", stimulus_rgb=(1023, 0, 0)
+            )
+
+        with patch("server._SessionCmsMeasurementSource.measure", fake_measure):
+            client.post(
+                f"/api/session/{session_id}/autocal/run",
+                json={"colours": ["Red"], "max_iterations": 2},
+            )
+            assert _wait_until(lambda: session_id not in server_module._autocal_loops)
+
+        resp = client.get(f"/api/session/{session_id}/autocal/history")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["available"] is True
+        red = body["colours"]["Red"]
+        assert red["converged"] is True
+        assert red["delta_e"] < 3.0
+        assert red["history"] == []  # converged on the first measurement; no corrections needed
 
 
 class TestAutocalPrefs:
@@ -175,6 +256,29 @@ class TestAutocalPrefs:
 
     def test_save_prefs_rejects_bad_damping(self, client):
         resp = client.post("/api/prefs", json={"autocal_damping": 0.0})
+        assert resp.status_code == 400
+
+    def test_save_prefs_updates_new_autocal_fields(self, client):
+        resp = client.post(
+            "/api/prefs",
+            json={
+                "autocal_skip_stalled_controls": True,
+                "autocal_bridge_timeout": 45.0,
+                "autocal_bridge_poll_interval": 1.5,
+            },
+        )
+        assert resp.status_code == 200
+        autocal = resp.json()["autocal"]
+        assert autocal["skip_stalled_controls"] is True
+        assert autocal["bridge_timeout"] == 45.0
+        assert autocal["bridge_poll_interval"] == 1.5
+
+    def test_save_prefs_rejects_bad_bridge_timeout(self, client):
+        resp = client.post("/api/prefs", json={"autocal_bridge_timeout": 500})
+        assert resp.status_code == 400
+
+    def test_save_prefs_rejects_bad_bridge_poll_interval(self, client):
+        resp = client.post("/api/prefs", json={"autocal_bridge_poll_interval": 20})
         assert resp.status_code == 400
 
     def test_run_uses_saved_prefs_as_defaults(self, client, session_id):

--- a/tests/test_autocal_api.py
+++ b/tests/test_autocal_api.py
@@ -1,0 +1,193 @@
+"""Tests for the autocal run/stop/stream endpoints (Autocal roadmap Item 1d)."""
+import threading
+import time
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+import server as server_module
+from server import app, _sessions
+
+
+@pytest.fixture(autouse=True)
+def clear_sessions():
+    _sessions.clear()
+    server_module._watched_session.set(None)
+    server_module._prefs["autocal"] = dict(server_module._AUTOCAL_DEFAULTS)
+    server_module._autocal_loops.clear()
+    server_module._autocal_queues.clear()
+    yield
+    _sessions.clear()
+    server_module._autocal_loops.clear()
+    server_module._autocal_queues.clear()
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture
+def session_id(client):
+    resp = client.post("/api/session", json={"tv_key": "u8g"})
+    sid = resp.json()["id"]
+    client.post(f"/api/session/{sid}/mode", json={"mode": "SDR"})
+    return sid
+
+
+def _wait_until(predicate, timeout=5.0, interval=0.05):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(interval)
+    return False
+
+
+class TestAutocalRunValidation:
+    def test_requires_target(self, client):
+        resp = client.post("/api/session", json={"tv_key": "u8g"})
+        sid = resp.json()["id"]
+        resp = client.post(f"/api/session/{sid}/autocal/run", json={})
+        assert resp.status_code == 400
+        assert "target" in resp.json()["detail"].lower()
+
+    def test_unknown_colour_rejected(self, client, session_id):
+        resp = client.post(
+            f"/api/session/{session_id}/autocal/run", json={"colours": ["Purple"]}
+        )
+        assert resp.status_code == 400
+        assert "Purple" in resp.json()["detail"]
+
+    def test_invalid_apply_mode_rejected(self, client, session_id):
+        resp = client.post(
+            f"/api/session/{session_id}/autocal/run", json={"apply_mode": "magic"}
+        )
+        assert resp.status_code == 400
+
+    def test_damping_out_of_range_rejected(self, client, session_id):
+        resp = client.post(
+            f"/api/session/{session_id}/autocal/run", json={"damping": 1.5}
+        )
+        assert resp.status_code == 400
+
+    def test_max_iterations_out_of_range_rejected(self, client, session_id):
+        resp = client.post(
+            f"/api/session/{session_id}/autocal/run", json={"max_iterations": 0}
+        )
+        assert resp.status_code == 400
+
+    def test_unknown_session_404s(self, client):
+        resp = client.post("/api/session/does-not-exist/autocal/run", json={})
+        assert resp.status_code == 404
+
+
+class TestAutocalRunLifecycle:
+    def test_run_starts_and_rejects_concurrent_run(self, client, session_id):
+        # Block the bridge trigger indefinitely so the background thread stays "running".
+        block = threading.Event()
+
+        def fake_measure(self, patch_obj):
+            block.wait(timeout=5.0)
+            raise TimeoutError("simulated: no measurement arrived")
+
+        with patch("server._SessionCmsMeasurementSource.measure", fake_measure):
+            resp = client.post(
+                f"/api/session/{session_id}/autocal/run",
+                json={"colours": ["Red"], "apply_mode": "manual", "max_iterations": 2},
+            )
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["status"] == "running"
+            assert body["colours"] == ["Red"]
+            assert body["apply_mode"] == "manual"
+
+            assert _wait_until(lambda: session_id in server_module._autocal_loops)
+
+            dupe = client.post(f"/api/session/{session_id}/autocal/run", json={})
+            assert dupe.status_code == 409
+
+            block.set()
+            assert _wait_until(lambda: session_id not in server_module._autocal_loops)
+
+    def test_stop_when_not_running(self, client, session_id):
+        resp = client.post(f"/api/session/{session_id}/autocal/stop")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "not_running"
+
+    def test_stop_cancels_running_loop(self, client, session_id):
+        block = threading.Event()
+        cancelled_seen = threading.Event()
+
+        def fake_measure(self, patch_obj):
+            block.wait(timeout=5.0)
+            raise TimeoutError("stopped before measuring")
+
+        with patch("server._SessionCmsMeasurementSource.measure", fake_measure):
+            client.post(
+                f"/api/session/{session_id}/autocal/run",
+                json={"colours": ["Red"], "max_iterations": 3},
+            )
+            assert _wait_until(lambda: session_id in server_module._autocal_loops)
+
+            stop_resp = client.post(f"/api/session/{session_id}/autocal/stop")
+            assert stop_resp.status_code == 200
+            assert stop_resp.json()["status"] == "stopping"
+
+            loop = server_module._autocal_loops.get(session_id)
+            assert loop is None or loop.cancelled
+            block.set()
+
+
+class TestAutocalStream:
+    def test_unknown_session_404s(self, client):
+        # A full happy-path read would block on the SSE generator's keep-alive
+        # loop, which never terminates — matches the existing llm/stream tests,
+        # which likewise only cover the 404-before-streaming-starts path.
+        resp = client.get("/api/session/does-not-exist/autocal/stream")
+        assert resp.status_code == 404
+
+
+class TestAutocalPrefs:
+    def test_get_prefs_includes_autocal_defaults(self, client):
+        resp = client.get("/api/prefs")
+        assert resp.json()["autocal"] == server_module._AUTOCAL_DEFAULTS
+
+    def test_save_prefs_updates_autocal_fields(self, client):
+        resp = client.post(
+            "/api/prefs",
+            json={
+                "autocal_apply_mode": "adb",
+                "autocal_damping": 0.5,
+                "autocal_max_iterations": 12,
+            },
+        )
+        assert resp.status_code == 200
+        autocal = resp.json()["autocal"]
+        assert autocal["apply_mode"] == "adb"
+        assert autocal["damping"] == 0.5
+        assert autocal["max_iterations"] == 12
+
+    def test_save_prefs_rejects_bad_apply_mode(self, client):
+        resp = client.post("/api/prefs", json={"autocal_apply_mode": "auto-pilot"})
+        assert resp.status_code == 400
+
+    def test_save_prefs_rejects_bad_damping(self, client):
+        resp = client.post("/api/prefs", json={"autocal_damping": 0.0})
+        assert resp.status_code == 400
+
+    def test_run_uses_saved_prefs_as_defaults(self, client, session_id):
+        client.post("/api/prefs", json={"autocal_damping": 0.42, "autocal_max_iterations": 3})
+        block = threading.Event()
+
+        def fake_measure(self, patch_obj):
+            block.wait(timeout=5.0)
+            raise TimeoutError("stopped")
+
+        with patch("server._SessionCmsMeasurementSource.measure", fake_measure):
+            resp = client.post(f"/api/session/{session_id}/autocal/run", json={"colours": ["Red"]})
+            assert resp.json()["damping"] == 0.42
+            assert resp.json()["max_iterations"] == 3
+            block.set()
+            _wait_until(lambda: session_id not in server_module._autocal_loops)

--- a/tests/test_autocal_apply.py
+++ b/tests/test_autocal_apply.py
@@ -1,0 +1,101 @@
+"""Tests for calibrator/autocal_apply.py (Autocal roadmap Item 1a)."""
+from unittest.mock import patch
+
+import pytest
+
+from calcore.models import Measurement, Patch
+from calibrator.autocal import CorrectionResult
+from calibrator.autocal_apply import (
+    AdbApplyTarget,
+    CallableMeasurementSource,
+    ManualApplyTarget,
+)
+
+
+def _correction(step=1, new_value=1, control="Hue", reason="damped step"):
+    return CorrectionResult(
+        control=control,
+        step=step,
+        new_value=new_value,
+        error=0.05,
+        damping=0.6,
+        gain=0.01,
+        gain_source="assumed",
+        converged=step == 0,
+        oscillating=False,
+        stalled=False,
+        out_of_range=False,
+        reason=reason,
+    )
+
+
+class TestCallableMeasurementSource:
+    def test_delegates_to_trigger_ignoring_patch(self):
+        expected = Measurement(x=0.3, y=0.3, Y=50.0, label="Red")
+        source = CallableMeasurementSource(lambda: expected)
+        patch_obj = Patch(label="Red", r_target=940, g_target=0, b_target=0, meas_xyz=(0, 0, 0))
+        assert source.measure(patch_obj) is expected
+
+
+class TestManualApplyTarget:
+    def test_no_change_needed_when_step_is_zero(self):
+        result = ManualApplyTarget().apply(_correction(step=0, new_value=3, reason="within deadband"), colour="Red")
+        assert result.ok is True
+        assert result.requires_user_action is False
+        assert "no change needed" in result.message.lower()
+
+    def test_describes_raise_and_lower(self):
+        up = ManualApplyTarget().apply(_correction(step=2, new_value=5), colour="Red")
+        assert up.requires_user_action is True
+        assert "Raise Hue to 5" in up.message
+
+        down = ManualApplyTarget().apply(_correction(step=-2, new_value=-5), colour="Green")
+        assert "Lower Hue to -5" in down.message
+
+    def test_never_touches_the_tv(self):
+        # No subprocess/adb import at all in this module's dependency graph;
+        # applying never raises even without ADB present.
+        result = ManualApplyTarget().apply(_correction(), colour="Blue")
+        assert result.ok is True
+
+
+class TestAdbApplyTarget:
+    def test_unknown_colour_rejected(self):
+        result = AdbApplyTarget().apply(_correction(), colour="Purple")
+        assert result.ok is False
+        assert "Unknown CMS colour" in result.message
+
+    def test_no_change_needed_skips_adb_calls(self):
+        with patch("calibrator.adb_control.set_cms_value") as set_mock:
+            result = AdbApplyTarget().apply(_correction(step=0, new_value=0), colour="Red")
+        assert result.ok is True
+        set_mock.assert_not_called()
+
+    def test_applies_and_verifies_readback(self):
+        with patch("calibrator.adb_control.set_cms_value", return_value={"ok": True, "stdout": "OK", "stderr": ""}) as set_mock, \
+             patch("calibrator.adb_control.get_cms_value", return_value={"ok": True, "value": 5, "stdout": "VALUE 5", "stderr": ""}) as get_mock:
+            result = AdbApplyTarget(device="serial123").apply(_correction(step=2, new_value=5), colour="Red")
+        assert result.ok is True
+        assert "verified" in result.message
+        set_mock.assert_called_once_with("Red", "Hue", 5, device="serial123")
+        get_mock.assert_called_once_with("Red", "Hue", device="serial123")
+
+    def test_set_failure_reported(self):
+        with patch("calibrator.adb_control.set_cms_value", return_value={"ok": False, "stdout": "", "stderr": "device offline"}):
+            result = AdbApplyTarget().apply(_correction(step=2, new_value=5), colour="Red")
+        assert result.ok is False
+        assert "ADB set failed" in result.message
+
+    def test_readback_mismatch_reported(self):
+        with patch("calibrator.adb_control.set_cms_value", return_value={"ok": True, "stdout": "OK", "stderr": ""}), \
+             patch("calibrator.adb_control.get_cms_value", return_value={"ok": True, "value": 4, "stdout": "VALUE 4", "stderr": ""}):
+            result = AdbApplyTarget().apply(_correction(step=2, new_value=5), colour="Red")
+        assert result.ok is False
+        assert "Read-back mismatch" in result.message
+
+    def test_invalid_control_raises_are_caught(self):
+        bad = _correction(control="NotAControl", step=1, new_value=1)
+        with patch("calibrator.adb_control.set_cms_value", side_effect=ValueError("Unknown control")):
+            result = AdbApplyTarget().apply(bad, colour="Red")
+        assert result.ok is False
+        assert "Unknown control" in result.message

--- a/tests/test_autocal_controller.py
+++ b/tests/test_autocal_controller.py
@@ -1,0 +1,186 @@
+"""Tests for the damped CMS correction controller (autocal Item 1b)."""
+
+from dataclasses import replace
+
+from calibrator.autocal import (
+    CMS_MAX,
+    CMS_MIN,
+    DEFAULT_CONFIG,
+    CmsCorrectionController,
+    ControllerConfig,
+    Observation,
+    compute_correction,
+)
+
+
+class SyntheticControl:
+    """Deterministic display response: measured error as a function of one control.
+
+    ``error = k * (value - optimal)`` with an optional asymmetric slope so the
+    fixed-gain path cannot be exact and the secant estimator has to adapt. Positive
+    error means "attribute too high", matching guidance.cms_hints sign convention.
+    """
+
+    def __init__(self, k: float, optimal: int, asymmetry: float = 0.0) -> None:
+        self.k = k
+        self.optimal = optimal
+        self.asymmetry = asymmetry
+
+    def error(self, value: int) -> float:
+        diff = value - self.optimal
+        slope = self.k * (1.0 + self.asymmetry * (1 if diff >= 0 else -1))
+        return slope * diff
+
+
+def run_loop(controller, model, control, start, cap=40):
+    value = start
+    errors = [model.error(value)]
+    values = [value]
+    converged = False
+    for _ in range(cap):
+        result = controller.step(control, value, model.error(value))
+        assert CMS_MIN <= result.new_value <= CMS_MAX
+        value = result.new_value
+        values.append(value)
+        errors.append(model.error(value))
+        if result.converged:
+            converged = True
+            break
+    return converged, errors, values
+
+
+def _sign_flips(errors, deadband):
+    flips = 0
+    for prev, curr in zip(errors, errors[1:]):
+        if abs(prev) <= deadband or abs(curr) <= deadband:
+            continue
+        if (prev > 0) != (curr > 0):
+            flips += 1
+    return flips
+
+
+def test_converges_on_synthetic_model_for_each_control():
+    models = {
+        "Hue": SyntheticControl(k=0.012, optimal=2, asymmetry=0.2),
+        "Saturation": SyntheticControl(k=0.006, optimal=-3, asymmetry=0.15),
+        "Brightness": SyntheticControl(k=4.0, optimal=5, asymmetry=0.25),
+    }
+    for control, model in models.items():
+        controller = CmsCorrectionController()
+        converged, errors, _ = run_loop(controller, model, control, start=-8)
+        deadband = DEFAULT_CONFIG.deadband[control]
+        assert converged, f"{control} did not converge: {errors}"
+        assert abs(errors[-1]) <= deadband
+        # A well-behaved damped loop settles quickly and does not ping-pong forever.
+        assert _sign_flips(errors, deadband) <= 2
+
+
+def test_secant_learns_gain_where_conservative_fixed_assumption_stalls():
+    # Assumed gain is ~8x too large (conservative), so the fixed-gain controller
+    # takes timid single-click steps whose correction rounds to zero before reaching
+    # target: it stalls short. The secant controller learns the true slope from its
+    # first observation and converges.
+    model = SyntheticControl(k=0.006, optimal=1)
+    cfg = replace(DEFAULT_CONFIG, error_per_step={**DEFAULT_CONFIG.error_per_step, "Saturation": 0.05})
+    deadband = cfg.deadband["Saturation"]
+
+    secant = CmsCorrectionController(cfg)
+    conv_s, errs_s, _ = run_loop(secant, model, "Saturation", start=-9)
+
+    fixed = CmsCorrectionController(replace(cfg, use_secant=False))
+    conv_f, errs_f, _ = run_loop(fixed, model, "Saturation", start=-9)
+
+    assert conv_s and abs(errs_s[-1]) <= deadband
+    assert not conv_f and abs(errs_f[-1]) > deadband
+
+
+def test_damped_proportional_core_is_oscillation_safe_without_secant():
+    # Assumed gain far below the true slope makes the raw proportional step overshoot
+    # (>2x), which without backoff diverges. The overshoot backoff must rescue it.
+    model = SyntheticControl(k=0.02, optimal=0)
+    cfg = replace(
+        DEFAULT_CONFIG,
+        use_secant=False,
+        error_per_step={**DEFAULT_CONFIG.error_per_step, "Saturation": 0.0025},
+    )
+    controller = CmsCorrectionController(cfg)
+    converged, errors, _ = run_loop(controller, model, "Saturation", start=-8)
+    assert converged
+    assert abs(errors[-1]) <= cfg.deadband["Saturation"]
+
+
+def test_without_backoff_the_same_setup_oscillates_and_does_not_converge():
+    # Contrast case: disabling the backoff (ratio 1.0) on the overshooting setup
+    # leaves a sustained limit cycle — proving the backoff is what fixes it.
+    model = SyntheticControl(k=0.02, optimal=0)
+    cfg = replace(
+        DEFAULT_CONFIG,
+        use_secant=False,
+        oscillation_backoff=1.0,
+        min_damping=0.6,
+        error_per_step={**DEFAULT_CONFIG.error_per_step, "Saturation": 0.0025},
+    )
+    controller = CmsCorrectionController(cfg)
+    converged, errors, _ = run_loop(controller, model, "Saturation", start=-8)
+    assert not converged
+    assert _sign_flips(errors, cfg.deadband["Saturation"]) >= 5
+
+
+def test_never_exceeds_control_range_on_huge_error():
+    # An error that naively demands a +100 step near the top of the range must clamp.
+    result = compute_correction("Brightness", current_value=8, error=-500.0)
+    assert result.new_value <= CMS_MAX
+    assert result.out_of_range
+
+    result = compute_correction("Brightness", current_value=-9, error=200.0)
+    assert result.new_value >= CMS_MIN
+
+
+def test_saturated_control_reports_stall_instead_of_illegal_step():
+    # Already at the floor but error still demands going lower: no legal step exists.
+    result = compute_correction("Saturation", current_value=CMS_MIN, error=0.08)
+    assert result.step == 0
+    assert result.new_value == CMS_MIN
+    assert result.stalled
+    assert result.out_of_range
+
+
+def test_oscillation_path_reduces_step_versus_naive_repeat():
+    # First move (no history) for a large positive error.
+    naive_pos = compute_correction("Saturation", current_value=0, error=0.05)
+    assert naive_pos.step < 0
+    assert not naive_pos.oscillating
+
+    # Now the error has flipped sign (overshoot). A naive controller would apply an
+    # equal-and-opposite step; ours must detect the overshoot and shrink it.
+    history = [Observation(error=0.05, step=naive_pos.step)]
+    overshoot = compute_correction(
+        "Saturation", current_value=naive_pos.new_value, error=-0.045, history=history
+    )
+    naive_flip = compute_correction("Saturation", current_value=naive_pos.new_value, error=-0.045)
+
+    assert overshoot.oscillating
+    assert overshoot.step > 0
+    assert abs(overshoot.step) < abs(naive_flip.step)
+
+
+def test_within_deadband_is_converged_with_zero_step():
+    result = compute_correction("Hue", current_value=3, error=0.01)
+    assert result.converged
+    assert result.step == 0
+    assert result.new_value == 3
+
+
+def test_default_damping_is_in_the_specified_range():
+    assert 0.5 <= ControllerConfig().damping <= 0.7
+
+
+def test_inverted_polarity_control_is_corrected_by_secant_sign():
+    # A TV whose control responds with inverted polarity: increasing the control
+    # lowers the attribute (negative realised gain). The nominal assumption would
+    # push the wrong way, but after one observation the secant flips direction.
+    model = SyntheticControl(k=-0.01, optimal=2)
+    controller = CmsCorrectionController()
+    converged, errors, _ = run_loop(controller, model, "Saturation", start=-6)
+    assert converged
+    assert abs(errors[-1]) <= DEFAULT_CONFIG.deadband["Saturation"]

--- a/tests/test_autocal_loop.py
+++ b/tests/test_autocal_loop.py
@@ -1,0 +1,141 @@
+"""Tests for calibrator/autocal_loop.py (Autocal roadmap Item 1c)."""
+import math
+
+import pytest
+
+from calcore.models import CalMode, CalibrationTarget, Measurement, Patch
+from calibrator.autocal_apply import ApplyResult, ApplyTarget, MeasurementSource
+from calibrator.autocal_loop import AutocalLoop
+from calibrator.guidance import target_nits_for_colour, target_xy_for_colour
+
+TARGET = CalibrationTarget(
+    mode=CalMode.SDR, gamma=2.2, peak_luminance_nits=120.0, gamut="bt709", eotf="BT.1886"
+)
+CMS_CONTROLS = ["Hue", "Saturation", "Brightness"]
+
+
+def _patch_for_colour(colour: str) -> Patch:
+    return Patch(label=colour, r_target=1023, g_target=0, b_target=0, meas_xyz=(0, 0, 0), kind="color")
+
+
+class RecordingApplyTarget(ApplyTarget):
+    def __init__(self):
+        self.calls = []
+
+    def apply(self, correction, *, colour):
+        self.calls.append((colour, correction.control, correction.step))
+        return ApplyResult(
+            ok=True,
+            control=correction.control,
+            step=correction.step,
+            new_value=correction.new_value,
+            message="applied",
+        )
+
+
+class SyntheticCmsSource(MeasurementSource):
+    """A fake TV: measured xyY responds linearly to the CMS controls, with a
+    per-colour 'true optimal' control setting where error is exactly zero."""
+
+    K_HUE = 0.01
+    K_SAT = 0.01
+    K_BRI = 3.0
+
+    def __init__(self, state, true_optimal):
+        self.state = state
+        self.true_optimal = true_optimal  # {colour: {"Hue": int, "Saturation": int, "Brightness": int}}
+
+    def measure(self, patch: Patch) -> Measurement:
+        colour = patch.label
+        values = self.state[colour]
+        optimal = self.true_optimal[colour]
+        target_xy = target_xy_for_colour(TARGET, colour)
+        target_nits = target_nits_for_colour(TARGET, colour)
+        wx, wy = TARGET.white_point_xy
+
+        angle_shift = (values.get("Hue", 0) - optimal["Hue"]) * self.K_HUE
+        radius_scale = 1.0 + (values.get("Saturation", 0) - optimal["Saturation"]) * self.K_SAT
+        dx, dy = target_xy[0] - wx, target_xy[1] - wy
+        cos_a, sin_a = math.cos(angle_shift), math.sin(angle_shift)
+        rx = (dx * cos_a - dy * sin_a) * radius_scale
+        ry = (dx * sin_a + dy * cos_a) * radius_scale
+
+        y_val = target_nits + (values.get("Brightness", 0) - optimal["Brightness"]) * self.K_BRI
+        return Measurement(
+            x=wx + rx, y=wy + ry, Y=max(y_val, 0.01), label=colour, stimulus_rgb=(1023, 0, 0)
+        )
+
+
+class TestAutocalLoopConvergence:
+    def test_converges_to_true_optimal_within_range(self):
+        state = {"Red": dict.fromkeys(CMS_CONTROLS, 0)}
+        true_optimal = {"Red": {"Hue": 4, "Saturation": -3, "Brightness": 2}}
+        source = SyntheticCmsSource(state, true_optimal)
+        apply_target = RecordingApplyTarget()
+
+        loop = AutocalLoop(source, apply_target, TARGET, CMS_CONTROLS, max_iterations=12)
+        result = loop.run(["Red"], _patch_for_colour, initial_values=state)
+
+        assert not result.cancelled
+        colour_result = result.colours["Red"]
+        assert colour_result.converged is True
+        assert colour_result.stopped_reason == "quality gate met"
+        assert colour_result.delta_e is not None
+        assert colour_result.delta_e < 3.0
+        assert apply_target.calls  # corrections were actually applied
+
+    def test_never_converges_reports_max_iterations(self):
+        state = {"Red": dict.fromkeys(CMS_CONTROLS, 0)}
+        # Unreachable true optimum: no combination of clamped controls can zero the error.
+        true_optimal = {"Red": {"Hue": 400, "Saturation": -300, "Brightness": 200}}
+        source = SyntheticCmsSource(state, true_optimal)
+        loop = AutocalLoop(source, RecordingApplyTarget(), TARGET, CMS_CONTROLS, max_iterations=5)
+
+        result = loop.run(["Red"], _patch_for_colour, initial_values=state)
+
+        colour_result = result.colours["Red"]
+        assert colour_result.converged is False
+        assert colour_result.stopped_reason == "max_iterations reached"
+        assert colour_result.iterations == 5
+
+    def test_runs_full_six_primary_pass(self):
+        colours = ["Red", "Green", "Blue", "Cyan", "Magenta", "Yellow"]
+        state = {c: dict.fromkeys(CMS_CONTROLS, 0) for c in colours}
+        true_optimal = {c: {"Hue": 1, "Saturation": -1, "Brightness": 1} for c in colours}
+        source = SyntheticCmsSource(state, true_optimal)
+        loop = AutocalLoop(source, RecordingApplyTarget(), TARGET, CMS_CONTROLS, max_iterations=10)
+
+        result = loop.run(colours, _patch_for_colour, initial_values=state)
+
+        assert set(result.colours) == set(colours)
+        assert all(cr.converged for cr in result.colours.values())
+
+    def test_cooperative_cancel_stops_between_colours(self):
+        colours = ["Red", "Green", "Blue"]
+        state = {c: dict.fromkeys(CMS_CONTROLS, 0) for c in colours}
+        true_optimal = {c: {"Hue": 0, "Saturation": 0, "Brightness": 0} for c in colours}
+        source = SyntheticCmsSource(state, true_optimal)
+        loop = AutocalLoop(source, RecordingApplyTarget(), TARGET, CMS_CONTROLS, max_iterations=10)
+
+        seen = []
+
+        def on_iteration(event):
+            seen.append(event.colour)
+
+        loop.on_iteration = on_iteration
+        loop.cancel()  # cancel before the loop even starts
+        result = loop.run(colours, _patch_for_colour, initial_values=state)
+
+        assert result.cancelled is True
+        assert result.colours == {}
+
+    def test_never_exceeds_control_range_even_with_extreme_error(self):
+        state = {"Red": {"Hue": 9, "Saturation": 9, "Brightness": 9}}
+        true_optimal = {"Red": {"Hue": -900, "Saturation": -900, "Brightness": -900}}
+        source = SyntheticCmsSource(state, true_optimal)
+        loop = AutocalLoop(source, RecordingApplyTarget(), TARGET, CMS_CONTROLS, max_iterations=6)
+
+        loop.run(["Red"], _patch_for_colour, initial_values=state)
+
+        for control in CMS_CONTROLS:
+            assert -10 <= state["Red"][control] <= 10

--- a/tests/test_autocal_loop.py
+++ b/tests/test_autocal_loop.py
@@ -139,3 +139,43 @@ class TestAutocalLoopConvergence:
 
         for control in CMS_CONTROLS:
             assert -10 <= state["Red"][control] <= 10
+
+    def test_skip_stalled_controls_stops_iterating_saturated_control(self):
+        # Saturation/Brightness start at their true optimum (converged from the
+        # first measurement); Hue's optimum is unreachable, so it saturates at
+        # a control rail and reports stalled=True.
+        state = {"Red": dict.fromkeys(CMS_CONTROLS, 0)}
+        true_optimal = {"Red": {"Hue": 400, "Saturation": 0, "Brightness": 0}}
+        source = SyntheticCmsSource(state, true_optimal)
+        loop = AutocalLoop(
+            source,
+            RecordingApplyTarget(),
+            TARGET,
+            CMS_CONTROLS,
+            max_iterations=6,
+            skip_stalled_controls=True,
+        )
+
+        result = loop.run(["Red"], _patch_for_colour, initial_values=state)
+
+        colour_result = result.colours["Red"]
+        hue_events = [e for e in colour_result.history if e.control == "Hue"]
+        assert any(e.correction.stalled for e in hue_events)
+        stall_iteration = next(e.iteration for e in hue_events if e.correction.stalled)
+        # No further Hue corrections were attempted after it stalled.
+        assert all(e.iteration <= stall_iteration for e in hue_events)
+        assert -10 <= state["Red"]["Hue"] <= 10
+
+    def test_skip_stalled_controls_off_by_default(self):
+        state = {"Red": dict.fromkeys(CMS_CONTROLS, 0)}
+        true_optimal = {"Red": {"Hue": 400, "Saturation": 0, "Brightness": 0}}
+        source = SyntheticCmsSource(state, true_optimal)
+        loop = AutocalLoop(source, RecordingApplyTarget(), TARGET, CMS_CONTROLS, max_iterations=6)
+
+        assert loop.skip_stalled_controls is False
+        result = loop.run(["Red"], _patch_for_colour, initial_values=state)
+
+        colour_result = result.colours["Red"]
+        hue_events = [e for e in colour_result.history if e.control == "Hue"]
+        # Without the opt-in flag, Hue keeps getting a correction attempt every iteration.
+        assert len(hue_events) == colour_result.iterations

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -37,8 +37,11 @@ def _reset_globals():
             "code_scale": "8bit",
             "pattern_generator": "dogegen",
         },
+        "autocal": dict(server_module._AUTOCAL_DEFAULTS),
     }
     server_module._llm_queues.clear()
+    server_module._autocal_loops.clear()
+    server_module._autocal_queues.clear()
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## 📺 Overview

Closes #522, #523, #524, #525, #528 (sub-tasks 1a, 1b, 1c, 1d, 1g of #519).

Implements the backend half of the Autocal closed-loop measure → correct → apply → re-measure controller described in `docs/autocal-roadmap.md` (Item 1), scoped to the pieces that form one safe, self-contained, hardware-independent PR:

- **1a** — `MeasurementSource` / `ApplyTarget` interfaces with `ManualApplyTarget`, `AdbApplyTarget`, and a `CallableMeasurementSource` adapter.
- **1b** — A damped, oscillation-safe CMS correction controller with secant-method gain learning and per-control clamping.
- **1c** — The `AutocalLoop` orchestrator: per-primary measure → correct → apply → re-measure, stopping on `quality.py`'s ΔE gate or `max_iterations`, with cooperative cancellation.
- **1d** — `POST /api/session/{sid}/autocal/run`, `POST .../autocal/stop`, and an SSE stream at `GET .../autocal/stream`, following the existing LLM SSE broadcaster pattern.
- **1g** — `apply_mode` / `damping` / `max_iterations` preferences persisted in `.prefs.json`, with validation and README documentation.

**Deliberately excluded** (separate follow-up PRs, per the roadmap's own sequencing):
- **1e** (manual-apply frontend UX) — different layer/review surface; cleaner once this API shape is stable.
- **1f** (ADB auto-apply's fallback-to-manual UX) — the roadmap flags this as "Phase 2, once the manual loop exists," and its DoD requires verification against real Hisense U8G hardware, which this PR can't honestly provide.

### What does this PR do?
* **Type of change:** [x] New feature
* **Component(s) affected:** Backend — `calibrator/autocal*.py`, `server.py` (new endpoints + prefs)

---

## 🛠️ Technical Context & Implementation

* **The Problem:** Calibrating a TV's Color Management System today is manual guesswork per primary — the app can tell you a color is off but not run a convergent measure/adjust loop for you. A naive proportional controller mapping "raise Saturation by X" to measured ΔE oscillates or stalls because the TV's response is nonlinear and unknown a priori.
* **The Solution:** A pluggable loop (`AutocalLoop`) that depends only on `MeasurementSource.measure()` / `ApplyTarget.apply()` — never on ADB or the ZRO Bridge directly — driven by a damped correction controller (`calibrator/autocal.py`, implemented separately per the roadmap's own model-tier guidance for this control-theory-heavy sub-task) with overshoot/oscillation backoff and optional secant gain learning. The orchestrator stops each primary on `quality.py`'s existing `QG_CMS_DE_THRESHOLD` gate or an iteration cap, and supports cooperative cancellation. `server.py` exposes this via `run`/`stop`/SSE-stream endpoints that reuse the existing LLM SSE broadcaster pattern, plus a `_SessionCmsMeasurementSource` that triggers the ZRO Bridge and polls the session's `cms_measurements` for the watch-folder import to land the new reading (the bridge itself only fires the meter — it doesn't return a parsed reading synchronously, matching the existing `/measure/sequence` limitation noted in the roadmap).
* **Impact on existing workflows/APIs:** Purely additive — three new endpoints, one new prefs key (`autocal`), two new modules. No existing endpoint, session field, or session-view shape changes.

### Mathematical / Data Integrity Checks (If Applicable)
* [x] The correction controller is unit-tested against a synthetic display-response model for convergence, oscillation backoff, and range clamping (never exceeds the CMS ±10 control range).
* [x] Floating-point step rounding rounds half-away-from-zero so sub-unit corrections still make progress instead of silently truncating to a no-op.

---

## 🧪 Testing & Validation

### Environment Details
* **OS / Target Display:** N/A — this PR is backend logic tested against fakes/synthetic models; no physical display was used (per roadmap: hardware verification is 1f's job).
* **Hardware/Mock Used:** Fully mocked — `unittest.mock.patch` over `calibrator.adb_control`, a synthetic per-colour display-response model for the controller/orchestrator tests, and FastAPI `TestClient` for the API layer.

### Verification Steps
1. `python -m pytest tests/test_autocal_controller.py tests/test_autocal_apply.py tests/test_autocal_loop.py tests/test_autocal_api.py -q` — 40 new tests, all passing.
2. `python -m pytest tests/ -q` — full suite (1299 tests) passes with no regressions.
3. `ruff check` clean on all changed/added files.

### Firmware / TV Settings
* Not applicable — no physical TV was used for this PR (see above).

---

## 🧼 Checklist
* [x] Code adheres to project style guidelines (formatting, typing, linting) — `ruff check` clean.
* [x] Unit tests added/updated and passing — 40 new tests across 4 files, full suite green.
* [x] Documentation (README, inline docstrings) updated to reflect changes — new "Autocal" section, API reference table entries, `.prefs.json` description.
* [x] No credentials, local absolute paths, or hardware-specific hardcoding leaked.


---
_Generated by [Claude Code](https://claude.ai/code/session_01J8h5Lp1vXbyDHjEEwuixTx)_