### PR TITLE
Deduplicate append-mode measurements in _locked_import (manual upload path)

### DIFF
--- a/calibrator/session.py
+++ b/calibrator/session.py
@@ -23,6 +23,7 @@ from calcore.models import (
     SDR_TARGET,
 )
 from calcore.eotf import pq_eotf
+from .file_watcher import _measurement_signature
 from .profiles import TV_PROFILES, TVProfile
 from .guidance import (
     FINE_GAMMA_TRACKING_LEVELS,
@@ -818,29 +819,6 @@ def measurement_time_bounds(
     }
 
 
-def _measurement_signature(measurement: object) -> tuple:
-    """Stable identity for deduplicating repeated rows from append-only logs.
-
-    Matches the signature used by the file watcher (``file_watcher._measurement_signature``)
-    so that manual HTTP uploads and auto-imports have identical dedup semantics.
-    """
-    if isinstance(measurement, dict):
-        timestamp = measurement.get("timestamp")
-        label = measurement.get("label")
-        stimulus_rgb = tuple(measurement.get("stimulus_rgb", []))
-        Y = measurement.get("Y")
-        x = measurement.get("x")
-        y = measurement.get("y")
-    else:
-        timestamp = getattr(measurement, "timestamp", None)
-        label = getattr(measurement, "label", None)
-        stimulus_rgb = tuple(getattr(measurement, "stimulus_rgb", ()))
-        Y = getattr(measurement, "Y", None)
-        x = getattr(measurement, "x", None)
-        y = getattr(measurement, "y", None)
-    return (timestamp, label, stimulus_rgb, Y, x, y)
-
-
 def grayscale_label_for_context(stim_pct: float) -> str:
     if stim_pct <= 0.5:
         return "Black (0%)"
@@ -1153,30 +1131,6 @@ def _gray_bucket_for_step(session_step):
     if session_step == "post_grayscale":
         return "post_measurements"
     return None
-
-
-def _measurement_signature(measurement: object) -> tuple:
-    """Stable identity for deduplicating repeated rows from append-only logs.
-
-    Matches the signature used in calibrator.file_watcher for consistent
-    deduplication across all ingestion paths (file watcher, manual upload,
-    merge_into_session).
-    """
-    if isinstance(measurement, dict):
-        timestamp = measurement.get("timestamp")
-        label = measurement.get("label")
-        stimulus_rgb = tuple(measurement.get("stimulus_rgb", []))
-        Y = measurement.get("Y")
-        x = measurement.get("x")
-        y = measurement.get("y")
-    else:
-        timestamp = getattr(measurement, "timestamp", None)
-        label = getattr(measurement, "label", None)
-        stimulus_rgb = tuple(getattr(measurement, "stimulus_rgb", ()))
-        Y = getattr(measurement, "Y", None)
-        x = getattr(measurement, "x", None)
-        y = getattr(measurement, "y", None)
-    return (timestamp, label, stimulus_rgb, Y, x, y)
 
 
 def latest_gamma_pass(

--- a/calibrator/session.py
+++ b/calibrator/session.py
@@ -818,6 +818,29 @@ def measurement_time_bounds(
     }
 
 
+def _measurement_signature(measurement: object) -> tuple:
+    """Stable identity for deduplicating repeated rows from append-only logs.
+
+    Matches the signature used by the file watcher (``file_watcher._measurement_signature``)
+    so that manual HTTP uploads and auto-imports have identical dedup semantics.
+    """
+    if isinstance(measurement, dict):
+        timestamp = measurement.get("timestamp")
+        label = measurement.get("label")
+        stimulus_rgb = tuple(measurement.get("stimulus_rgb", []))
+        Y = measurement.get("Y")
+        x = measurement.get("x")
+        y = measurement.get("y")
+    else:
+        timestamp = getattr(measurement, "timestamp", None)
+        label = getattr(measurement, "label", None)
+        stimulus_rgb = tuple(getattr(measurement, "stimulus_rgb", ()))
+        Y = getattr(measurement, "Y", None)
+        x = getattr(measurement, "x", None)
+        y = getattr(measurement, "y", None)
+    return (timestamp, label, stimulus_rgb, Y, x, y)
+
+
 def grayscale_label_for_context(stim_pct: float) -> str:
     if stim_pct <= 0.5:
         return "Black (0%)"
@@ -1130,6 +1153,30 @@ def _gray_bucket_for_step(session_step):
     if session_step == "post_grayscale":
         return "post_measurements"
     return None
+
+
+def _measurement_signature(measurement: object) -> tuple:
+    """Stable identity for deduplicating repeated rows from append-only logs.
+
+    Matches the signature used in calibrator.file_watcher for consistent
+    deduplication across all ingestion paths (file watcher, manual upload,
+    merge_into_session).
+    """
+    if isinstance(measurement, dict):
+        timestamp = measurement.get("timestamp")
+        label = measurement.get("label")
+        stimulus_rgb = tuple(measurement.get("stimulus_rgb", []))
+        Y = measurement.get("Y")
+        x = measurement.get("x")
+        y = measurement.get("y")
+    else:
+        timestamp = getattr(measurement, "timestamp", None)
+        label = getattr(measurement, "label", None)
+        stimulus_rgb = tuple(getattr(measurement, "stimulus_rgb", ()))
+        Y = getattr(measurement, "Y", None)
+        x = getattr(measurement, "x", None)
+        y = getattr(measurement, "y", None)
+    return (timestamp, label, stimulus_rgb, Y, x, y)
 
 
 def latest_gamma_pass(
@@ -2155,6 +2202,10 @@ class SessionStore:
         deadlock.  This serialises the full get → mutate → save sequence
         against concurrent file-watcher auto-imports and other callers
         that share the same lock (``store._lock``).
+
+        Append-mode buckets (wb, gamma, cms, lum) are deduplicated by
+        measurement signature (timestamp, label, stimulus_rgb, Y, x, y)
+        to prevent duplicate rows from cumulative ZRO exports.
         """
         with self._lock:
             session = self.get(sid)
@@ -2163,14 +2214,34 @@ class SessionStore:
                     400, "Select a calibration mode before importing measurements."
                 )
             counts: Dict[str, int] = {}
+            duplicates_skipped = 0
             target_gray_bucket = _gray_bucket_for_step(session.get("step"))
+            # Buckets that accumulate measurements across imports (not cleared per step)
+            append_mode_buckets = {"wb_measurements", "gamma_measurements", "cms_measurements", "lum_measurements"}
             for key, meas_dicts in bucket_map.items():
                 if key == target_gray_bucket and meas_dicts:
                     session[key] = []
-                for item in meas_dicts:
-                    session[key].append(deserialize_measurement(item))
-                if meas_dicts:
-                    counts[key] = len(meas_dicts)
+                if key in append_mode_buckets:
+                    existing_signatures = {
+                        _measurement_signature(m) for m in session.setdefault(key, [])
+                    }
+                    appended = 0
+                    for item in meas_dicts:
+                        measurement = deserialize_measurement(item)
+                        signature = _measurement_signature(measurement)
+                        if signature in existing_signatures:
+                            duplicates_skipped += 1
+                            continue
+                        session[key].append(measurement)
+                        existing_signatures.add(signature)
+                        appended += 1
+                    if appended:
+                        counts[key] = appended
+                else:
+                    for item in meas_dicts:
+                        session[key].append(deserialize_measurement(item))
+                    if meas_dicts:
+                        counts[key] = len(meas_dicts)
             if session.get("lum_measurements"):
                 last_lum = session["lum_measurements"][-1]
                 y_val = getattr(last_lum, "Y", last_lum.get("Y") if isinstance(last_lum, dict) else None)
@@ -2187,6 +2258,7 @@ class SessionStore:
                 "session_breaks": session_breaks,
                 "abl_warnings": step_warnings,
                 "unknown_rows": unknown_rows,
+                "duplicates_skipped": duplicates_skipped,
                 "buckets_populated": counts,
                 "raw_rows": raw_rows,
                 **measurement_time_bounds(bucket_map),

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -784,6 +784,43 @@ class TestZROImport:
         resp = _upload_csv(client, session_id, "not,a,valid,zro,file\n")
         assert resp.status_code == 400
 
+    def test_import_dedup_append_mode_buckets(self, client, session_id):
+        """Regression test for #550: uploading the same cumulative ZRO export twice
+        at the WB step should not duplicate wb/gamma/cms/lum measurements.
+        """
+        self._to_pre_grayscale(client, session_id)
+        # Upload grayscale and advance to luminance
+        _upload_csv(client, session_id, _make_zro_csv(_grayscale_rows()))
+        client.post(f"/api/session/{session_id}/next")
+        # Upload dedicated luminance reading
+        _upload_csv(client, session_id, _make_zro_csv([(235, 235, 235, 120.0, 0.3127, 0.3290)]))
+        client.post(f"/api/session/{session_id}/next")
+        # Upload WB patches (80% and 30% gray)
+        wb_rows = [
+            (188, 188, 188, 96.0, 0.3127, 0.3290),  # 80%
+            (71, 71, 71, 36.0, 0.3127, 0.3290),  # 30%
+        ]
+        wb_csv = _make_zro_csv(wb_rows)
+        resp1 = _upload_csv(client, session_id, wb_csv)
+        assert resp1.status_code == 200
+        summary1 = resp1.json()["import_summary"]
+        assert summary1["buckets_populated"].get("wb_measurements") == 2
+        assert summary1["duplicates_skipped"] == 0
+
+        # Upload the SAME CSV again — should not duplicate
+        resp2 = _upload_csv(client, session_id, wb_csv)
+        assert resp2.status_code == 200
+        summary2 = resp2.json()["import_summary"]
+        # No new items appended (all were duplicates), so buckets_populated may not include wb_measurements
+        # but duplicates_skipped should report the 2 skipped rows
+        assert summary2["duplicates_skipped"] == 2
+
+        # Verify session state — bucket length unchanged
+        # session["wb_measurements"] may not be in view; check the store directly
+        # Use the store directly to avoid view transformation issues
+        s = _sessions[session_id]
+        assert len(s.get("wb_measurements", [])) == 2
+
 
 class TestImportRoutesDoNotBlockEventLoop:
     """Regression test for #504: the import routes must not run blocking,


### PR DESCRIPTION
## 📺 Overview

Fixes duplicate measurements accumulating in append-mode buckets (wb, gamma, cms, lum) when the same cumulative ZRO CSV is manually uploaded multiple times via the HTTP upload endpoint.

Closes [#550](https://github.com/jweber93/tv-calibration/issues/550)

### What does this PR do?

-   **Type of change:** [x] Bug fix | [ ] New feature | [ ] Refactoring | [ ] CI/CD or Tooling
-   **Component(s) affected:** calibrator/session.py, tests/test_server_api.py

---

## 🛠️ Technical Context & Implementation

-   **The Problem:** Deduplication was implemented in the file-watcher path (file_watcher.py:497-532 via _measurement_signature) and in merge_into_session, but never in the manual HTTP upload path (_locked_import). The three ingestion paths had divergent semantics: file-watcher and merge_into_session deduplicated, but _locked_import blindly appended to append-mode buckets each time a CSV was uploaded.
-   **The Solution:** Applied the same signature-based dedup (timestamp, label, stimulus_rgb, Y, x, y) in _locked_import for append-mode buckets (wb_measurements, gamma_measurements, cms_measurements, lum_measurements). The grayscale bucket behavior (pre_measurements/post_measurements) is unchanged — they are cleared and replaced per-step. Added duplicates_skipped to the import summary matching merge_into_session's interface.
-   **Impact on existing workflows/APIs:** The import_summary now includes a 'duplicates_skipped' field. No behavioral change for new measurements. Duplicate rows are silently skipped instead of accumulated.

---

## 🧪 Testing & Validation

### Environment Details

-   **OS / Target Display:** macOS (CI) / Hisense U8G (production)
-   **Hardware/Mock Used:** Simulated ZRO CSV import via FastAPI TestClient

### Verification Steps

1.  Run the regression test: `python3 -m pytest tests/test_server_api.py::TestZROImport::test_import_dedup_append_mode_buckets -xvs`
2.  All existing TestZROImport tests pass (12/12)

### Test coverage

-   Upload WB measurements once → 2 measurements, duplicates_skipped=0
-   Upload the same CSV again → bucket length unchanged (2), duplicates_skipped=2
-   Session store verified directly to confirm no duplication

---

## 📸 Visual Evidence (UI / Plot Changes)

-   No UI changes. The fix is purely on the server-side import path.
-   Previously, uploading the same CSV twice would double the measurement count; now duplicates are silently skipped and reported in the import summary.

---

## 🧼 Checklist

-   [x] Code adheres to project style guidelines (formatting, typing, linting).
-   [x] Unit tests added/updated and passing.
-   [x] Documentation (inline docstrings) updated to reflect changes.
-   [x] No credentials, local absolute paths, or hardware-specific hardcoding leaked.
