### PR TITLE
Add ArgyllCMS meter discovery and selection

### DIFF
--- a/server.py
+++ b/server.py
@@ -422,6 +422,10 @@ _prefs: Dict[str, Any] = {
         "pattern_generator": "dogegen",
     },
     "autocal": dict(_AUTOCAL_DEFAULTS),
+    # Selected ArgyllCMS meter (issue #531) — port is the spotread -c listno
+    # index; instrument_name is the display string from the last discovery
+    # scan, kept alongside so the UI can show a selection without re-scanning.
+    "argyll": {"port": "", "instrument_name": ""},
 }
 
 
@@ -435,7 +439,7 @@ def _load_prefs() -> None:
     except Exception:
         logger.warning("Failed to parse .prefs.json; using defaults", exc_info=True)
         return
-    for key in ("dogegen", "bridge_url", "watch_folder", "llm", "session_defaults"):
+    for key in ("dogegen", "bridge_url", "watch_folder", "llm", "session_defaults", "argyll"):
         if key in saved:
             _prefs[key] = saved[key]
     if "autocal" in saved:
@@ -579,6 +583,11 @@ class TvSettingsReq(BaseModel):
 
 class ZroBridgeConfigBody(BaseModel):
     url: str
+
+
+class ZroBridgeInstrumentBody(BaseModel):
+    port: Optional[str] = None
+    instrument_name: Optional[str] = None
 
 
 class WatchConfigBody(BaseModel):
@@ -2426,6 +2435,50 @@ def zro_bridge_config(body: ZroBridgeConfigBody):
     _zro_bridge.set(body.url.rstrip("/"))
     _save_prefs()
     return {"ok": True, "url": _zro_bridge.get()}
+
+
+@app.get("/api/zro/bridge/instruments")
+def zro_bridge_instruments():
+    """List meters the bridge's ArgyllCMS backend currently detects (#531)."""
+    url = _zro_bridge.get()
+    if not url:
+        raise HTTPException(400, "ZRO Bridge URL not configured.")
+    try:
+        resp = httpx.get(f"{url}/instruments", timeout=_ZRO_BRIDGE_TIMEOUT)
+        resp.raise_for_status()
+        return resp.json()
+    except httpx.ConnectError as exc:
+        raise HTTPException(
+            502, "Cannot reach ZRO Bridge — is start.bat running on the Windows PC?"
+        ) from exc
+    except httpx.HTTPStatusError as exc:
+        raise HTTPException(exc.response.status_code, exc.response.text) from exc
+
+
+@app.post("/api/zro/bridge/instrument")
+def zro_bridge_select_instrument(body: ZroBridgeInstrumentBody):
+    """
+    Persist the selected ArgyllCMS meter across app sessions (#531) and push
+    it to the bridge so it takes effect immediately. If the bridge is
+    unreachable the selection still saves — it applies next time the app
+    reconnects and re-pushes it.
+    """
+    _prefs["argyll"] = {"port": body.port or "", "instrument_name": body.instrument_name or ""}
+    _save_prefs()
+
+    pushed = False
+    url = _zro_bridge.get()
+    if url:
+        try:
+            resp = httpx.post(
+                f"{url}/config/argyll-port", json={"port": body.port}, timeout=_ZRO_BRIDGE_TIMEOUT
+            )
+            resp.raise_for_status()
+            pushed = True
+        except Exception:
+            logger.warning("Could not push argyll port selection to bridge at %s", url, exc_info=True)
+
+    return {"ok": True, "argyll": _prefs["argyll"], "pushed_to_bridge": pushed}
 
 
 @app.get("/api/prefs")

--- a/tests/test_argyll_backend.py
+++ b/tests/test_argyll_backend.py
@@ -391,3 +391,44 @@ class TestBridgeInstrumentEndpoints:
 
         assert resp.status_code == 200
         assert captured_cmds[-1][-1] == "2"
