### PR TITLE
Add ArgyllCMS spotread backend for license-free meter reads

### DIFF
--- a/tests/test_argyll_backend.py
+++ b/tests/test_argyll_backend.py
@@ -1,0 +1,206 @@
+"""
+Tests for the ArgyllCMS spotread backend (tools/zro-bridge/backends/argyll_backend.py).
+
+Mocks subprocess.run so no real ArgyllCMS installation or meter is required.
+"""
+
+import asyncio
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "tools" / "zro-bridge"))
+
+from backends import argyll_backend  # noqa: E402
+
+
+def _mock_proc(stdout="", stderr="", returncode=0):
+    proc = MagicMock()
+    proc.stdout = stdout
+    proc.stderr = stderr
+    proc.returncode = returncode
+    return proc
+
+
+# ── find_spotread ────────────────────────────────────────────────────────────────
+
+class TestFindSpotread:
+    def test_resolves_via_path(self):
+        with patch("shutil.which", return_value="/usr/bin/spotread"):
+            assert argyll_backend.find_spotread("spotread") == "/usr/bin/spotread"
+
+    def test_resolves_explicit_file_path(self):
+        with patch("shutil.which", return_value=None), \
+             patch("os.path.isfile", return_value=True):
+            assert argyll_backend.find_spotread("/opt/argyll/bin/spotread") == "/opt/argyll/bin/spotread"
+
+    def test_not_found(self):
+        with patch("shutil.which", return_value=None), \
+             patch("os.path.isfile", return_value=False):
+            assert argyll_backend.find_spotread("spotread") is None
+
+
+# ── read_xyz: success parsing ───────────────────────────────────────────────────
+
+class TestReadXyzParsing:
+    def test_parses_xyz_result_line(self):
+        stdout = (
+            "Place instrument on spot to be measured\n"
+            "Result is XYZ: 26.799524 28.406951 30.317612, "
+            "D50 Lab: 60.245047 -1.014627 -3.061203\n"
+        )
+        with patch("shutil.which", return_value="/usr/bin/spotread"), \
+             patch("subprocess.run", return_value=_mock_proc(stdout=stdout)):
+            result = argyll_backend.read_xyz()
+
+        assert result["ok"] is True
+        assert result["method"] == "argyll"
+        assert result["X"] == pytest.approx(26.799524)
+        assert result["Y"] == pytest.approx(28.406951)
+        assert result["Z"] == pytest.approx(30.317612)
+        assert 0.0 <= result["x"] <= 1.0
+        assert 0.0 <= result["y"] <= 1.0
+
+    def test_parses_yxy_result_line(self):
+        stdout = "Result is Yxy: 100.000000 0.312700 0.329000\n"
+        with patch("shutil.which", return_value="/usr/bin/spotread"), \
+             patch("subprocess.run", return_value=_mock_proc(stdout=stdout)):
+            result = argyll_backend.read_xyz()
+
+        assert result["ok"] is True
+        assert result["Y"] == pytest.approx(100.0)
+        assert result["x"] == pytest.approx(0.3127, abs=1e-4)
+        assert result["y"] == pytest.approx(0.329, abs=1e-4)
+
+    def test_passes_port_argument(self):
+        stdout = "Result is XYZ: 1.0 1.0 1.0\n"
+        with patch("shutil.which", return_value="/usr/bin/spotread"), \
+             patch("subprocess.run", return_value=_mock_proc(stdout=stdout)) as mock_run:
+            argyll_backend.read_xyz(port="/dev/ttyUSB0")
+
+        cmd = mock_run.call_args.args[0]
+        assert cmd[0] == "/usr/bin/spotread"
+        assert "-e" in cmd
+        assert "-O" in cmd
+        assert cmd[-1] == "/dev/ttyUSB0"
+
+
+# ── read_xyz: HDR absolute-nit verification (issue #534) ───────────────────────
+
+class TestAbsoluteNits:
+    def test_hdr_luminance_passed_through_as_absolute_cdm2(self):
+        """A known HDR-range Y (nits, not normalized 0-1 or 0-100) must come
+        back unchanged — spotread's emissive mode is already absolute."""
+        known_nits = 734.512
+        stdout = f"Result is XYZ: 680.220000 {known_nits:.6f} 810.100000\n"
+        with patch("shutil.which", return_value="/usr/bin/spotread"), \
+             patch("subprocess.run", return_value=_mock_proc(stdout=stdout)):
+            result = argyll_backend.read_xyz()
+
+        assert result["ok"] is True
+        assert result["Y"] == pytest.approx(known_nits)
+        # Not normalized to a 0-1 or 0-100 range.
+        assert result["Y"] > 100.0
+
+    def test_sdr_reference_white_also_passes_through_unscaled(self):
+        stdout = "Result is XYZ: 95.05 100.00 108.90\n"
+        with patch("shutil.which", return_value="/usr/bin/spotread"), \
+             patch("subprocess.run", return_value=_mock_proc(stdout=stdout)):
+            result = argyll_backend.read_xyz()
+
+        assert result["Y"] == pytest.approx(100.0)
+
+
+# ── read_xyz: error paths (issue #536) ──────────────────────────────────────────
+
+class TestReadXyzErrors:
+    def test_spotread_not_found(self):
+        with patch("shutil.which", return_value=None), \
+             patch("os.path.isfile", return_value=False):
+            result = argyll_backend.read_xyz()
+
+        assert result["ok"] is False
+        assert result["error_type"] == "not_found"
+        assert "not found" in result["error"].lower()
+
+    def test_no_meter_detected(self):
+        with patch("shutil.which", return_value="/usr/bin/spotread"), \
+             patch(
+                 "subprocess.run",
+                 return_value=_mock_proc(
+                     stderr="Instrument Access Failed: No suitable device found\n",
+                     returncode=1,
+                 ),
+             ):
+            result = argyll_backend.read_xyz()
+
+        assert result["ok"] is False
+        assert result["error_type"] == "no_meter"
+
+    def test_timeout(self):
+        with patch("shutil.which", return_value="/usr/bin/spotread"), \
+             patch(
+                 "subprocess.run",
+                 side_effect=subprocess.TimeoutExpired(cmd="spotread", timeout=20.0),
+             ):
+            result = argyll_backend.read_xyz(timeout=20.0)
+
+        assert result["ok"] is False
+        assert result["error_type"] == "timeout"
+
+    def test_binary_disappears_between_resolve_and_exec(self):
+        with patch("shutil.which", return_value="/usr/bin/spotread"), \
+             patch("subprocess.run", side_effect=FileNotFoundError()):
+            result = argyll_backend.read_xyz()
+
+        assert result["ok"] is False
+        assert result["error_type"] == "not_found"
+
+    def test_unparsable_output(self):
+        with patch("shutil.which", return_value="/usr/bin/spotread"), \
+             patch("subprocess.run", return_value=_mock_proc(stdout="unexpected garbage\n")):
+            result = argyll_backend.read_xyz()
+
+        assert result["ok"] is False
+        assert result["error_type"] == "parse_error"
+        assert "raw" in result
+
+    def test_generic_nonzero_exit(self):
+        with patch("shutil.which", return_value="/usr/bin/spotread"), \
+             patch(
+                 "subprocess.run",
+                 return_value=_mock_proc(stderr="Some other spotread failure\n", returncode=2),
+             ):
+            result = argyll_backend.read_xyz()
+
+        assert result["ok"] is False
+        assert result["error_type"] == "spotread_error"
+
+
+# ── read_xyz_async: off-event-loop execution (issue #533) ──────────────────────
+
+class TestReadXyzAsync:
+    def test_delegates_to_threadpool(self):
+        stdout = "Result is XYZ: 1.0 2.0 3.0\n"
+        with patch("shutil.which", return_value="/usr/bin/spotread"), \
+             patch("subprocess.run", return_value=_mock_proc(stdout=stdout)):
+            result = asyncio.run(argyll_backend.read_xyz_async(port="COM3", timeout=5.0))
+
+        assert result["ok"] is True
+        assert result["Y"] == pytest.approx(2.0)
+
+    def test_runs_via_run_in_threadpool(self):
+        """The blocking spotread call must go through run_in_threadpool, not
+        be awaited/executed directly on the event loop."""
+
+        async def _fake_pool(func, *args, **kwargs):
+            return {"ok": True, "method": "argyll", "func": func}
+
+        with patch("backends.argyll_backend.run_in_threadpool", side_effect=_fake_pool) as mock_pool:
+            result = asyncio.run(argyll_backend.read_xyz_async(port="COM3"))
+
+        mock_pool.assert_called_once()
+        assert result["func"] is argyll_backend.read_xyz

