### PR TITLE
[Argyll 2f] Prefs + install/permissions docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,9 @@ Each session moves through nine sequential steps. You can jump back to any compl
 ### Software
 
 - **Python 3.11+**
-- **ColourSpace ZRO** or **ColourSpace Zero** (measurement software) — [LightIllusion](https://www.lightillusion.com/)
+- A measurement backend — either:
+  - **ColourSpace ZRO** or **ColourSpace Zero** (paid) — [LightIllusion](https://www.lightillusion.com/), triggered via the ZRO Bridge, or
+  - **ArgyllCMS** (free, open-source) — [argyllcms.com](https://www.argyllcms.com/), read directly via the Bridge's `spotread` backend (see [ArgyllCMS Direct-Meter Backend](#argyllcms-direct-meter-backend-no-paid-products) — no ColourSpace license required)
 - A modern browser (Chrome or Edge recommended)
 
 ### Hardware
@@ -141,7 +143,7 @@ One of the following pattern generator setups:
 | **Dogegen** | PC application that generates HDR10 test patterns over HDMI. Recommended for HDR10 calibration on Windows. |
 | **LightSpace Connect** | Apple TV app that sends patches from ColourSpace. Free tier supports up to 25 patches; paid tier is unlimited. |
 
-A colorimeter or spectrophotometer supported by ColourSpace ZRO (i1Display, Colorimetry Research, Klein K10-A, etc.).
+A colorimeter or spectrophotometer supported by ColourSpace ZRO or ArgyllCMS (i1Display, i1Pro, Colorimetry Research, Klein K10-A, etc.).
 
 ---
 
@@ -356,6 +358,68 @@ The ZRO Bridge lets ColourSpace ZRO trigger a measurement from within the app wo
 The Bridge status indicator in the header bar shows whether the connection is live (green) or unreachable (red).
 
 > **Note — Remote Control backend:** The `tools/zro-bridge/backends/remote_control_backend.py` stub is **experimental and not ready for use**. The Light Illusion Integration Protocol format has not been obtained, so `trigger_measurement()` always returns an error. The webhook path (above) is the working integration method.
+
+### ArgyllCMS Direct-Meter Backend (No Paid Products)
+
+The Bridge can read a colorimeter or spectrophotometer **directly via [ArgyllCMS](https://www.argyllcms.com/)'s `spotread`**, instead of triggering ColourSpace ZRO. This removes ZRO/ColourSpace from the measurement loop entirely — useful if you don't have a ColourSpace license, since ArgyllCMS is free and open-source. Supported meters include i1Display, i1Pro, Klein K10-A, and Colorimetry Research devices.
+
+**1. Install ArgyllCMS**
+
+Download a release from [argyllcms.com](https://www.argyllcms.com/) (or your distro's `argyll` package) and make sure `spotread` is reachable:
+
+```bash
+# Linux/macOS: unpack the release, then either add its bin/ dir to PATH,
+# or point bridge.json at the full executable path (see below).
+spotread -? # should print usage/help, not "command not found"
+```
+
+**2. Linux meter permissions (udev)**
+
+On Linux, USB meters usually aren't readable by a normal user until udev grants access. ArgyllCMS's release archive ships udev rule files under its `usb/` (or `linux/`) subdirectory (e.g. `55-Argyll.rules`):
+
+```bash
+sudo cp <argyll-release-dir>/usb/*.rules /etc/udev/rules.d/
+sudo udevadm control --reload-rules
+sudo udevadm trigger
+# Unplug and replug the meter so the new rule takes effect.
+```
+
+If `spotread -?` still can't see the instrument after that, unplug/replug once more, or add your user to the group the rule assigns (commonly `plugdev`) and re-login. Windows and macOS don't need this step — Windows uses the instrument driver bundled with the ArgyllCMS installer, and macOS meters work over the standard USB HID/serial stack.
+
+**3. Select the backend in `bridge.json`**
+
+Copy `tools/zro-bridge/bridge.example.json` to `bridge.json` and set:
+
+```json
+{
+  "backend": "argyll",
+  "argyll_spotread_path": "spotread",
+  "argyll_port": null,
+  "argyll_timeout_s": 20.0,
+  "argyll_correction": null
+}
+```
+
+- `argyll_spotread_path` — leave as `"spotread"` to resolve via PATH, or set a full path if it isn't on PATH.
+- `argyll_port` — the serial/USB port `spotread -c` should use. Leave `null` to auto-detect (most USB meters); set it explicitly if you have multiple meters attached.
+- `argyll_correction` — path to a CCMX/CCSS meter-correction file (see below).
+
+**4. Meter discovery and selection**
+
+With `backend: "argyll"` and the Bridge running, the app can list and persist which detected instrument to use:
+
+```
+GET  /api/zro/bridge/instruments   → { instruments: [{index, name}, ...], selected_port, correction_path }
+POST /api/zro/bridge/instrument    { port, instrument_name?, correction_path? }
+```
+
+The selection (and correction path) is saved to the app's `.prefs.json` (`argyll.port` / `argyll.instrument_name` / `argyll.correction_path`) so it survives app restarts, and is pushed to the Bridge immediately if it's reachable; if the Bridge is offline the choice still saves and is re-applied the next time the app reconnects.
+
+**5. CCMX/CCSS meter correction**
+
+Modern wide-gamut panels (QD-OLED, WOLED, QD-LCD) need a per-panel spectral correction for **colorimeters** (i1Display and similar) to read accurately — spectrophotometers (i1Pro) do not need one. Acquire a `.ccmx`/`.ccss` file for your meter/panel combination and set its path via `argyll_correction` in `bridge.json` or `correction_path` in the `POST /api/zro/bridge/instrument` call above. If a colorimeter takes a reading with no correction configured, `spotread`'s output is checked for a missing-correction warning and it's surfaced back through the reading result (`warning` field) rather than failing silently.
+
+**Graceful "ArgyllCMS not found" handling** — if `spotread` isn't on PATH/at the configured path, or no meter is detected, `GET /api/zro/bridge/status` still returns `200` with `spotread_found: false` (or a `no_meter` error type from a triggered read) and a human-readable message instead of a crash, so the UI can show a clear "install ArgyllCMS" / "check the meter connection" prompt rather than a generic failure.
 
 ### Dogegen Integration
 
@@ -849,3 +913,5 @@ SSE stream (`GET /api/session/{sid}/llm/stream`) now emits two event types:
 | **ZRO** | ColourSpace ZRO / Zero — the measurement software by LightIllusion that drives colorimeters and exports CSV data. |
 | **Dogegen** | A Windows pattern generator application that sends HDR10 test patches over HDMI. |
 | **LightSpace Connect** | An Apple TV app that pairs with ColourSpace to generate patches via an Apple TV connected to the display. |
+| **ArgyllCMS / `spotread`** | Free, open-source color management tools; `spotread` takes single-shot meter readings directly, letting the Bridge measure without ColourSpace/ZRO. |
+| **CCMX/CCSS** | ArgyllCMS meter-correction file formats — a per-meter, per-panel spectral correction colorimeters need for accurate readings on wide-gamut panels. |

--- a/server.py
+++ b/server.py
@@ -425,7 +425,10 @@ _prefs: Dict[str, Any] = {
     # Selected ArgyllCMS meter (issue #531) — port is the spotread -c listno
     # index; instrument_name is the display string from the last discovery
     # scan, kept alongside so the UI can show a selection without re-scanning.
-    "argyll": {"port": "", "instrument_name": ""},
+    # correction_path (issue #535) is the CCMX/CCSS meter-correction file
+    # passed through to spotread -X; colorimeters need one on wide-gamut
+    # panels, spectrophotometers (i1Pro) don't.
+    "argyll": {"port": "", "instrument_name": "", "correction_path": ""},
 }
 
 
@@ -588,6 +591,7 @@ class ZroBridgeConfigBody(BaseModel):
 class ZroBridgeInstrumentBody(BaseModel):
     port: Optional[str] = None
     instrument_name: Optional[str] = None
+    correction_path: Optional[str] = None
 
 
 class WatchConfigBody(BaseModel):
@@ -2458,12 +2462,16 @@ def zro_bridge_instruments():
 @app.post("/api/zro/bridge/instrument")
 def zro_bridge_select_instrument(body: ZroBridgeInstrumentBody):
     """
-    Persist the selected ArgyllCMS meter across app sessions (#531) and push
-    it to the bridge so it takes effect immediately. If the bridge is
-    unreachable the selection still saves — it applies next time the app
-    reconnects and re-pushes it.
+    Persist the selected ArgyllCMS meter and CCMX/CCSS correction path
+    across app sessions (#531, #535) and push them to the bridge so they
+    take effect immediately. If the bridge is unreachable the selection
+    still saves — it applies next time the app reconnects and re-pushes it.
     """
-    _prefs["argyll"] = {"port": body.port or "", "instrument_name": body.instrument_name or ""}
+    _prefs["argyll"] = {
+        "port": body.port or "",
+        "instrument_name": body.instrument_name or "",
+        "correction_path": body.correction_path or "",
+    }
     _save_prefs()
 
     pushed = False
@@ -2471,7 +2479,9 @@ def zro_bridge_select_instrument(body: ZroBridgeInstrumentBody):
     if url:
         try:
             resp = httpx.post(
-                f"{url}/config/argyll-port", json={"port": body.port}, timeout=_ZRO_BRIDGE_TIMEOUT
+                f"{url}/config/argyll-port",
+                json={"port": body.port, "correction_path": body.correction_path},
+                timeout=_ZRO_BRIDGE_TIMEOUT,
             )
             resp.raise_for_status()
             pushed = True

--- a/tests/test_argyll_backend.py
+++ b/tests/test_argyll_backend.py
@@ -437,6 +437,62 @@ class TestBridgeInstrumentEndpoints:
         assert resp.json() == {"ok": True, "argyll_port": "2"}
         assert bridge._config["argyll_port"] == "2"
 
+    def test_set_argyll_correction_path_updates_runtime_config(self):
+        bridge._config["backend"] = "argyll"
+        assert bridge._config.get("argyll_correction") is None
+
+        async def _run():
+            transport = httpx.ASGITransport(app=bridge.app)
+            async with httpx.AsyncClient(transport=transport, base_url="http://bridge.test") as client:
+                return await client.post(
+                    "/config/argyll-port",
+                    json={"port": "2", "correction_path": "/etc/argyll/i1d3.ccss"},
+                )
+
+        resp = asyncio.run(_run())
+
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "ok": True,
+            "argyll_port": "2",
+            "argyll_correction": "/etc/argyll/i1d3.ccss",
+        }
+        assert bridge._config["argyll_port"] == "2"
+        assert bridge._config["argyll_correction"] == "/etc/argyll/i1d3.ccss"
+
+    def test_set_argyll_port_omits_correction_key_when_not_given(self):
+        """Omitting correction_path leaves the existing correction untouched
+        and the response doesn't grow an unrequested key (back-compat)."""
+        bridge._config["backend"] = "argyll"
+        bridge._config["argyll_correction"] = "/etc/argyll/existing.ccmx"
+
+        async def _run():
+            transport = httpx.ASGITransport(app=bridge.app)
+            async with httpx.AsyncClient(transport=transport, base_url="http://bridge.test") as client:
+                return await client.post("/config/argyll-port", json={"port": "3"})
+
+        resp = asyncio.run(_run())
+
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": True, "argyll_port": "3"}
+        assert bridge._config["argyll_correction"] == "/etc/argyll/existing.ccmx"
+
+    def test_instruments_reports_selected_correction_path(self):
+        bridge._config["backend"] = "argyll"
+        bridge._config["argyll_correction"] = "/etc/argyll/i1d3.ccss"
+
+        async def _run():
+            transport = httpx.ASGITransport(app=bridge.app)
+            async with httpx.AsyncClient(transport=transport, base_url="http://bridge.test") as client:
+                return await client.get("/instruments")
+
+        with patch("shutil.which", return_value="/usr/bin/spotread"), \
+             patch("subprocess.run", return_value=_mock_proc(stdout=_SPOTREAD_HELP_TWO_INSTRUMENTS, returncode=1)):
+            resp = asyncio.run(_run())
+
+        assert resp.status_code == 200
+        assert resp.json()["correction_path"] == "/etc/argyll/i1d3.ccss"
+
     def test_set_argyll_port_takes_effect_on_next_measure(self):
         """The runtime override actually drives the next read, not just the config dict."""
         bridge._config["backend"] = "argyll"

--- a/tests/test_zro_bridge.py
+++ b/tests/test_zro_bridge.py
@@ -151,7 +151,7 @@ class TestZroBridgeInstruments:
 
     def test_select_persists_and_pushes_to_bridge(self):
         srv._zro_bridge.set("http://192.168.1.50:7070")
-        srv._prefs["argyll"] = {"port": "", "instrument_name": ""}
+        srv._prefs["argyll"] = {"port": "", "instrument_name": "", "correction_path": ""}
         captured = {}
 
         def mock_post(url, **kwargs):
@@ -162,17 +162,29 @@ class TestZroBridgeInstruments:
         with patch("httpx.post", side_effect=mock_post):
             r = client.post(
                 "/api/zro/bridge/instrument",
-                json={"port": "2", "instrument_name": "X-Rite i1 Display Pro, USB"},
+                json={
+                    "port": "2",
+                    "instrument_name": "X-Rite i1 Display Pro, USB",
+                    "correction_path": "/etc/argyll/i1d3.ccss",
+                },
             )
 
         assert r.status_code == 200
         d = r.json()
         assert d["ok"] is True
         assert d["pushed_to_bridge"] is True
-        assert d["argyll"] == {"port": "2", "instrument_name": "X-Rite i1 Display Pro, USB"}
-        assert srv._prefs["argyll"] == {"port": "2", "instrument_name": "X-Rite i1 Display Pro, USB"}
+        assert d["argyll"] == {
+            "port": "2",
+            "instrument_name": "X-Rite i1 Display Pro, USB",
+            "correction_path": "/etc/argyll/i1d3.ccss",
+        }
+        assert srv._prefs["argyll"] == {
+            "port": "2",
+            "instrument_name": "X-Rite i1 Display Pro, USB",
+            "correction_path": "/etc/argyll/i1d3.ccss",
+        }
         assert captured["url"] == "http://192.168.1.50:7070/config/argyll-port"
-        assert captured["json"] == {"port": "2"}
+        assert captured["json"] == {"port": "2", "correction_path": "/etc/argyll/i1d3.ccss"}
 
     def test_select_persists_even_if_bridge_unreachable(self):
         srv._zro_bridge.set("http://192.168.1.50:7070")
@@ -192,7 +204,7 @@ class TestZroBridgeInstruments:
         assert r.status_code == 200
         d = r.json()
         assert d["pushed_to_bridge"] is False
-        assert srv._prefs["argyll"] == {"port": "3", "instrument_name": "Meter"}
+        assert srv._prefs["argyll"] == {"port": "3", "instrument_name": "Meter", "correction_path": ""}
 
 
 # ── POST /api/zro/trigger ──────────────────────────────────────────────────────

--- a/tools/zro-bridge/bridge.py
+++ b/tools/zro-bridge/bridge.py
@@ -165,14 +165,16 @@ async def list_instruments():
     Enumerate the meters ArgyllCMS's spotread currently detects (backend=argyll only).
 
     Returns {"ok": True, "instruments": [{"index": int, "name": str}, ...],
-             "selected_port": <current argyll_port, or null>}.
+             "selected_port": <current argyll_port, or null>,
+             "correction_path": <current argyll_correction, or null>}.
     An empty instruments list means spotread ran but nothing is connected —
     that's a valid result, not an error.
 
-    ``selected_port`` reflects whichever value is currently in effect for
-    reads: bridge.json's static ``argyll_port`` until/unless a client has
-    since called ``POST /config/argyll-port``, which overrides it in memory
-    for the rest of this bridge process's life.
+    ``selected_port`` and ``correction_path`` reflect whichever values are
+    currently in effect for reads: bridge.json's static ``argyll_port`` /
+    ``argyll_correction`` until/unless a client has since called
+    ``POST /config/argyll-port``, which overrides them in memory for the
+    rest of this bridge process's life.
     """
     backend = _config.get("backend", "pyautogui")
     if backend != "argyll":
@@ -185,20 +187,34 @@ async def list_instruments():
     )
     if not result["ok"]:
         raise HTTPException(502, result.get("error", "Instrument discovery failed"))
-    return {**result, "selected_port": _config.get("argyll_port")}
+    return {
+        **result,
+        "selected_port": _config.get("argyll_port"),
+        "correction_path": _config.get("argyll_correction"),
+    }
 
 
 @app.post("/config/argyll-port")
 def set_argyll_port(body: dict):
     """
-    Select which detected instrument/port argyll reads use for the rest of
-    this bridge process's lifetime (in-memory only — edit argyll_port in
-    bridge.json if you want the choice to survive a bridge restart too).
+    Select which detected instrument/port argyll reads use, and optionally
+    its CCMX/CCSS correction file path, for the rest of this bridge
+    process's lifetime (in-memory only — edit argyll_port / argyll_correction
+    in bridge.json if you want the choice to survive a bridge restart too).
+
+    Body: {"port": <str|null>, "correction_path"?: <str|null>}. The
+    ``correction_path`` key is optional — omit it to change the port only.
     """
     port = body.get("port") or None
     _config["argyll_port"] = port
     logger.info("Argyll port set to %r (runtime only)", port)
-    return {"ok": True, "argyll_port": port}
+    response = {"ok": True, "argyll_port": port}
+    if "correction_path" in body:
+        correction_path = body.get("correction_path") or None
+        _config["argyll_correction"] = correction_path
+        logger.info("Argyll correction path set to %r (runtime only)", correction_path)
+        response["argyll_correction"] = correction_path
+    return response
 
 
 @app.post("/measure")


### PR DESCRIPTION
## 📺 Overview

Closes #535

### What does this PR do?
* **Type of change:** [x] New feature (docs + small prefs extension) | [ ] Bug fix | [ ] Refactoring | [ ] CI/CD or Tooling
* **Component(s) affected:** ArgyllCMS backend prefs (`server.py`, `tools/zro-bridge/bridge.py`), README documentation

---

## 🛠️ Technical Context & Implementation

* **The Problem:** Issue #520 (ArgyllCMS direct-meter backend) shipped `spotread` wrapping, meter discovery/selection, and CCMX/CCSS correction support in prior PRs (#563/#566/#567), but the correction-file path was only configurable via `bridge.json` — it wasn't persisted in the app's prefs alongside the meter selection, and there was no install/permissions documentation for the feature at all.
* **The Solution:** Persist the ArgyllCMS correction path in app prefs and document install/udev setup. Specifically:
  - Extended `_prefs["argyll"]` in `server.py` with a `correction_path` field, persisted to `.prefs.json` the same way `port`/`instrument_name` already are.
  - Extended `POST /api/zro/bridge/instrument` (`ZroBridgeInstrumentBody`) to accept `correction_path` and push it to the Bridge alongside the port selection.
  - Extended `bridge.py`'s `POST /config/argyll-port` to optionally accept/apply `correction_path` in the same call (back-compat: omitting the key leaves the existing correction and response shape untouched), and `GET /instruments` now reports the currently selected `correction_path`.
  - Added a new **ArgyllCMS Direct-Meter Backend (No Paid Products)** section to the README: install instructions, Linux udev permission setup, `bridge.json` backend selection, meter discovery/selection API, CCMX/CCSS correction file guidance, and a note on the existing graceful "ArgyllCMS not found" / "no meter detected" messaging.
  - Updated the Requirements and Glossary sections to mention ArgyllCMS as a license-free alternative to ColourSpace ZRO.
* **Impact on existing workflows/APIs:** Additive only — `correction_path` is optional everywhere it was added; existing calls without it behave exactly as before (covered by existing + new tests).

---

## 🧪 Testing & Validation

### Verification Steps
1. `python -m pytest tests/test_zro_bridge.py tests/test_argyll_backend.py tests/test_server_api.py -q --no-cov` — all passing, including new coverage for `correction_path` persistence/push and the bridge's `/config/argyll-port` + `/instruments` correction-path plumbing.
2. `python -m pytest tests/ -q --no-cov` — full suite green, no regressions.

### Environment Details
* **Hardware/Mock Used:** Mocked `spotread`/httpx calls (no physical meter or Bridge instance required for these tests).

---

## 🧼 Checklist
* [x] Code adheres to project style guidelines (formatting, typing, linting).
* [x] Unit tests added/updated and passing.
* [x] Documentation (README, inline docstrings) updated to reflect changes.
* [x] No credentials, local absolute paths, or hardware-specific hardcoding leaked.

---
_Generated by [Claude Code](https://claude.ai/code/session_012izA4tfUkJ95a94FHGj5HF)_