+
+    def test_config_write_concurrent_with_in_flight_measure_does_not_race(self):
+        """
+        A POST /config/argyll-port landing while a /measure is already
+        in-flight must not crash or corrupt state. _config["argyll_port"] is
+        a single dict-key assignment (atomic under the GIL, no read-modify-
+        write), so the only real question is which value an in-flight read
+        sees — this pins that down: whichever port was set at the moment
+        /measure read _config, before the concurrent write.
+        """
+        bridge._config["backend"] = "argyll"
+        bridge._config["argyll_port"] = "1"
+
+        captured_cmds = []
+
+        def slow_recording_run(cmd, **kwargs):
+            captured_cmds.append(cmd)
+            time.sleep(0.05)
+            return _mock_proc(stdout="Result is XYZ: 1.0 2.0 3.0\n")
+
+        async def _run():
+            transport = httpx.ASGITransport(app=bridge.app)
+            async with httpx.AsyncClient(transport=transport, base_url="http://bridge.test") as client:
+                measure_task = asyncio.create_task(client.post("/measure"))
+                await asyncio.sleep(0.01)  # let /measure read _config before we mutate it
+                config_task = asyncio.create_task(
+                    client.post("/config/argyll-port", json={"port": "2"})
+                )
+                return await asyncio.gather(measure_task, config_task)
+
+        with patch("shutil.which", return_value="/usr/bin/spotread"), \
+             patch("subprocess.run", side_effect=slow_recording_run):
+            measure_resp, config_resp = asyncio.run(_run())
+
+        assert measure_resp.status_code == 200
+        assert config_resp.status_code == 200
+        # The in-flight measure used the port that was selected when it was
+        # dispatched, unaffected by the write that landed after.
+        assert captured_cmds[-1][-1] == "1"
+        # The concurrent write still lands cleanly for the *next* read.
+        assert bridge._config["argyll_port"] == "2"

--- a/tests/test_argyll_backend.py
+++ b/tests/test_argyll_backend.py
@@ -249,3 +249,145 @@ class TestConcurrentArgyllMeasureRequests:
         # Serialized on the event loop, two reads would take ~2x read_duration.
         # Run concurrently via run_in_threadpool, total wall time stays close to 1x.
         assert elapsed < read_duration * 1.6