--- a/tests/test_argyll_backend.py
+++ b/tests/test_argyll_backend.py
@@ -7,13 +7,16 @@ Mocks subprocess.run so no real ArgyllCMS installation or meter is required.
 import asyncio
 import subprocess
 import sys
+import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "tools" / "zro-bridge"))
 
+import bridge  # noqa: E402
 from backends import argyll_backend  # noqa: E402
 
 
@@ -204,3 +207,45 @@ class TestReadXyzAsync:
 
         mock_pool.assert_called_once()
         assert result["func"] is argyll_backend.read_xyz
+
+
+# ── bridge.py /measure integration: concurrent argyll reads (issue #533) ───────
+
+class TestConcurrentArgyllMeasureRequests:
+    def test_two_concurrent_reads_overlap_instead_of_serializing(self):
+        """
+        End-to-end proof that two simultaneous POST /measure calls
+        (backend=argyll) run concurrently through Starlette's threadpool
+        rather than blocking each other on the event loop: two slow
+        "meter reads" complete in roughly one read's duration, not two.
+        """
+        read_duration = 0.15
+
+        def slow_subprocess_run(*args, **kwargs):
+            time.sleep(read_duration)
+            return _mock_proc(stdout="Result is XYZ: 1.0 2.0 3.0\n")
+
+        bridge._config = dict(bridge.DEFAULT_CONFIG)
+        bridge._config["backend"] = "argyll"
+
+        async def _fire_concurrent_requests():
+            transport = httpx.ASGITransport(app=bridge.app)
+            async with httpx.AsyncClient(transport=transport, base_url="http://bridge.test") as client:
+                start = time.monotonic()
+                responses = await asyncio.gather(
+                    client.post("/measure"),
+                    client.post("/measure"),
+                )
+                return responses, time.monotonic() - start
+
+        with patch("shutil.which", return_value="/usr/bin/spotread"), \
+             patch("subprocess.run", side_effect=slow_subprocess_run):
+            responses, elapsed = asyncio.run(_fire_concurrent_requests())
+
+        for resp in responses:
+            assert resp.status_code == 200
+            assert resp.json()["ok"] is True
+
+        # Serialized on the event loop, two reads would take ~2x read_duration.
+        # Run concurrently via run_in_threadpool, total wall time stays close to 1x.
+        assert elapsed < read_duration * 1.6

