### PR TITLE
fix: ColorTuner Apply sends relative delta to new /api/adb/cms/adjust endpoint (#544)

### DIFF
--- a/calibrator/adb_control.py
+++ b/calibrator/adb_control.py
@@ -221,6 +221,68 @@ def get_cms_value(
     return {"ok": ok, "value": value, "stdout": result.stdout, "stderr": result.stderr}
 
 
+def adjust_cms_value(
+    channel: str,
+    control: str,
+    delta: int,
+    device: Optional[str] = None,
+) -> dict:
+    """
+    Adjust a CMS value by a relative delta, clamped to [CMS_MIN, CMS_MAX].
+
+    Reads the current value from the TV, adds delta, clamps to the valid
+    range (−10…+10), and writes back if changed.  This is the correct
+    operation for UI controls that express intent as relative adjustments,
+    since the underlying CmsTool API is an absolute set.
+
+    Args:
+        channel: One of CMS_CHANNELS keys (e.g. "Red", "Cyan").
+        control: One of CMS_SET_ACTIONS keys ("Hue", "Saturation", "Brightness").
+        delta:   The relative change to apply (positive or negative).
+        device:  ADB device serial (optional).
+
+    Returns:
+        {"ok": bool, "stdout": str, "stderr": str,
+         "old_value": int | None, "new_value": int | None}
+    """
+    # Reuse validation from get/set — raises ValueError on bad inputs.
+    if channel not in CMS_CHANNELS:
+        raise ValueError(f"Unknown channel {channel!r}. Valid: {sorted(CMS_CHANNELS)}")
+    if control not in CMS_SET_ACTIONS:
+        raise ValueError(f"Unknown control {control!r}. Valid: {sorted(CMS_SET_ACTIONS)}")
+
+    current = get_cms_value(channel, control, device=device)
+    if not current["ok"] or current["value"] is None:
+        return {
+            "ok": False,
+            "stdout": current["stdout"],
+            "stderr": current["stderr"] or "Failed to read current CMS value",
+            "old_value": None,
+            "new_value": None,
+        }
+
+    old_value = current["value"]
+    new_value = max(CMS_MIN, min(CMS_MAX, old_value + delta))
+
+    if new_value == old_value:
+        return {
+            "ok": True,
+            "stdout": f"no change: value already {old_value}",
+            "stderr": "",
+            "old_value": old_value,
+            "new_value": new_value,
+        }
+
+    set_result = set_cms_value(channel, control, new_value, device=device)
+    return {
+        "ok": set_result["ok"],
+        "stdout": set_result["stdout"],
+        "stderr": set_result["stderr"],
+        "old_value": old_value,
+        "new_value": new_value if set_result["ok"] else None,
+    }
+
+
 def get_all_cms_values(device: Optional[str] = None) -> dict:
     """
     Read all CMS values (all 6 channels × 3 controls) from the TV.

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -103,8 +103,8 @@ export const api = {
   // ADB — CMS (per-channel colour tuner)
   getAdbStatus:  ()           => api.get('/api/adb/status'),
   adbDeploy:     ()           => api.post('/api/adb/cms/push'),
-  adbApply:      (channel, control, value) =>
-    api.post('/api/adb/cms/set', { channel, control, value }),
+  adbApply:      (channel, control, delta) =>
+    api.post('/api/adb/cms/adjust', { channel, control, delta }),
   adbReset:      ()           => api.post('/api/adb/cms/reset'),
 
   // ADB — main picture controls (Brightness, Contrast, Saturation, PictureMode)

--- a/frontend/src/pages/ColorTuner.test.jsx
+++ b/frontend/src/pages/ColorTuner.test.jsx
@@ -1,0 +1,177 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import { ColorTuner } from './ColorTuner';
+
+const adbReady = { connected: true, cms_tool_deployed: true };
+
+const baseSession = {
+  id: 'session-1',
+  cms_data: {
+    colors: [{ name: 'Red 100%', rgb: [255, 0, 0] }],
+    measurements: [{ label: 'Red 100%', delta_e: 3.2 }],
+    control_plan: [
+      { control: 'Hue', direction: 'down', amount: 2, summary: 'Lower Hue' },
+    ],
+    latest_hint: true,
+  },
+};
+
+describe('ColorTuner', () => {
+  it('renders Color Status with colour swatches and delta_e values', () => {
+    render(
+      <ColorTuner
+        session={baseSession}
+        adbStatus={adbReady}
+        onAdbApply={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('Red 100%')).toBeInTheDocument();
+    expect(screen.getByText(/ΔE/)).toBeInTheDocument();
+  });
+
+  it('renders "What to Adjust" when control_plan is present', () => {
+    render(
+      <ColorTuner
+        session={baseSession}
+        adbStatus={adbReady}
+        onAdbApply={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('What to Adjust')).toBeInTheDocument();
+  });
+
+  it('does not render "What to Adjust" when latest_hint is false', () => {
+    const session = { ...baseSession, cms_data: { ...baseSession.cms_data, latest_hint: false } };
+    render(
+      <ColorTuner session={session} adbStatus={adbReady} onAdbApply={vi.fn()} />,
+    );
+    expect(screen.queryByText('What to Adjust')).not.toBeInTheDocument();
+  });
+
+  it('Apply button calls onAdbApply with positive delta for direction=up', async () => {
+    const onAdbApply = vi.fn();
+    const session = {
+      ...baseSession,
+      cms_data: {
+        ...baseSession.cms_data,
+        control_plan: [
+          { control: 'Hue', direction: 'up', amount: 3, summary: 'Raise Hue' },
+        ],
+      },
+    };
+    render(
+      <ColorTuner
+        session={session}
+        adbStatus={adbReady}
+        onAdbApply={onAdbApply}
+      />,
+    );
+    await userEvent.click(screen.getByText('Apply'));
+    expect(onAdbApply).toHaveBeenCalledOnce();
+    expect(onAdbApply).toHaveBeenCalledWith('Red', 'Hue', 3);
+  });
+
+  it('Apply button calls onAdbApply with negative delta for direction=down', async () => {
+    const onAdbApply = vi.fn();
+    render(
+      <ColorTuner
+        session={baseSession}
+        adbStatus={adbReady}
+        onAdbApply={onAdbApply}
+      />,
+    );
+    await userEvent.click(screen.getByText('Apply'));
+    expect(onAdbApply).toHaveBeenCalledOnce();
+    // direction=down, amount=2 → delta = -2 (relative adjustment)
+    expect(onAdbApply).toHaveBeenCalledWith('Red', 'Hue', -2);
+  });
+
+  it('Apply all sends one call per non-hold step with correct deltas', async () => {
+    const onAdbApply = vi.fn();
+    const session = {
+      ...baseSession,
+      cms_data: {
+        ...baseSession.cms_data,
+        control_plan: [
+          { control: 'Hue', direction: 'up', amount: 3, summary: 'Raise Hue' },
+          { control: 'Saturation', direction: 'down', amount: 1, summary: 'Lower Sat' },
+          { control: 'Brightness', direction: 'hold', amount: 2, summary: 'Hold Bri' },
+        ],
+      },
+    };
+    render(
+      <ColorTuner
+        session={session}
+        adbStatus={adbReady}
+        onAdbApply={onAdbApply}
+      />,
+    );
+    await userEvent.click(screen.getByText('Apply all'));
+    expect(onAdbApply).toHaveBeenCalledTimes(2);
+    expect(onAdbApply).toHaveBeenCalledWith('Red', 'Hue', 3);
+    expect(onAdbApply).toHaveBeenCalledWith('Red', 'Saturation', -1);
+    // hold step should NOT be called
+  });
+
+  it('Reset CMS button is present when ADB is ready', () => {
+    render(
+      <ColorTuner session={baseSession} adbStatus={adbReady} onAdbApply={vi.fn()} />,
+    );
+    expect(screen.getByText('Reset All CMS to 0')).toBeInTheDocument();
+  });
+
+  it('does not render CMS measurements when there are none', () => {
+    const session = { ...baseSession, cms_data: { ...baseSession.cms_data, measurements: [] } };
+    render(
+      <ColorTuner session={session} adbStatus={adbReady} onAdbApply={vi.fn()} />,
+    );
+    expect(screen.queryByText('CMS Measurements')).not.toBeInTheDocument();
+  });
+
+  it('renders CMS measurements section when there are readings', () => {
+    render(
+      <ColorTuner session={baseSession} adbStatus={adbReady} onAdbApply={vi.fn()} />,
+    );
+    expect(screen.getByText('CMS Measurements')).toBeInTheDocument();
+  });
+
+  it('deploy button shown when ADB connected but cms_tool.dex missing', () => {
+    render(
+      <ColorTuner
+        session={baseSession}
+        adbStatus={{ connected: true, cms_tool_deployed: false }}
+        onAdbApply={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('Deploy cms_tool.dex')).toBeInTheDocument();
+  });
+
+  it('Reset button disabled when ADB not connected', () => {
+    render(
+      <ColorTuner
+        session={baseSession}
+        adbStatus={{ connected: false, cms_tool_deployed: false }}
+        onAdbApply={vi.fn()}
+      />,
+    );
+    const btn = screen.getByText('Reset All CMS to 0');
+    expect(btn).toBeDisabled();
+  });
+
+  it('navigation buttons present', () => {
+    const onPrev = vi.fn();
+    const onNext = vi.fn();
+    render(
+      <ColorTuner
+        session={baseSession}
+        adbStatus={adbReady}
+        onAdbApply={vi.fn()}
+        onPrev={onPrev}
+        onNext={onNext}
+      />,
+    );
+    expect(screen.getByText('← Back')).toBeInTheDocument();
+    expect(screen.getByText('Continue to Post-Cal Grayscale →')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/ColorTuner.test.jsx
+++ b/frontend/src/pages/ColorTuner.test.jsx
@@ -26,8 +26,11 @@ describe('ColorTuner', () => {
         onAdbApply={vi.fn()}
       />,
     );
-    expect(screen.getByText('Red 100%')).toBeInTheDocument();
-    expect(screen.getByText(/ΔE/)).toBeInTheDocument();
+    // "Red 100%" appears in both AutocalCard and Color Status sections
+    const all = screen.getAllByText('Red 100%');
+    expect(all.length).toBeGreaterThanOrEqual(2);
+    // DeltaE pill renders as "ΔE 3.20" inside a span with class "de-pill"
+    expect(screen.getByText('ΔE 3.20')).toBeInTheDocument();
   });
 
   it('renders "What to Adjust" when control_plan is present', () => {

--- a/server.py
+++ b/server.py
@@ -545,6 +545,13 @@ class AdbCmsSetReq(BaseModel):
     device: Optional[str] = None
 
 
+class AdbCmsAdjustReq(BaseModel):
+    channel: str
+    control: str
+    delta: int
+    device: Optional[str] = None
+
+
 class AdbCmsGetReq(BaseModel):
     channel: str
     control: str
@@ -2274,6 +2281,23 @@ def adb_cms_set(req: AdbCmsSetReq):
     try:
         result = _adb.set_cms_value(
             channel=req.channel, control=req.control, value=req.value, device=req.device
+        )
+    except ValueError as exc:
+        raise HTTPException(400, str(exc)) from exc
+    except Exception as exc:
+        raise HTTPException(500, f"ADB error: {exc}") from exc
+    if not result["ok"]:
+        raise HTTPException(
+            502, f"ADB command failed: {result['stderr'] or result['stdout']}"
+        )
+    return result
+
+
+@app.post("/api/adb/cms/adjust")
+def adb_cms_adjust(req: AdbCmsAdjustReq):
+    try:
+        result = _adb.adjust_cms_value(
+            channel=req.channel, control=req.control, delta=req.delta, device=req.device
         )
     except ValueError as exc:
         raise HTTPException(400, str(exc)) from exc

--- a/tests/test_adb_control.py
+++ b/tests/test_adb_control.py
@@ -344,6 +344,198 @@ class TestAdbCmsGetAllEndpoint:
         assert len(r.json()["values"]) == 6
 
 
+class TestAdjustCmsValue:
+    """Unit tests for adb_control.adjust_cms_value()."""
+
+    def test_adds_delta_to_current(self):
+        """current=5, delta=-2 → set_cms_value called with 3."""
+        get_result = {"ok": True, "value": 5, "stdout": "VALUE 5", "stderr": ""}
+        set_result = {"ok": True, "stdout": "OK", "stderr": ""}
+        with patch.object(adb_mod, "get_cms_value", return_value=get_result), \
+             patch.object(adb_mod, "set_cms_value", return_value=set_result) as mock_set:
+            result = adb_mod.adjust_cms_value("Red", "Hue", -2)
+        assert result["ok"] is True
+        assert result["old_value"] == 5
+        assert result["new_value"] == 3
+        mock_set.assert_called_once_with("Red", "Hue", 3, device=None)
+
+    def test_clamps_to_minimum(self):
+        """current=-8, delta=-5 → clamped to -10, not -13."""
+        get_result = {"ok": True, "value": -8, "stdout": "VALUE -8", "stderr": ""}
+        set_result = {"ok": True, "stdout": "OK", "stderr": ""}
+        with patch.object(adb_mod, "get_cms_value", return_value=get_result), \
+             patch.object(adb_mod, "set_cms_value", return_value=set_result) as mock_set:
+            result = adb_mod.adjust_cms_value("Red", "Hue", -5)
+        assert result["ok"] is True
+        assert result["new_value"] == -10
+        mock_set.assert_called_once_with("Red", "Hue", -10, device=None)
+
+    def test_clamps_to_maximum(self):
+        """current=9, delta=5 → clamped to 10, not 14."""
+        get_result = {"ok": True, "value": 9, "stdout": "VALUE 9", "stderr": ""}
+        set_result = {"ok": True, "stdout": "OK", "stderr": ""}
+        with patch.object(adb_mod, "get_cms_value", return_value=get_result), \
+             patch.object(adb_mod, "set_cms_value", return_value=set_result) as mock_set:
+            result = adb_mod.adjust_cms_value("Green", "Saturation", 5)
+        assert result["ok"] is True
+        assert result["new_value"] == 10
+        mock_set.assert_called_once_with("Green", "Saturation", 10, device=None)
+
+    def test_no_set_when_value_unchanged(self):
+        """current=3, delta=0 → no set call, returns ok with new_value=old_value."""
+        get_result = {"ok": True, "value": 3, "stdout": "VALUE 3", "stderr": ""}
+        with patch.object(adb_mod, "get_cms_value", return_value=get_result), \
+             patch.object(adb_mod, "set_cms_value") as mock_set:
+            result = adb_mod.adjust_cms_value("Blue", "Brightness", 0)
+        assert result["ok"] is True
+        assert result["old_value"] == 3
+        assert result["new_value"] == 3
+        mock_set.assert_not_called()
+
+    def test_returns_error_when_get_fails(self):
+        """get_cms_value failure → adjust returns ok=False without calling set."""
+        get_result = {"ok": False, "value": None, "stdout": "", "stderr": "no devices"}
+        with patch.object(adb_mod, "get_cms_value", return_value=get_result), \
+             patch.object(adb_mod, "set_cms_value") as mock_set:
+            result = adb_mod.adjust_cms_value("Red", "Hue", 1)
+        assert result["ok"] is False
+        mock_set.assert_not_called()
+
+    def test_returns_error_when_set_fails(self):
+        """get succeeds, set fails → adjust returns ok=False with old_value."""
+        get_result = {"ok": True, "value": 2, "stdout": "VALUE 2", "stderr": ""}
+        set_result = {"ok": False, "stdout": "", "stderr": "timeout"}
+        with patch.object(adb_mod, "get_cms_value", return_value=get_result), \
+             patch.object(adb_mod, "set_cms_value", return_value=set_result):
+            result = adb_mod.adjust_cms_value("Red", "Hue", 1)
+        assert result["ok"] is False
+        assert result["old_value"] == 2
+        assert result["new_value"] is None
+
+    def test_invalid_channel_raises(self):
+        with pytest.raises(ValueError, match="Unknown channel"):
+            adb_mod.adjust_cms_value("Purple", "Hue", 1)
+
+    def test_invalid_control_raises(self):
+        with pytest.raises(ValueError, match="Unknown control"):
+            adb_mod.adjust_cms_value("Red", "Tint", 1)
+
+    def test_passes_device_serial(self):
+        get_result = {"ok": True, "value": 0, "stdout": "VALUE 0", "stderr": ""}
+        set_result = {"ok": True, "stdout": "OK", "stderr": ""}
+        with patch.object(adb_mod, "get_cms_value", return_value=get_result), \
+             patch.object(adb_mod, "set_cms_value", return_value=set_result) as mock_set:
+            adb_mod.adjust_cms_value("Red", "Hue", 1, device="ABC123")
+        mock_set.assert_called_once_with("Red", "Hue", 1, device="ABC123")
+
+
+class TestAdbCmsAdjustEndpoint:
+    """Integration tests for POST /api/adb/cms/adjust."""
+
+    def test_valid_adjust_returns_ok(self, client):
+        get_result = {"ok": True, "value": 5, "stdout": "VALUE 5", "stderr": ""}
+        set_result = {"ok": True, "stdout": "OK", "stderr": ""}
+        with patch.object(adb_mod, "get_cms_value", return_value=get_result), \
+             patch.object(adb_mod, "set_cms_value", return_value=set_result):
+            r = client.post("/api/adb/cms/adjust",
+                            json={"channel": "Red", "control": "Hue", "delta": -2})
+        assert r.status_code == 200
+        body = r.json()
+        assert body["ok"] is True
+        assert body["old_value"] == 5
+        assert body["new_value"] == 3
+
+    def test_invalid_channel_returns_400(self, client):
+        r = client.post("/api/adb/cms/adjust",
+                        json={"channel": "Purple", "control": "Hue", "delta": 1})
+        assert r.status_code == 400
+
+    def test_invalid_control_returns_400(self, client):
+        r = client.post("/api/adb/cms/adjust",
+                        json={"channel": "Red", "control": "Tint", "delta": 1})
+        assert r.status_code == 400
+
+    def test_get_failure_returns_502(self, client):
+        get_result = {"ok": False, "value": None, "stdout": "", "stderr": "no devices"}
+        with patch.object(adb_mod, "get_cms_value", return_value=get_result):
+            r = client.post("/api/adb/cms/adjust",
+                            json={"channel": "Red", "control": "Hue", "delta": 1})
+        assert r.status_code == 502
+
+    def test_set_failure_returns_502(self, client):
+        get_result = {"ok": True, "value": 3, "stdout": "VALUE 3", "stderr": ""}
+        set_result = {"ok": False, "stdout": "", "stderr": "timeout"}
+        with patch.object(adb_mod, "get_cms_value", return_value=get_result), \
+             patch.object(adb_mod, "set_cms_value", return_value=set_result):
+            r = client.post("/api/adb/cms/adjust",
+                            json={"channel": "Red", "control": "Hue", "delta": 1})
+        assert r.status_code == 502
+
+    def test_all_channels_accepted(self, client):
+        get_result = {"ok": True, "value": 0, "stdout": "VALUE 0", "stderr": ""}
+        set_result = {"ok": True, "stdout": "OK", "stderr": ""}
+        for ch in adb_mod.CMS_CHANNELS:
+            with patch.object(adb_mod, "get_cms_value", return_value=get_result), \
+                 patch.object(adb_mod, "set_cms_value", return_value=set_result):
+                r = client.post("/api/adb/cms/adjust",
+                                json={"channel": ch, "control": "Hue", "delta": 0})
+            assert r.status_code == 200, f"Failed for channel {ch}"
+
+    def test_all_controls_accepted(self, client):
+        get_result = {"ok": True, "value": 0, "stdout": "VALUE 0", "stderr": ""}
+        set_result = {"ok": True, "stdout": "OK", "stderr": ""}
+        for ctrl in adb_mod.CMS_SET_ACTIONS:
+            with patch.object(adb_mod, "get_cms_value", return_value=get_result), \
+                 patch.object(adb_mod, "set_cms_value", return_value=set_result):
+                r = client.post("/api/adb/cms/adjust",
+                                json={"channel": "Red", "control": ctrl, "delta": 0})
+            assert r.status_code == 200, f"Failed for control {ctrl}"
+
+    def test_clamps_response_to_range(self, client):
+        """current=9, delta=5 → server clamps to 10 in response."""
+        get_result = {"ok": True, "value": 9, "stdout": "VALUE 9", "stderr": ""}
+        set_result = {"ok": True, "stdout": "OK", "stderr": ""}
+        with patch.object(adb_mod, "get_cms_value", return_value=get_result), \
+             patch.object(adb_mod, "set_cms_value", return_value=set_result):
+            r = client.post("/api/adb/cms/adjust",
+                            json={"channel": "Red", "control": "Hue", "delta": 5})
+        assert r.status_code == 200
+        assert r.json()["new_value"] == 10
+
+    def test_no_change_response(self, client):
+        """delta=0 and value unchanged → ok=true with no set call."""
+        get_result = {"ok": True, "value": 0, "stdout": "VALUE 0", "stderr": ""}
+        with patch.object(adb_mod, "get_cms_value", return_value=get_result), \
+             patch.object(adb_mod, "set_cms_value") as mock_set:
+            r = client.post("/api/adb/cms/adjust",
+                            json={"channel": "Red", "control": "Hue", "delta": 0})
+        assert r.status_code == 200
+        assert r.json()["old_value"] == 0
+        assert r.json()["new_value"] == 0
+        mock_set.assert_not_called()
+
+    def test_negative_delta_decreases_value(self, client):
+        get_result = {"ok": True, "value": 5, "stdout": "VALUE 5", "stderr": ""}
+        set_result = {"ok": True, "stdout": "OK", "stderr": ""}
+        with patch.object(adb_mod, "get_cms_value", return_value=get_result), \
+             patch.object(adb_mod, "set_cms_value", return_value=set_result):
+            r = client.post("/api/adb/cms/adjust",
+                            json={"channel": "Red", "control": "Hue", "delta": -3})
+        assert r.status_code == 200
+        assert r.json()["new_value"] == 2
+
+    def test_device_serial_forwarded(self, client):
+        get_result = {"ok": True, "value": 0, "stdout": "VALUE 0", "stderr": ""}
+        set_result = {"ok": True, "stdout": "OK", "stderr": ""}
+        with patch.object(adb_mod, "get_cms_value", return_value=get_result), \
+             patch.object(adb_mod, "set_cms_value", return_value=set_result) as mock_set:
+            r = client.post("/api/adb/cms/adjust",
+                            json={"channel": "Red", "control": "Hue", "delta": 1,
+                                  "device": "SERIAL42"})
+        assert r.status_code == 200
+        mock_set.assert_called_once_with("Red", "Hue", 1, device="SERIAL42")
+
+
 class TestAdbCmsResetEndpoint:
     def test_valid_reset(self, client):
         with patch.object(adb_mod, "reset_cms",


### PR DESCRIPTION
## 📺 Overview

Fixes a critical bug where the ColorTuner "Apply" button sent relative adjustments (±delta) to `/api/adb/cms/set`, which expects absolute values — causing the TV CMS register to be set to the delta value instead of adjusting from the current value.

Closes [#544](https://github.com/jweber93/tv-calibration/issues/544)

### What does this PR do?

-   **Type of change:** [x] Bug fix | [ ] New feature | [ ] Refactoring | [ ] CI/CD or Tooling
-   **Component(s) affected:** calibrator/adb_control.py, server.py, frontend/src/api/client.js, frontend/src/pages/ColorTuner.test.jsx

---

## 🛠️ Technical Context & Implementation

-   **The Problem:** The frontend treated the CMS write API as a relative increment (`POST /api/adb/cms/set` with `value = -2`), but the backend and TV API (`CmsTool set_hue <ch> <value>`) is an **absolute** set. With Red Hue at +5 and a plan saying "Lower by 2", clicking Apply would slam the register from +5 to -2 — a 7-click jump past the target. The correction loop could never converge, and "Apply all" compounded the error across Hue/Sat/Brightness.
-   **The Solution:** Added a new backend endpoint `/api/adb/cms/adjust` that performs an atomic read-modify-write:
    1. `get_cms_value(channel, control)` reads the current register value
    2. Computes `new = clamp(current + delta, -10, 10)`
    3. `set_cms_value(channel, control, new)` writes the clamped absolute value
    4. Returns `old_value` and `new_value` so the frontend can reflect changes
-   The existing `/api/adb/cms/set` endpoint is unchanged (still accepts absolute values for direct use cases).
-   The frontend `client.js` now routes `adbApply(channel, control, delta)` to the new adjust endpoint instead of set.
-   **Impact on existing workflows/APIs:** The `/api/adb/cms/set` endpoint is unchanged. A new `POST /api/adb/cms/adjust` endpoint is added. Frontend callers of `adbApply` now send a delta field that the backend interprets as relative.

---

## 🧪 Testing & Validation

### Environment Details

-   **OS / Target Display:** macOS (CI) / Hisense U8G (production)
-   **Hardware/Mock Used:** `unittest.mock.patch` for ADB calls; Vitest + React Testing Library for frontend

### Verification Steps

1.  Run `python3 -m pytest tests/test_adb_control.py` — **80 passed**
2.  Run `npx vitest run` (in frontend/) — **108 passed**

### Coverage of New Code

-   `adjust_cms_value` unit tests: adds delta, clamps min (-10), clamps max (+10), no-op when unchanged, get failure path, set failure path, invalid channel/control, device serial forwarding
-   `/api/adb/cms/adjust` endpoint tests: valid request returns ok with old/new values, invalid channel/control return 400, get/set failures return 502, all channels/controls accepted, clamping verified in response, no-change path, negative delta decreases value, device serial forwarded
-   ColorTuner frontend tests: Apply with direction=up sends positive delta, direction=down sends negative delta, Apply all skips hold steps, navigation/reset/deploy buttons render correctly

---

## 📸 Visual Evidence (UI / Plot Changes)

-   No UI layout changes — the Apply button behavior is now correct: clicking "Apply" on a plan step that says "Lower Hue by 2" when current value is +5 will set it to +3 (not -2).

---

## 🧼 Checklist

-    Code adheres to project style guidelines (formatting, typing, linting).
-    Unit tests added/updated and passing.
-    Documentation (README, inline docstrings) updated to reflect changes.
-    No credentials, local absolute paths, or hardware-specific hardcoding leaked.