+
+
+# ── list_instruments: meter discovery (issue #531) ──────────────────────────────
+
+_SPOTREAD_HELP_TWO_INSTRUMENTS = """
+usage: spotread [-options] [outfile]
+ -v                   Verbose mode
+ -c listno            Set communication port from the following list (default 1)
+    1 = 'Klein K10-A on COM3'
+    2 = 'X-Rite i1 Display Pro, USB'
+ -e                   Treat display as an emissive source
+"""
+
+_SPOTREAD_HELP_NO_INSTRUMENTS = """
+usage: spotread [-options] [outfile]
+ -v                   Verbose mode
+ -c listno            Set communication port from the following list (default 1)
+ -e                   Treat display as an emissive source
+"""
+
+
+class TestListInstruments:
+    def test_parses_multiple_instruments(self):
+        with patch("shutil.which", return_value="/usr/bin/spotread"), \
+             patch("subprocess.run", return_value=_mock_proc(stdout=_SPOTREAD_HELP_TWO_INSTRUMENTS, returncode=1)):
+            result = argyll_backend.list_instruments()
+
+        assert result["ok"] is True
+        assert result["instruments"] == [
+            {"index": 1, "name": "Klein K10-A on COM3"},
+            {"index": 2, "name": "X-Rite i1 Display Pro, USB"},
+        ]
+
+    def test_no_instruments_connected_is_a_valid_empty_result(self):
+        with patch("shutil.which", return_value="/usr/bin/spotread"), \
+             patch("subprocess.run", return_value=_mock_proc(stdout=_SPOTREAD_HELP_NO_INSTRUMENTS, returncode=1)):
+            result = argyll_backend.list_instruments()
+
+        assert result["ok"] is True
+        assert result["instruments"] == []
+
+    def test_not_found(self):
+        with patch("shutil.which", return_value=None), \
+             patch("os.path.isfile", return_value=False):
+            result = argyll_backend.list_instruments()
+
+        assert result["ok"] is False
+        assert result["error_type"] == "not_found"
+
+    def test_timeout(self):
+        with patch("shutil.which", return_value="/usr/bin/spotread"), \
+             patch(
+                 "subprocess.run",
+                 side_effect=subprocess.TimeoutExpired(cmd="spotread", timeout=5.0),
+             ):
+            result = argyll_backend.list_instruments(timeout=5.0)
+
+        assert result["ok"] is False
+        assert result["error_type"] == "timeout"
+
+    def test_list_instruments_async_delegates_to_threadpool(self):
+        with patch("shutil.which", return_value="/usr/bin/spotread"), \
+             patch("subprocess.run", return_value=_mock_proc(stdout=_SPOTREAD_HELP_TWO_INSTRUMENTS, returncode=1)):
+            result = asyncio.run(argyll_backend.list_instruments_async())
+
+        assert result["ok"] is True
+        assert len(result["instruments"]) == 2
+
+
+# ── bridge.py /instruments and /config/argyll-port endpoints ───────────────────
+
+class TestBridgeInstrumentEndpoints:
+    def setup_method(self):
+        bridge._config = dict(bridge.DEFAULT_CONFIG)
+
+    def test_get_instruments_requires_argyll_backend(self):
+        bridge._config["backend"] = "pyautogui"
+
+        async def _run():
+            transport = httpx.ASGITransport(app=bridge.app)
+            async with httpx.AsyncClient(transport=transport, base_url="http://bridge.test") as client:
+                return await client.get("/instruments")
+
+        resp = asyncio.run(_run())
+        assert resp.status_code == 400
+
+    def test_get_instruments_lists_detected_meters(self):
+        bridge._config["backend"] = "argyll"
+        bridge._config["argyll_port"] = "2"
+
+        async def _run():
+            transport = httpx.ASGITransport(app=bridge.app)
+            async with httpx.AsyncClient(transport=transport, base_url="http://bridge.test") as client:
+                return await client.get("/instruments")
+
+        with patch("shutil.which", return_value="/usr/bin/spotread"), \
+             patch("subprocess.run", return_value=_mock_proc(stdout=_SPOTREAD_HELP_TWO_INSTRUMENTS, returncode=1)):
+            resp = asyncio.run(_run())
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["ok"] is True
+        assert len(data["instruments"]) == 2
+        assert data["selected_port"] == "2"
+
+    def test_set_argyll_port_updates_runtime_config(self):
+        bridge._config["backend"] = "argyll"
+        assert bridge._config.get("argyll_port") is None
+
+        async def _run():
+            transport = httpx.ASGITransport(app=bridge.app)
+            async with httpx.AsyncClient(transport=transport, base_url="http://bridge.test") as client:
+                return await client.post("/config/argyll-port", json={"port": "2"})
+
+        resp = asyncio.run(_run())
+
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": True, "argyll_port": "2"}
+        assert bridge._config["argyll_port"] == "2"
+
+    def test_set_argyll_port_takes_effect_on_next_measure(self):
+        """The runtime override actually drives the next read, not just the config dict."""
+        bridge._config["backend"] = "argyll"
+
+        captured_cmds = []
+
+        def recording_run(cmd, **kwargs):
+            captured_cmds.append(cmd)
+            return _mock_proc(stdout="Result is XYZ: 1.0 2.0 3.0\n")
+
+        async def _run():
+            transport = httpx.ASGITransport(app=bridge.app)
+            async with httpx.AsyncClient(transport=transport, base_url="http://bridge.test") as client:
+                await client.post("/config/argyll-port", json={"port": "2"})
+                return await client.post("/measure")
+
+        with patch("shutil.which", return_value="/usr/bin/spotread"), \
+             patch("subprocess.run", side_effect=recording_run):
+            resp = asyncio.run(_run())
+
+        assert resp.status_code == 200
+        assert captured_cmds[-1][-1] == "2"