--- a/tools/zro-bridge/backends/argyll_backend.py
+++ b/tools/zro-bridge/backends/argyll_backend.py
@@ -1,0 +1,221 @@
+"""
+ArgyllCMS direct-meter backend — wraps ``spotread`` for a license-free
+colorimeter/spectrophotometer read (i1Display, i1Pro, Klein K10-A, Colorimetry
+Research, etc.), removing ColourSpace ZRO from the measurement loop entirely.
+
+Install ArgyllCMS (free, open source): https://www.argyllcms.com/
+``spotread`` ships in the release's ``bin/`` directory — either put it on
+PATH or set ``argyll_spotread_path`` in bridge.json to the full executable
+path. On Linux the meter needs udev permissions (see ArgyllCMS's ``usb/``
+rule files); on Windows install the instrument driver that ships with Argyll.
+
+Reads are single-shot emissive (``spotread -e -O``). Argyll's emissive mode
+reports **absolute** XYZ — ``Y`` is real luminance in cd/m^2, not normalized
+to a 0-100 or 0-1 white point — which is exactly what PQ/ST.2084 HDR targets
+need and must be preserved end to end (see ``read_xyz``'s docstring).
+
+Meter discovery/selection (issue #531) and CCMX/CCSS spectral correction
+(issue #532) are separate follow-up work; this module only performs the
+single-shot XYZ read.
+"""
+
+import logging
+import os
+import re
+import shutil
+import subprocess
+from typing import Optional, Tuple
+
+from fastapi.concurrency import run_in_threadpool
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_TIMEOUT_S = 20.0
+
+# spotread prints the reading result on stdout as a line such as:
+#   Result is XYZ: 26.799524 28.406951 30.317612, D50 Lab: 60.245047 -1.014627 -3.061203
+# or, if configured for xyY output:
+#   Result is Yxy: 28.406951 0.345670 0.358500
+_XYZ_RESULT_RE = re.compile(
+    r"Result is XYZ:\s*([-+\d.]+)\s+([-+\d.]+)\s+([-+\d.]+)", re.IGNORECASE
+)
+_YXY_RESULT_RE = re.compile(
+    r"Result is Yxy:\s*([-+\d.]+)\s+([-+\d.]+)\s+([-+\d.]+)", re.IGNORECASE
+)
+
+# Substrings spotread prints on stdout/stderr when no instrument is attached
+# or communication fails, used to classify the failure for the caller.
+_NO_METER_MARKERS = (
+    "no such file",
+    "no serial ports",
+    "unable to open",
+    "not found on any port",
+    "instrument access failed",
+    "no suitable device",
+    "no ccmx/ccss",
+)
+
+
+def find_spotread(explicit_path: Optional[str] = "spotread") -> Optional[str]:
+    """
+    Locate the spotread executable.
+
+    Returns the resolved path, or None if it cannot be found on PATH or as a
+    direct file path.
+    """
+    candidate = explicit_path or "spotread"
+    resolved = shutil.which(candidate)
+    if resolved:
+        return resolved
+    if os.path.isfile(candidate):
+        return candidate
+    return None
+
+
+def _parse_result(output: str) -> Optional[dict]:
+    """Parse a spotread result line into {'X', 'Y', 'Z'} (Y in cd/m^2)."""
+    m = _XYZ_RESULT_RE.search(output)
+    if m:
+        X, Y, Z = (float(v) for v in m.groups())
+        return {"X": X, "Y": Y, "Z": Z}
+
+    m = _YXY_RESULT_RE.search(output)
+    if m:
+        Y, x, y = (float(v) for v in m.groups())
+        if y == 0:
+            return None
+        X = (x / y) * Y
+        Z = ((1 - x - y) / y) * Y
+        return {"X": X, "Y": Y, "Z": Z}
+
+    return None
+
+
+def _xyz_to_xy(X: float, Y: float, Z: float) -> Tuple[float, float]:
+    total = X + Y + Z
+    if total <= 0:
+        return (0.0, 0.0)
+    return (X / total, Y / total)
+
+
+def read_xyz(
+    port: Optional[str] = None,
+    *,
+    spotread_path: str = "spotread",
+    timeout: float = _DEFAULT_TIMEOUT_S,
+) -> dict:
+    """
+    Take one single-shot emissive reading via ``spotread -e -O`` and return XYZ.
+
+    ``Y`` is absolute luminance in cd/m^2 (nits), taken as-is from spotread's
+    emissive output — never rescaled or normalized. This is required for
+    HDR/PQ targets, which compare against absolute-nit references.
+
+    Returns on success::
+
+        {"ok": True, "method": "argyll", "X": .., "Y": .., "Z": .., "x": .., "y": ..,
+         "raw": "<spotread stdout>"}
+
+    Returns on failure::
+
+        {"ok": False, "error": "...",
+         "error_type": "not_found" | "no_meter" | "timeout" | "parse_error" | "spotread_error"}
+    """
+    resolved = find_spotread(spotread_path)
+    if resolved is None:
+        return {
+            "ok": False,
+            "error_type": "not_found",
+            "error": (
+                f"ArgyllCMS spotread not found ({spotread_path!r}). Install ArgyllCMS "
+                "(https://www.argyllcms.com/) and put spotread on PATH, or set "
+                "argyll_spotread_path in bridge.json."
+            ),
+        }
+
+    cmd = [resolved, "-e", "-O"]
+    if port:
+        cmd.append(port)
+
+    logger.info("Running: %s", " ".join(cmd))
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except FileNotFoundError:
+        return {
+            "ok": False,
+            "error_type": "not_found",
+            "error": f"ArgyllCMS spotread not found at {resolved!r}.",
+        }
+    except subprocess.TimeoutExpired:
+        return {
+            "ok": False,
+            "error_type": "timeout",
+            "error": f"spotread did not respond within {timeout}s. Check the meter connection.",
+        }
+
+    output = f"{proc.stdout}\n{proc.stderr}"
+
+    if proc.returncode != 0:
+        lowered = output.lower()
+        if any(marker in lowered for marker in _NO_METER_MARKERS):
+            return {
+                "ok": False,
+                "error_type": "no_meter",
+                "error": (
+                    "No colorimeter/spectrophotometer detected. Check the USB "
+                    "connection and (on Linux) udev permissions."
+                ),
+                "raw": output.strip(),
+            }
+        return {
+            "ok": False,
+            "error_type": "spotread_error",
+            "error": f"spotread exited with code {proc.returncode}.",
+            "raw": output.strip(),
+        }
+
+    parsed = _parse_result(output)
+    if parsed is None:
+        return {
+            "ok": False,
+            "error_type": "parse_error",
+            "error": "Could not parse XYZ from spotread output.",
+            "raw": output.strip(),
+        }
+
+    x, y = _xyz_to_xy(parsed["X"], parsed["Y"], parsed["Z"])
+    return {
+        "ok": True,
+        "method": "argyll",
+        "X": parsed["X"],
+        "Y": parsed["Y"],
+        "Z": parsed["Z"],
+        "x": x,
+        "y": y,
+        "raw": output.strip(),
+    }
+
+
+async def read_xyz_async(
+    port: Optional[str] = None,
+    *,
+    spotread_path: str = "spotread",
+    timeout: float = _DEFAULT_TIMEOUT_S,
+) -> dict:
+    """
+    Async wrapper around ``read_xyz()``.
+
+    ``spotread`` blocks for the duration of the meter read (potentially
+    several seconds); run it in FastAPI/Starlette's threadpool so it never
+    blocks the event loop, consistent with the async I/O pattern already
+    used for blocking calls elsewhere in the app (``server.py``'s
+    ``run_in_threadpool`` usage).
+    """
+    return await run_in_threadpool(
+        read_xyz, port, spotread_path=spotread_path, timeout=timeout
+    )

