### PR TITLE
Fix HDR PQ grayscale targets to use absolute ST.2084 nits

### DIFF
--- a/calcore/analysis.py
+++ b/calcore/analysis.py
@@ -5,7 +5,7 @@ import statistics
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 from .colour import D65_XYZ, D65_xy, ciede2000, xyY_to_xyz, xyz_to_lab
-from .eotf import pq_eotf
+from .eotf import pq_target_nits
 from .models import AnalysisConfig, Patch, Summary
 from .targets import target_xyz_for_patch
 
@@ -93,11 +93,14 @@ def analyze(
         pq_err_pct = None
         if 0 < n < 1 and meas_y > 0 and measured_peak_y_effective > 0:
             if cfg.mode.lower() == "hdr" or cfg.eotf.lower() == "pq":
-                target_rel = pq_eotf(n) / 10000.0
-                meas_rel = meas_y / measured_peak_y_effective
-                pq_err_pct = 100.0 * (meas_rel - target_rel)
-                if 0.20 <= n <= 0.80:
-                    gray_pq_err_mid.append(pq_err_pct)
+                # PQ is absolute: compare measured nits directly against the
+                # (peak-clipped) absolute ST.2084 target, not a peak-relative
+                # rescaling of it.
+                target_y = pq_target_nits(n, measured_peak_y_effective)
+                if target_y > 0:
+                    pq_err_pct = 100.0 * (meas_y - target_y) / target_y
+                    if 0.20 <= n <= 0.80:
+                        gray_pq_err_mid.append(pq_err_pct)
             else:
                 if 0 < meas_y < measured_peak_y_effective:
                     rel = meas_y / measured_peak_y_effective

--- a/calcore/eotf.py
+++ b/calcore/eotf.py
@@ -23,6 +23,13 @@ def pq_eotf(n: float) -> float:
     return 10000.0 * ((num / den) ** (1 / m1))
 
 
+def pq_target_nits(n: float, peak_nits: float) -> float:
+    # ST.2084 is an absolute EOTF: the encoded signal maps directly to nits,
+    # not to a fraction of the display's peak. A display can't reproduce
+    # nits above its own peak, so the target clips (tone-maps) there.
+    return min(pq_eotf(n), peak_nits)
+
+
 def pq_inverse_eotf(nits: float) -> float:
     # SMPTE ST 2084 forward (OETF): nits -> normalised signal in [0, 1].
     # Inverse of pq_eotf(). nits are clamped to [0, 10000] to stay in the valid

--- a/calcore/eotf.py
+++ b/calcore/eotf.py
@@ -24,9 +24,20 @@ def pq_eotf(n: float) -> float:
 
 
 def pq_target_nits(n: float, peak_nits: float) -> float:
-    # ST.2084 is an absolute EOTF: the encoded signal maps directly to nits,
-    # not to a fraction of the display's peak. A display can't reproduce
-    # nits above its own peak, so the target clips (tone-maps) there.
+    """Absolute ST.2084 target luminance for signal *n*, clipped at *peak_nits*.
+
+    ST.2084 is an absolute EOTF: the encoded signal maps directly to nits,
+    not to a fraction of the display's peak. A display can't reproduce nits
+    above its own peak, so above that point the target is clipped flat at
+    *peak_nits* rather than continuing to rise with pq_eotf(n).
+
+    *peak_nits* is whatever peak the caller considers authoritative for this
+    comparison — the display's measured peak luminance in `analyze()` and
+    `target_xyz_for_patch()`, or the session's configured
+    `CalibrationTarget.peak_luminance_nits` in `m_to_dict()`. This is a hard
+    clip at that single value, not a soft-rolloff tone-map curve; it doesn't
+    model a display's actual (often gradual) knee behaviour below peak.
+    """
     return min(pq_eotf(n), peak_nits)
 
 

--- a/calcore/targets.py
+++ b/calcore/targets.py
@@ -4,7 +4,7 @@ import logging
 from typing import Optional, Tuple
 
 from .colour import D65_xy, xyY_to_xyz
-from .eotf import bt1886_eotf, gamma_eotf, pq_eotf
+from .eotf import bt1886_eotf, gamma_eotf, pq_target_nits
 from .models import AnalysisConfig, Patch
 from .spaces import detect_matrix, rgb_to_xyz
 
@@ -42,8 +42,10 @@ def target_xyz_for_patch(
     if patch.is_grayscale:
         n = patch.r_target / code_max
         if cfg.mode.lower() == "hdr" or cfg.eotf.lower() == "pq":
-            rel = pq_eotf(n) / 10000.0
-            target_y = measured_peak_y * rel
+            # PQ (ST.2084) is an absolute EOTF: the signal encodes nits
+            # directly, not a fraction of peak. Clip at the display's
+            # measured peak (its tone-map knee).
+            target_y = pq_target_nits(n, measured_peak_y)
         elif cfg.eotf.lower() == "bt1886":
             # Use target's gamma: 2.2 for SDR (per SDR_TARGET in models.py), 2.4 for others
             gamma = 2.2 if cfg.mode.lower() == "sdr" else 2.4

--- a/calibrator/session.py
+++ b/calibrator/session.py
@@ -22,7 +22,7 @@ from calcore.models import (
     Measurement,
     SDR_TARGET,
 )
-from calcore.eotf import pq_eotf
+from calcore.eotf import pq_target_nits
 from .file_watcher import _measurement_signature
 from .profiles import TV_PROFILES, TVProfile
 from .guidance import (
@@ -984,8 +984,7 @@ def m_to_dict(
     elif is_grayscale_patch and target.eotf.lower().startswith("pq") and target.peak_luminance_nits > 0:
         ref_xy = target.white_point_xy
         n = stim_pct / 100.0
-        rel = pq_eotf(n) / 10000.0
-        ref_Y = target.peak_luminance_nits * rel
+        ref_Y = pq_target_nits(n, target.peak_luminance_nits)
     else:
         ref_xy = target.white_point_xy
         ref_Y = m.Y

--- a/tests/golden/data/hdr_pq_p3d65_grayscale.json
+++ b/tests/golden/data/hdr_pq_p3d65_grayscale.json
@@ -1,9 +1,9 @@
 {
-  "grayscale_avg_de": 25.915901352175666,
-  "grayscale_max_de": 56.49381734906199,
-  "grayscale_over_3": 8,
+  "grayscale_avg_de": 5.301172653319991,
+  "grayscale_max_de": 11.294583512523838,
+  "grayscale_over_3": 7,
   "gamma_midtones": null,
-  "pq_err_midtones": 18.74560626887872,
+  "pq_err_midtones": 9.484247382633441,
   "color_75_avg_de": null,
   "color_75_max_de": null,
   "color_100_avg_de": null,

--- a/tests/golden/test_golden_regression.py
+++ b/tests/golden/test_golden_regression.py
@@ -42,7 +42,9 @@ _SDR_REFERENCE_CSV = textwrap.dedent("""\
     11,235,235,235,99.80,0.3127,0.3279
 """).encode()
 
-# HDR10/PQ: 11-point grayscale at 1000 nit peak (PQ-linearised Y values).
+# HDR10/PQ: 11-point grayscale at ~995 nit measured peak. Fixture Y values are
+# representative measured luminances (not a perfect ST.2084 tracker), so the
+# resulting ΔE/pq_err baselines below reflect real-world tracking error.
 _HDR_REFERENCE_CSV = textwrap.dedent("""\
     1,64,64,64,0.010,0.3127,0.3290
     2,102,102,102,0.455,0.3127,0.3290

--- a/tests/test_hdr_pq_absolute_targets.py
+++ b/tests/test_hdr_pq_absolute_targets.py
@@ -7,49 +7,54 @@ pq_err_midtones ≈ 0, not the peak-rescaled error the old code produced.
 """
 from __future__ import annotations
 
-import textwrap
+import pytest
 
 from calcore.analysis import analyze
 from calcore.csv_import import parse_measurement_csv
 from calcore.eotf import pq_eotf, pq_target_nits
 from calcore.models import AnalysisConfig
 
-PEAK_NITS = 1000.0
 CODE_MAX = 1023
 WHITE_XY = (0.3127, 0.3290)
 
-# A perfect 1000-nit PQ display: measured Y at each code value equals the
-# absolute ST.2084 target, clipped at the panel's peak (its tone-map knee).
-_PERFECT_PQ_RAMP_CSV = "\n".join(
-    f"{i},{code},{code},{code},{min(pq_eotf(code / CODE_MAX), PEAK_NITS):.4f},"
-    f"{WHITE_XY[0]},{WHITE_XY[1]}"
-    for i, code in enumerate(
-        (round(n / 10 * CODE_MAX) for n in range(1, 10)), start=1
+
+def _perfect_pq_ramp_csv(peak_nits: float) -> bytes:
+    # A perfect PQ display at the given peak: measured Y at each code value
+    # equals the absolute ST.2084 target, clipped at the panel's peak (its
+    # tone-map knee).
+    rows = (
+        f"{i},{code},{code},{code},{min(pq_eotf(code / CODE_MAX), peak_nits):.4f},"
+        f"{WHITE_XY[0]},{WHITE_XY[1]}"
+        for i, code in enumerate(
+            (round(n / 10 * CODE_MAX) for n in range(1, 10)), start=1
+        )
     )
-).encode() + b"\n"
+    return ("\n".join(rows) + "\n").encode()
 
 
-def _analyze_ramp():
+def _analyze_ramp(peak_nits: float):
     cfg = AnalysisConfig(mode="hdr", eotf="pq", target_space="bt2020", code_max=CODE_MAX)
-    patches = parse_measurement_csv(_PERFECT_PQ_RAMP_CSV, format="xyY")
+    patches = parse_measurement_csv(_perfect_pq_ramp_csv(peak_nits), format="xyY")
     return analyze(patches, cfg, white_point_xy=WHITE_XY)
 
 
-def test_perfect_pq_ramp_scores_near_zero_delta_e():
-    summary = _analyze_ramp()
+@pytest.mark.parametrize("peak_nits", [1000.0, 500.0])
+def test_perfect_pq_ramp_scores_near_zero_delta_e(peak_nits):
+    summary = _analyze_ramp(peak_nits)
     assert summary.grayscale_avg_de is not None
     assert summary.grayscale_avg_de < 1.0, (
-        f"grayscale_avg_de={summary.grayscale_avg_de:.3f} — PQ targets are still "
-        "being rescaled by peak instead of treated as absolute nits"
+        f"[peak={peak_nits}] grayscale_avg_de={summary.grayscale_avg_de:.3f} — PQ "
+        "targets are still being rescaled by peak instead of treated as absolute nits"
     )
 
 
-def test_perfect_pq_ramp_scores_near_zero_pq_err_midtones():
-    summary = _analyze_ramp()
+@pytest.mark.parametrize("peak_nits", [1000.0, 500.0])
+def test_perfect_pq_ramp_scores_near_zero_pq_err_midtones(peak_nits):
+    summary = _analyze_ramp(peak_nits)
     assert summary.pq_err_midtones is not None
     assert abs(summary.pq_err_midtones) < 1.0, (
-        f"pq_err_midtones={summary.pq_err_midtones:.3f}% — expected ~0 for a "
-        "perfectly-tracking PQ display"
+        f"[peak={peak_nits}] pq_err_midtones={summary.pq_err_midtones:.3f}% — "
+        "expected ~0 for a perfectly-tracking PQ display"
     )
 
 
@@ -64,3 +69,13 @@ def test_pq_target_nits_is_absolute_below_knee():
 def test_pq_target_nits_clips_at_panel_peak():
     # Above the knee, the display physically cannot exceed its own peak.
     assert pq_target_nits(1.0, 1000.0) == 1000.0
+
+
+def test_pq_target_nits_clips_at_a_lower_peak():
+    # A 500-nit display (e.g. an entry-level HDR10 panel) clips well before
+    # the 1000-nit reference: pq_eotf(0.7) is ~621 nits, already above 500.
+    assert pq_eotf(0.7) > 500.0
+    assert pq_target_nits(0.7, 500.0) == 500.0
+    # But a lower stimulus that's still below the 500-nit knee stays absolute.
+    assert pq_eotf(0.4) < 500.0
+    assert pq_target_nits(0.4, 500.0) == pq_eotf(0.4)

--- a/tests/test_hdr_pq_absolute_targets.py
+++ b/tests/test_hdr_pq_absolute_targets.py
@@ -1,0 +1,66 @@
+"""Regression test for issue #543: PQ grayscale targets must be absolute.
+
+ST.2084 (PQ) is an absolute EOTF — the encoded signal maps directly to nits,
+not to a fraction of the display's peak luminance. A display that tracks the
+PQ curve perfectly (clipping only above its own peak) must score ΔE ≈ 0 and
+pq_err_midtones ≈ 0, not the peak-rescaled error the old code produced.
+"""
+from __future__ import annotations
+
+import textwrap
+
+from calcore.analysis import analyze
+from calcore.csv_import import parse_measurement_csv
+from calcore.eotf import pq_eotf, pq_target_nits
+from calcore.models import AnalysisConfig
+
+PEAK_NITS = 1000.0
+CODE_MAX = 1023
+WHITE_XY = (0.3127, 0.3290)
+
+# A perfect 1000-nit PQ display: measured Y at each code value equals the
+# absolute ST.2084 target, clipped at the panel's peak (its tone-map knee).
+_PERFECT_PQ_RAMP_CSV = "\n".join(
+    f"{i},{code},{code},{code},{min(pq_eotf(code / CODE_MAX), PEAK_NITS):.4f},"
+    f"{WHITE_XY[0]},{WHITE_XY[1]}"
+    for i, code in enumerate(
+        (round(n / 10 * CODE_MAX) for n in range(1, 10)), start=1
+    )
+).encode() + b"\n"
+
+
+def _analyze_ramp():
+    cfg = AnalysisConfig(mode="hdr", eotf="pq", target_space="bt2020", code_max=CODE_MAX)
+    patches = parse_measurement_csv(_PERFECT_PQ_RAMP_CSV, format="xyY")
+    return analyze(patches, cfg, white_point_xy=WHITE_XY)
+
+
+def test_perfect_pq_ramp_scores_near_zero_delta_e():
+    summary = _analyze_ramp()
+    assert summary.grayscale_avg_de is not None
+    assert summary.grayscale_avg_de < 1.0, (
+        f"grayscale_avg_de={summary.grayscale_avg_de:.3f} — PQ targets are still "
+        "being rescaled by peak instead of treated as absolute nits"
+    )
+
+
+def test_perfect_pq_ramp_scores_near_zero_pq_err_midtones():
+    summary = _analyze_ramp()
+    assert summary.pq_err_midtones is not None
+    assert abs(summary.pq_err_midtones) < 1.0, (
+        f"pq_err_midtones={summary.pq_err_midtones:.3f}% — expected ~0 for a "
+        "perfectly-tracking PQ display"
+    )
+
+
+def test_pq_target_nits_is_absolute_below_knee():
+    # Below the panel's peak, the target is the raw absolute ST.2084 value —
+    # not scaled by peak_nits (the historical bug divided by 10000 then
+    # multiplied by peak, which only equals pq_eotf(n) when peak == 10000).
+    assert pq_target_nits(0.5, 1000.0) == pq_eotf(0.5)
+    assert pq_eotf(0.5) < 100.0  # ~92.25 nits, not ~9.2 nits
+
+
+def test_pq_target_nits_clips_at_panel_peak():
+    # Above the knee, the display physically cannot exceed its own peak.
+    assert pq_target_nits(1.0, 1000.0) == 1000.0

--- a/tests/test_wb_hints.py
+++ b/tests/test_wb_hints.py
@@ -242,13 +242,13 @@ class TestHDRGrayscaleDeltaE:
         """
         from calcore.models import HDR10_TARGET
         from calibrator.utils import stimulus_pct_from_code_value
-        from calcore.eotf import pq_eotf
+        from calcore.eotf import pq_target_nits
 
         # 50% gray (code value 128 → ~50% stimulus for full10 range).
-        # PQ target luminance at 50%: pq_eotf(0.5) / 10000 * 1000 nits
+        # PQ is an absolute EOTF: target luminance at 50% is pq_eotf(0.5) nits
+        # (~92.25 nits), clipped at the target's peak — not rescaled by peak.
         stim_pct = stimulus_pct_from_code_value(512, "full10")
-        expected_rel = pq_eotf(stim_pct / 100.0) / 10000.0
-        expected_y = HDR10_TARGET.peak_luminance_nits * expected_rel
+        expected_y = pq_target_nits(stim_pct / 100.0, HDR10_TARGET.peak_luminance_nits)
 
         # On-target measurement — should produce near-zero ΔE.
         m_on = Measurement(


### PR DESCRIPTION
## 📺 Overview

Closes #543

### What does this PR do?
* **Type of change:** [x] Bug fix
* **Component(s) affected:** `calcore/analysis.py`, `calcore/targets.py`, `calcore/eotf.py`, `calibrator/session.py` (PQ/HDR10 grayscale scoring)

---

## 🛠️ Technical Context & Implementation

* **The Problem:** `pq_eotf()` returns absolute nits per SMPTE ST.2084, but `target_xyz_for_patch`, `analyze()`'s `pq_err_pct`, and `m_to_dict`'s PQ branch all rescaled that value by the display's peak luminance as if PQ were a peak-relative EOTF (like BT.1886). A display tracking PQ perfectly at 50% stimulus (92.25 nits, the correct ST.2084 reference) was scored **ΔE 48.7 ("poor")** because the target was computed as `peak × pq_eotf(n)/10000` (≈9.2 nits for a 1000-nit target) instead of the absolute ≈92.25 nits — while the same row's `effective_gamma` (via `eotf_from_luminance`, which already used the absolute interpretation) read a perfect `1.0`.
* **The Solution:** Added `pq_target_nits(n, peak_nits) = min(pq_eotf(n), peak_nits)` in `calcore/eotf.py` — the absolute ST.2084 target, clipped at the panel's peak (its tone-map knee) since a display can't reproduce nits above its own peak. Applied consistently in all three call sites (`targets.py`, `analysis.py`'s `pq_err_pct`, and `session.py`'s `m_to_dict`).
* **Impact on existing workflows/APIs:** HDR10/Dolby Vision grayscale ΔE and `pq_err_midtones` values will change (drop significantly) for any existing session data re-analyzed with this fix, since they were previously inflated by the peak-rescaling bug. SDR/BT.1886 scoring is unaffected.

### Mathematical / Data Integrity Checks (If Applicable)
* [x] Matrix transformations or LUT calculations have been validated — verified `pq_target_nits(0.5, 1000) == pq_eotf(0.5) ≈ 92.25` nits, matching the existing `eotf_from_luminance` doctest in `calibrator/utils.py`.
* [x] Floating-point precision or data truncation risks have been addressed — no change to precision, only to which formula is applied.

---

## 🧪 Testing & Validation

### Verification Steps
1. `pytest tests/test_hdr_pq_absolute_targets.py` — new regression test: a perfect 1000-nit PQ ramp now scores `grayscale_avg_de < 1.0` and `pq_err_midtones ≈ 0`, and pins `pq_target_nits`'s absolute/clipped behavior directly.
2. `pytest tests/golden/` — HDR golden baseline (`tests/golden/data/hdr_pq_p3d65_grayscale.json`) regenerated: `grayscale_avg_de` 25.9 → 5.3, `grayscale_max_de` 56.5 → 11.3, `pq_err_midtones` 18.7% → 9.5% (remaining error reflects the fixture's real tracking imperfections, not the metric bug).
3. Updated `tests/test_wb_hints.py::TestHDRGrayscaleDeltaE::test_hdr_grayscale_reflects_luminance_error`, which had pinned the old peak-rescaled (buggy) expected value and started failing once the bug was fixed.
4. Full suite: `pytest -q` — 1328 passed, 2 skipped.

---

## 🧼 Checklist
* [x] Code adheres to project style guidelines (formatting, typing, linting).
* [x] Unit tests added/updated and passing.
* [ ] Documentation (README, inline docstrings) updated to reflect changes — n/a, no user-facing docs describe this internal metric.
* [x] No credentials, local absolute paths, or hardware-specific hardcoding leaked.


---
_Generated by [Claude Code](https://claude.ai/code/session_01D1ZPjcqJ6NiPhT2zTRFxy3)_