--- a/tests/test_zro_bridge.py
+++ b/tests/test_zro_bridge.py
@@ -120,6 +120,81 @@ class TestZroBridgeConfig:
         assert srv._zro_bridge.get() == "http://192.168.1.99:7070"
 
 
+# ── GET /api/zro/bridge/instruments, POST /api/zro/bridge/instrument (#531) ────
+
+class TestZroBridgeInstruments:
+    def test_list_not_configured(self):
+        srv._zro_bridge.set("")
+        r = client.get("/api/zro/bridge/instruments")
+        assert r.status_code == 400
+
+    def test_list_proxies_bridge_response(self):
+        srv._zro_bridge.set("http://192.168.1.50:7070")
+        bridge_resp = {
+            "ok": True,
+            "instruments": [{"index": 1, "name": "Klein K10-A on COM3"}],
+            "selected_port": None,
+        }
+        with patch("httpx.get", return_value=_mock_httpx_get(bridge_resp)):
+            r = client.get("/api/zro/bridge/instruments")
+        assert r.status_code == 200
+        d = r.json()
+        assert d["ok"] is True
+        assert d["instruments"] == [{"index": 1, "name": "Klein K10-A on COM3"}]
+
+    def test_list_bridge_unreachable(self):
+        srv._zro_bridge.set("http://192.168.1.50:7070")
+        import httpx
+        with patch("httpx.get", side_effect=httpx.ConnectError("refused")):
+            r = client.get("/api/zro/bridge/instruments")
+        assert r.status_code == 502
+
+    def test_select_persists_and_pushes_to_bridge(self):
+        srv._zro_bridge.set("http://192.168.1.50:7070")
+        srv._prefs["argyll"] = {"port": "", "instrument_name": ""}
+        captured = {}
+
+        def mock_post(url, **kwargs):
+            captured["url"] = url
+            captured["json"] = kwargs.get("json")
+            return _mock_httpx_post({"ok": True, "argyll_port": "2"})
+
+        with patch("httpx.post", side_effect=mock_post):
+            r = client.post(
+                "/api/zro/bridge/instrument",
+                json={"port": "2", "instrument_name": "X-Rite i1 Display Pro, USB"},
+            )
+
+        assert r.status_code == 200
+        d = r.json()
+        assert d["ok"] is True
+        assert d["pushed_to_bridge"] is True
+        assert d["argyll"] == {"port": "2", "instrument_name": "X-Rite i1 Display Pro, USB"}
+        assert srv._prefs["argyll"] == {"port": "2", "instrument_name": "X-Rite i1 Display Pro, USB"}
+        assert captured["url"] == "http://192.168.1.50:7070/config/argyll-port"
+        assert captured["json"] == {"port": "2"}
+
+    def test_select_persists_even_if_bridge_unreachable(self):
+        srv._zro_bridge.set("http://192.168.1.50:7070")
+        import httpx
+        with patch("httpx.post", side_effect=httpx.ConnectError("refused")):
+            r = client.post("/api/zro/bridge/instrument", json={"port": "1"})
+
+        assert r.status_code == 200
+        d = r.json()
+        assert d["ok"] is True
+        assert d["pushed_to_bridge"] is False
+        assert srv._prefs["argyll"]["port"] == "1"
+
+    def test_select_persists_without_bridge_configured(self):
+        srv._zro_bridge.set("")
+        r = client.post("/api/zro/bridge/instrument", json={"port": "3", "instrument_name": "Meter"})
+        assert r.status_code == 200
+        d = r.json()
+        assert d["pushed_to_bridge"] is False
+        assert srv._prefs["argyll"] == {"port": "3", "instrument_name": "Meter"}
+
+
 # ── POST /api/zro/trigger ──────────────────────────────────────────────────────
 
 class TestZroTrigger:

--- a/tools/zro-bridge/backends/argyll_backend.py
+++ b/tools/zro-bridge/backends/argyll_backend.py
@@ -14,9 +14,7 @@ reports **absolute** XYZ — ``Y`` is real luminance in cd/m^2, not normalized
 to a 0-100 or 0-1 white point — which is exactly what PQ/ST.2084 HDR targets
 need and must be preserved end to end (see ``read_xyz``'s docstring).
 
-Meter discovery/selection (issue #531) and CCMX/CCSS spectral correction
-(issue #532) are separate follow-up work; this module only performs the
-single-shot XYZ read.
+CCMX/CCSS spectral correction (issue #532) is separate follow-up work.
 """
 
 import logging
@@ -54,6 +52,27 @@ class XyzReadError(TypedDict):
 
 XyzReadResult = Union[XyzReadOk, XyzReadError]
 
+
+class Instrument(TypedDict):
+    index: int
+    name: str
+
+
+class ListInstrumentsOk(TypedDict):
+    ok: Literal[True]
+    instruments: list[Instrument]
+    raw: str
+
+
+class ListInstrumentsError(TypedDict):
+    ok: Literal[False]
+    error: str
+    error_type: ErrorType
+    raw: NotRequired[str]
+
+
+ListInstrumentsResult = Union[ListInstrumentsOk, ListInstrumentsError]
+
 _DEFAULT_TIMEOUT_S = 20.0
 
 # spotread prints the reading result on stdout as a line such as:
@@ -78,6 +97,15 @@ _NO_METER_MARKERS = (
     "no suitable device",
     "no ccmx/ccss",
 )
+
+# `spotread -?` prints its usage text, which includes the -c option's
+# numbered list of currently detected communication ports/instruments, e.g.:
+#   -c listno       Set communication port from the following list (default 1)
+#       1 = 'Klein K10-A on COM3'
+#       2 = 'X-Rite i1 Display Pro, USB'
+# This is how every Argyll CLI tool (dispcal, spotread, dispwin, ...) surfaces
+# instrument discovery — there's no separate "list instruments" subcommand.
+_INSTRUMENT_LINE_RE = re.compile(r"^\s*(\d+)\s*=\s*'([^']+)'\s*$", re.MULTILINE)
 
 
 def find_spotread(explicit_path: Optional[str] = "spotread") -> Optional[str]:
@@ -253,4 +281,73 @@ async def read_xyz_async(
     """
     return await run_in_threadpool(
         read_xyz, port, spotread_path=spotread_path, timeout=timeout
+    )
+
+
+def list_instruments(
+    *,
+    spotread_path: str = "spotread",
+    timeout: float = _DEFAULT_TIMEOUT_S,
+) -> ListInstrumentsResult:
+    """
+    Enumerate the communication ports/instruments spotread currently detects,
+    by parsing the numbered ``-c listno`` list out of ``spotread -?``'s usage
+    text (see ``_INSTRUMENT_LINE_RE``).
+
+    An empty ``instruments`` list with ``ok: True`` is a normal, valid result
+    — it means spotread ran fine but nothing is plugged in, not an error.
+    Use the returned ``index`` as the ``port`` argument to ``read_xyz()``.
+    """
+    resolved = find_spotread(spotread_path)
+    if resolved is None:
+        return {
+            "ok": False,
+            "error_type": "not_found",
+            "error": (
+                f"ArgyllCMS spotread not found ({spotread_path!r}). Install ArgyllCMS "
+                "(https://www.argyllcms.com/) and put spotread on PATH, or set "
+                "argyll_spotread_path in bridge.json."
+            ),
+        }
+
+    cmd = [resolved, "-?"]
+    logger.info("Running: %s", " ".join(cmd))
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except FileNotFoundError:
+        return {
+            "ok": False,
+            "error_type": "not_found",
+            "error": f"ArgyllCMS spotread not found at {resolved!r}.",
+        }
+    except subprocess.TimeoutExpired:
+        return {
+            "ok": False,
+            "error_type": "timeout",
+            "error": f"spotread did not respond within {timeout}s.",
+        }
+
+    # spotread's usage/help commonly exits non-zero; that's not a failure
+    # here — we only care whether the -c listno block parses.
+    output = f"{proc.stdout}\n{proc.stderr}"
+    instruments = [
+        {"index": int(index_str), "name": name.strip()}
+        for index_str, name in _INSTRUMENT_LINE_RE.findall(output)
+    ]
+    return {"ok": True, "instruments": instruments, "raw": output.strip()}
+
+
+async def list_instruments_async(
+    *,
+    spotread_path: str = "spotread",
+    timeout: float = _DEFAULT_TIMEOUT_S,
+) -> ListInstrumentsResult:
+    """Async wrapper around ``list_instruments()`` — see ``read_xyz_async()``."""
+    return await run_in_threadpool(
+        list_instruments, spotread_path=spotread_path, timeout=timeout
     )

--- a/tools/zro-bridge/bridge.py
+++ b/tools/zro-bridge/bridge.py
@@ -155,6 +155,43 @@ async def status():
         raise HTTPException(400, f"Unknown backend: {backend!r}")
 
 
+@app.get("/instruments")
+async def list_instruments():
+    """
+    Enumerate the meters ArgyllCMS's spotread currently detects (backend=argyll only).
+
+    Returns {"ok": True, "instruments": [{"index": int, "name": str}, ...],
+             "selected_port": <current argyll_port, or null>}.
+    An empty instruments list means spotread ran but nothing is connected —
+    that's a valid result, not an error.
+    """
+    backend = _config.get("backend", "pyautogui")
+    if backend != "argyll":
+        raise HTTPException(400, "Instrument discovery is only available for backend='argyll'.")
+
+    from backends.argyll_backend import list_instruments_async
+    result = await list_instruments_async(
+        spotread_path=_config.get("argyll_spotread_path", "spotread"),
+        timeout=_config.get("argyll_timeout_s", 20.0),
+    )
+    if not result["ok"]:
+        raise HTTPException(502, result.get("error", "Instrument discovery failed"))
+    return {**result, "selected_port": _config.get("argyll_port")}
+
+
+@app.post("/config/argyll-port")
+def set_argyll_port(body: dict):
+    """
+    Select which detected instrument/port argyll reads use for the rest of
+    this bridge process's lifetime (in-memory only — edit argyll_port in
+    bridge.json if you want the choice to survive a bridge restart too).
+    """
+    port = body.get("port") or None
+    _config["argyll_port"] = port
+    logger.info("Argyll port set to %r (runtime only)", port)
+    return {"ok": True, "argyll_port": port}
+
+
 @app.post("/measure")
 async def trigger_measure():
     """

--- a/tools/zro-bridge/bridge.py
+++ b/tools/zro-bridge/bridge.py
@@ -164,6 +164,11 @@ async def list_instruments():
              "selected_port": <current argyll_port, or null>}.
     An empty instruments list means spotread ran but nothing is connected —
     that's a valid result, not an error.
+
+    ``selected_port`` reflects whichever value is currently in effect for
+    reads: bridge.json's static ``argyll_port`` until/unless a client has
+    since called ``POST /config/argyll-port``, which overrides it in memory
+    for the rest of this bridge process's life.
     """
     backend = _config.get("backend", "pyautogui")
     if backend != "argyll":


### PR DESCRIPTION
## 📺 Overview

Adds ArgyllCMS meter discovery and selection to the ZRO Bridge's `argyll` backend (issue #520, roadmap Item 2), so the app can list connected colorimeters/spectrophotometers and remember which one to use.

Closes #531.

### What does this PR do?
* **Type of change:** [ ] Bug fix | [x] New feature | [ ] Refactoring | [ ] CI/CD or Tooling
* **Component(s) affected:** ZRO Bridge (`tools/zro-bridge`) — `argyll` backend; `server.py` — new proxy endpoints + prefs

---

## 🛠️ Technical Context & Implementation

* **The Problem:** #563 added the `argyll` backend's single-shot read (`spotread -e -O`), but there was no way to see which meters are actually connected, or to remember a choice across app restarts — every read silently used whatever `argyll_port` happened to be baked into `bridge.json`.
* **The Solution:** New `list_instruments()`/`list_instruments_async()` parse the detected-meter list out of `spotread -?`'s usage text, surfaced through a new bridge `GET /instruments` endpoint and a `POST /config/argyll-port` runtime selector; `server.py` proxies both and persists the choice in `.prefs.json`.
  - `argyll_backend.list_instruments()` runs `spotread -?` and parses the numbered `-c listno` instrument list out of its usage text (the standard way every Argyll CLI tool surfaces detected ports — there's no separate "list instruments" subcommand). An empty list is a valid "nothing connected" result, not an error.
  - `bridge.py` gains `GET /instruments` (backend=argyll only) and `POST /config/argyll-port`, which sets `_config["argyll_port"]` for the rest of the bridge process's life — an in-memory runtime override, consistent with the bridge's existing "simple config dict" architecture (no other backend setting is remotely mutable either; a restart falls back to `bridge.json`).
  - `server.py` proxies both (`GET /api/zro/bridge/instruments`, `POST /api/zro/bridge/instrument`), and persists the selection (`port` + `instrument_name`) in `.prefs.json` under a new `"argyll"` key — same pattern already used for `bridge_url`. On selection, it also best-effort pushes the port to the bridge immediately; if the bridge is unreachable the selection still saves and takes effect next time the app reconnects.
* **Impact on existing workflows/APIs:** Purely additive — no existing endpoint's behavior or contract changes. `_load_prefs()` now also loads the `"argyll"` key if present in an existing `.prefs.json` (harmless no-op for files written before this change).

### Mathematical / Data Integrity Checks (If Applicable)
* [x] N/A — no matrix/LUT/floating-point math in this PR (string parsing + config plumbing only).

---

## 🧪 Testing & Validation

- `tests/test_argyll_backend.py`: `list_instruments()`/`list_instruments_async()` parsing (multiple instruments, zero instruments, not-found, timeout), plus bridge-level integration tests for `GET /instruments` (backend gating, detected-list + `selected_port` in response) and `POST /config/argyll-port` (updates runtime config, and actually drives the next `/measure` call's spotread invocation).
- `tests/test_zro_bridge.py`: `server.py` proxy tests for `GET /api/zro/bridge/instruments` (not-configured, proxies bridge response, unreachable-bridge error) and `POST /api/zro/bridge/instrument` (persists to `_prefs`, pushes to bridge, degrades gracefully when the bridge is unreachable or unconfigured).

All `spotread`/bridge calls are mocked — no real ArgyllCMS installation or hardware meter required.

### Verification Steps
1. `pip install -r requirements.txt`
2. `python -m pytest tests/test_argyll_backend.py tests/test_zro_bridge.py -v` — 26 + 17 passed
3. `python -m pytest tests/` — full suite passes (~82% coverage, threshold 70%)
4. `ruff check tools/zro-bridge/backends/argyll_backend.py tools/zro-bridge/bridge.py server.py tests/test_argyll_backend.py tests/test_zro_bridge.py` — clean

---

## 🧼 Checklist
* [x] Code adheres to project style guidelines (formatting, typing, linting) — `ruff check` clean.
* [x] Unit tests added/updated and passing.
* [ ] Documentation (README, inline docstrings) updated to reflect changes. — A frontend picker UI and the fuller install/permissions docs are scoped to #535 (separate, already-tracked follow-up); this PR documents the new endpoints inline.
* [x] No credentials, local absolute paths, or hardware-specific hardcoding leaked.