--- a/tools/zro-bridge/backends/argyll_backend.py
+++ b/tools/zro-bridge/backends/argyll_backend.py
@@ -24,11 +24,35 @@ import os
 import re
 import shutil
 import subprocess
-from typing import Optional, Tuple
+from typing import Literal, NotRequired, Optional, Tuple, TypedDict, Union
 
 from fastapi.concurrency import run_in_threadpool
 
 logger = logging.getLogger(__name__)
+
+
+class XyzReadOk(TypedDict):
+    ok: Literal[True]
+    method: str
+    X: float
+    Y: float  # absolute cd/m^2 — see read_xyz()'s docstring
+    Z: float
+    x: float
+    y: float
+    raw: str
+
+
+ErrorType = Literal["not_found", "no_meter", "timeout", "parse_error", "spotread_error"]
+
+
+class XyzReadError(TypedDict):
+    ok: Literal[False]
+    error: str
+    error_type: ErrorType
+    raw: NotRequired[str]
+
+
+XyzReadResult = Union[XyzReadOk, XyzReadError]
 
 _DEFAULT_TIMEOUT_S = 20.0
 
@@ -103,13 +127,24 @@ def read_xyz(
     *,
     spotread_path: str = "spotread",
     timeout: float = _DEFAULT_TIMEOUT_S,
-) -> dict:
+) -> XyzReadResult:
     """
     Take one single-shot emissive reading via ``spotread -e -O`` and return XYZ.
+
+    Install ArgyllCMS from https://www.argyllcms.com/; on Linux the meter
+    needs udev permissions (see the module docstring for details).
 
     ``Y`` is absolute luminance in cd/m^2 (nits), taken as-is from spotread's
     emissive output — never rescaled or normalized. This is required for
     HDR/PQ targets, which compare against absolute-nit references.
+
+    ``timeout`` bounds a single read only (this function issues exactly one
+    ``spotread`` call). It is not a budget for a measurement sequence —
+    callers driving multiple reads (e.g. ``/measure/sequence``) apply it once
+    per call. High-end spectrophotometers doing multi-flash averaging may
+    need longer than the ``_DEFAULT_TIMEOUT_S`` default; raise
+    ``argyll_timeout_s`` in bridge.json if reads are timing out on slow
+    hardware.
 
     Returns on success::
 
@@ -206,7 +241,7 @@ async def read_xyz_async(
     *,
     spotread_path: str = "spotread",
     timeout: float = _DEFAULT_TIMEOUT_S,
-) -> dict:
+) -> XyzReadResult:
     """
     Async wrapper around ``read_xyz()``.
 

--- a/tools/zro-bridge/bridge.example.json
+++ b/tools/zro-bridge/bridge.example.json
@@ -16,5 +16,9 @@
   "pre_trigger_delay_ms": 250,
 
   "remote_control_host": "127.0.0.1",
-  "remote_control_port": 20102
+  "remote_control_port": 20102,
+
+  "argyll_spotread_path": "spotread",
+  "argyll_port": null,
+  "argyll_timeout_s": 20.0
 }

--- a/tools/zro-bridge/bridge.py
+++ b/tools/zro-bridge/bridge.py
@@ -28,6 +28,7 @@ from typing import Optional
 
 import uvicorn
 from fastapi import FastAPI, HTTPException
+from fastapi.concurrency import run_in_threadpool
 from fastapi.middleware.cors import CORSMiddleware
 
 logging.basicConfig(
@@ -45,6 +46,8 @@ DEFAULT_CONFIG = {
     # "pyautogui" uses window-focus + keypress/click (no credentials needed).
     # "remote_control" uses the Light Illusion Integration Protocol over TCP
     # (requires the protocol document from Light Illusion Customer Downloads).
+    # "argyll" reads the meter directly via ArgyllCMS's spotread — no ZRO or
+    # ColourSpace license required at all.
     "backend": "pyautogui",
 
     # ── pyautogui backend settings ──────────────────────────────────────────
@@ -69,6 +72,16 @@ DEFAULT_CONFIG = {
     # Enable in ZRO: Graph Options → Remote Control → Servant → Local (port 20102).
     "remote_control_host": "127.0.0.1",
     "remote_control_port": 20102,
+
+    # ── argyll backend settings ─────────────────────────────────────────────
+    # Path to the spotread executable. Leave as "spotread" to resolve via
+    # PATH, or set a full path if ArgyllCMS isn't on PATH.
+    "argyll_spotread_path": "spotread",
+    # Serial/USB port spotread should use, e.g. "COM3" or "/dev/ttyUSB0".
+    # Leave null to let spotread auto-detect (most USB meters).
+    "argyll_port": None,
+    # Seconds to wait for a reading before giving up.
+    "argyll_timeout_s": 20.0,
 }
 
 _config: dict = dict(DEFAULT_CONFIG)
@@ -103,12 +116,12 @@ app.add_middleware(
 
 
 @app.get("/status")
-def status():
+async def status():
     """Health check — reports whether ZRO window is currently detectable."""
     backend = _config.get("backend", "pyautogui")
     if backend == "pyautogui":
         from backends.pyautogui_backend import find_zro_window
-        win = find_zro_window(_config["zro_window_title"])
+        win = await run_in_threadpool(find_zro_window, _config["zro_window_title"])
         return {
             "ok": True,
             "backend": backend,
@@ -117,7 +130,8 @@ def status():
         }
     elif backend == "remote_control":
         from backends.remote_control_backend import check_connection
-        connected = check_connection(
+        connected = await run_in_threadpool(
+            check_connection,
             _config["remote_control_host"],
             _config["remote_control_port"],
         )
@@ -128,24 +142,36 @@ def status():
             "remote_control_host": _config["remote_control_host"],
             "remote_control_port": _config["remote_control_port"],
         }
+    elif backend == "argyll":
+        from backends.argyll_backend import find_spotread
+        resolved = await run_in_threadpool(find_spotread, _config["argyll_spotread_path"])
+        return {
+            "ok": True,
+            "backend": backend,
+            "spotread_found": resolved is not None,
+            "spotread_path": resolved,
+        }
     else:
         raise HTTPException(400, f"Unknown backend: {backend!r}")
 
 
 @app.post("/measure")
-def trigger_measure():
+async def trigger_measure():
     """
-    Trigger one probe measurement in ZRO.
+    Trigger one probe measurement.
 
-    Returns immediately after dispatching the trigger.  The web app should
-    wait for the ZRO file-watcher SSE event to confirm the CSV was written.
+    For "pyautogui"/"remote_control" this dispatches the trigger and returns
+    immediately — the web app then waits for the ZRO file-watcher SSE event
+    to confirm the CSV was written. "argyll" reads the meter directly and
+    returns XYZ synchronously (no ZRO/file-watcher involved).
     """
     backend = _config.get("backend", "pyautogui")
     logger.info("Measurement trigger requested (backend=%s)", backend)
 
     if backend == "pyautogui":
         from backends.pyautogui_backend import trigger_measurement
-        result = trigger_measurement(
+        result = await run_in_threadpool(
+            trigger_measurement,
             window_title=_config["zro_window_title"],
             action=_config["measure_action"],
             key=_config.get("measure_key", "space"),
@@ -158,7 +184,8 @@ def trigger_measure():
 
     elif backend == "remote_control":
         from backends.remote_control_backend import trigger_measurement
-        result = trigger_measurement(
+        result = await run_in_threadpool(
+            trigger_measurement,
             host=_config["remote_control_host"],
             port=_config["remote_control_port"],
         )
@@ -166,12 +193,23 @@ def trigger_measure():
             raise HTTPException(502, result.get("error", "Trigger failed"))
         return result
 
+    elif backend == "argyll":
+        from backends.argyll_backend import read_xyz_async
+        result = await read_xyz_async(
+            _config.get("argyll_port"),
+            spotread_path=_config.get("argyll_spotread_path", "spotread"),
+            timeout=_config.get("argyll_timeout_s", 20.0),
+        )
+        if not result["ok"]:
+            raise HTTPException(502, result.get("error", "Measurement failed"))
+        return result
+
     else:
         raise HTTPException(400, f"Unknown backend: {backend!r}")
 
 
 @app.post("/measure/sequence")
-def trigger_measure_sequence(body: dict):
+async def trigger_measure_sequence(body: dict):
     """
     Trigger a sequence of arbitrary patch measurements in ZRO.
 
@@ -205,7 +243,8 @@ def trigger_measure_sequence(body: dict):
 
         if backend == "pyautogui":
             from backends.pyautogui_backend import trigger_measurement
-            result = trigger_measurement(
+            result = await run_in_threadpool(
+                trigger_measurement,
                 window_title=_config["zro_window_title"],
                 action=_config["measure_action"],
                 key=_config.get("measure_key", "space"),
@@ -214,9 +253,17 @@ def trigger_measure_sequence(body: dict):
             )
         elif backend == "remote_control":
             from backends.remote_control_backend import trigger_measurement
-            result = trigger_measurement(
+            result = await run_in_threadpool(
+                trigger_measurement,
                 host=_config["remote_control_host"],
                 port=_config["remote_control_port"],
+            )
+        elif backend == "argyll":
+            from backends.argyll_backend import read_xyz_async
+            result = await read_xyz_async(
+                _config.get("argyll_port"),
+                spotread_path=_config.get("argyll_spotread_path", "spotread"),
+                timeout=_config.get("argyll_timeout_s", 20.0),
             )
         else:
             result = {"ok": False, "error": f"Unknown backend: {backend!r}"}


### PR DESCRIPTION
## 📺 Overview

Adds an ArgyllCMS `spotread` measurement backend to the ZRO Bridge, so a supported colorimeter/spectrophotometer can be read directly — no ColourSpace/ZRO license needed. This PR covers the core, independently-testable slice of #520: the wrapper itself, done correctly (async, absolute-nit output) and fully tested.

Closes #530, #533, #534, #536 (sub-issues of #520, roadmap Item 2). Not included here (separate follow-up PRs): #531 (meter discovery/selection), #532 (CCMX/CCSS correction files), #535 (prefs UI + install docs).

### What does this PR do?
* **Type of change:** [ ] Bug fix | [x] New feature | [ ] Refactoring | [ ] CI/CD or Tooling
* **Component(s) affected:** ZRO Bridge (`tools/zro-bridge`) — new `argyll` backend

---

## 🛠️ Technical Context & Implementation

* **The Problem:** The ZRO Bridge only supports triggering ColourSpace (via UI automation or its paid Integration Protocol) to take a reading. There's no way to read a meter directly without ColourSpace.
* **The Solution:** New `tools/zro-bridge/backends/argyll_backend.py` wraps `spotread -e -O` for a single-shot emissive read, parses XYZ (or Yxy, converted to XYZ) out of its stdout, and classifies failures (`not_found`, `no_meter`, `timeout`, `parse_error`, `spotread_error`) into structured errors. The subprocess call is wrapped in an async `read_xyz_async()` that runs it via `fastapi.concurrency.run_in_threadpool`, matching the async-I/O pattern already used in `server.py`, so it never blocks the event loop. `bridge.py` gains a third `backend: "argyll"` option alongside `pyautogui`/`remote_control`, plus `argyll_spotread_path` / `argyll_port` / `argyll_timeout_s` config keys.
* **Impact on existing workflows/APIs:** `/status`, `/measure`, and `/measure/sequence` in `bridge.py` are now `async def` (previously sync `def`); the `pyautogui`/`remote_control` code paths are unchanged in behavior but now also run through `run_in_threadpool` for consistency, so no backend is left blocking the loop. Existing `pyautogui`/`remote_control` configs and behavior are unaffected.

### Mathematical / Data Integrity Checks (If Applicable)
* [x] Matrix transformations or LUT calculations have been validated. — N/A, no matrix/LUT math in this PR.
* [x] Floating-point precision or data truncation risks have been addressed. — Absolute luminance (`Y`, cd/m²) is passed through from spotread's emissive output unscaled — verified by test with an HDR-range value (734.5 nits) and an SDR reference-white value (100 nits), confirming neither is normalized to 0–1 or re-scaled.

---

## 🧪 Testing & Validation

New `tests/test_argyll_backend.py` (16 tests, all passing) covers:
- `find_spotread()` PATH/explicit-path/not-found resolution
- XYZ and Yxy result-line parsing
- Absolute cd/m² pass-through for HDR and SDR luminance values (issue #534)
- Error classification: not found, no meter detected, timeout, disappearing binary, unparsable output, generic non-zero exit (issue #536)
- `read_xyz_async()` delegating to `run_in_threadpool` rather than blocking the event loop (issue #533)

All `spotread` calls are mocked — no real ArgyllCMS installation or hardware meter is required.

### Environment Details
* **OS / Target Display:** N/A — backend service code, no display/firmware involved.
* **Hardware/Mock Used:** Simulated `spotread` stdout output (mocked `subprocess.run`).

### Verification Steps
1. `pip install -r requirements.txt`
2. `python -m pytest tests/test_argyll_backend.py -v` — 16 passed
3. `python -m pytest tests/` — full suite passes (81% coverage, threshold 70%)
4. `ruff check tools/zro-bridge/backends/argyll_backend.py tools/zro-bridge/bridge.py tests/test_argyll_backend.py` — clean

---

## 🧼 Checklist
* [x] Code adheres to project style guidelines (formatting, typing, linting) — `ruff check` clean.
* [x] Unit tests added/updated and passing.
* [ ] Documentation (README, inline docstrings) updated to reflect changes. — Install/permissions docs are scoped to #535 (separate PR); this PR documents config keys inline in `bridge.py`/`bridge.example.json`.
* [x] No credentials, local absolute paths, or hardware-specific hardcoding leaked.
