### PR TITLE
fix: HDR luminance step no longer requires panel peak to match 1000-nit reference

### DIFF
--- a/calibrator/quality.py
+++ b/calibrator/quality.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, Optional
 
-from calcore.models import CalibrationTarget
+from calcore.models import CalibrationTarget, CalMode
 from .profiles import TVProfile
 from .guidance import gamma_nominal_pct
 from .session import (
@@ -14,6 +14,7 @@ from .session import (
     latest_wb_measurements,
     m_to_dict,
     gamma_levels_for_session,
+    validate_peak_luminance,
 )
 from .utils import gamma_from_luminance
 
@@ -31,16 +32,30 @@ def step_quality(session: Dict[str, Any], tv: Optional[TVProfile]) -> Dict[str, 
 
     peak = session.get("peak_luminance", 0.0)
     if peak > 0 and target:
-        target_nits = target.peak_luminance_nits
-        pct_err = abs(peak - target_nits) / target_nits * 100
-        gates["luminance"] = {
-            "passed": pct_err <= QG_LUMINANCE_PCT,
-            "score": round(pct_err, 1),
-            "threshold": QG_LUMINANCE_PCT,
-            "unit": "%",
-            "label": f"Peak nits ±{QG_LUMINANCE_PCT:.0f}%",
-            "detail": f"{peak:.0f} nits (target {target_nits:.0f})",
-        }
+        if target.mode == CalMode.SDR:
+            target_nits = target.peak_luminance_nits
+            pct_err = abs(peak - target_nits) / target_nits * 100
+            gates["luminance"] = {
+                "passed": pct_err <= QG_LUMINANCE_PCT,
+                "score": round(pct_err, 1),
+                "threshold": QG_LUMINANCE_PCT,
+                "unit": "%",
+                "label": f"Peak nits ±{QG_LUMINANCE_PCT:.0f}%",
+                "detail": f"{peak:.0f} nits (target {target_nits:.0f})",
+            }
+        else:
+            # HDR peak is panel-limited, not tuned to match the mastering
+            # reference — gate on plausibility, not proximity to target (#546).
+            validation = validate_peak_luminance(peak, target)
+            bounds = validation["bounds"]
+            gates["luminance"] = {
+                "passed": validation["valid"],
+                "score": round(peak, 1),
+                "threshold": bounds["max"],
+                "unit": "nits",
+                "label": f"Peak within {bounds['min']:.0f}-{bounds['max']:.0f} nits",
+                "detail": f"{peak:.0f} nits measured (panel-limited HDR peak)",
+            }
 
     wb = session.get("wb_measurements", [])
     if wb and target:

--- a/calibrator/session.py
+++ b/calibrator/session.py
@@ -1961,11 +1961,18 @@ class SessionStore:
                 if session.get("target") is None:
                     raise HTTPException(400, "Target not set. Go back and select a calibration mode.")
                 latest = session["lum_measurements"][-1]
-                validation = validate_peak_luminance(latest.Y, session["target"])
+                target = session["target"]
+                validation = validate_peak_luminance(latest.Y, target)
                 if not validation["valid"]:
                     raise HTTPException(400, validation["message"])
-                if session["target"]:
-                    target_nits = session["target"].peak_luminance_nits
+                # SDR targets a fixed peak (e.g. 100/120 nits) achievable via Backlight,
+                # so require the reading to land within tolerance of that target. HDR
+                # targets (HDR10, Dolby Vision) carry a nominal mastering reference
+                # (e.g. 1000 nits) that is not an achievable or desirable panel setting
+                # — panel peak is display-limited and tone mapping handles the rest —
+                # so HDR only needs to pass the sanity-bounds check above (#546).
+                if target.mode == CalMode.SDR:
+                    target_nits = target.peak_luminance_nits
                     pct_err = abs(latest.Y - target_nits) / target_nits * 100
                     if pct_err > luminance_threshold_pct:
                         raise HTTPException(

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -1088,6 +1088,76 @@ class TestStepNavigation:
         assert s1["step_index"] > 0
 
 
+# ── HDR luminance gate (#546) ─────────────────────────────────────────────────
+# HDR10/Dolby Vision targets carry a nominal 1000-nit mastering reference that a
+# real panel is not expected to hit — peak is panel-limited and tone mapping
+# handles the rest. The ±5% "dial Backlight to match target" gate only makes
+# sense for SDR, where the target nits are an achievable Backlight setting.
+
+class TestHDRLuminanceGate:
+    def _to_luminance(self, client, sid, mode):
+        client.post(f"/api/session/{sid}/mode", json={"mode": mode})
+        client.post(f"/api/session/{sid}/prepared")
+        _upload_csv(client, sid, _make_zro_csv(_grayscale_rows()))
+        resp = client.post(f"/api/session/{sid}/next")
+        assert resp.json()["step"] == "luminance"
+
+    def _measure_white(self, client, sid, nits):
+        # Dogegen + full-range HDR10/Dolby Vision sessions default to 10-bit code
+        # values (see recommended_code_scale), so 100% white is RGB 1023, not 235.
+        code_scale = client.get(f"/api/session/{sid}").json().get("code_scale", "8bit")
+        white = 1023 if code_scale == "10bit" else 235
+        _upload_csv(client, sid, _make_zro_csv([(white, white, white, nits, 0.3127, 0.3290)]))
+
+    def test_hdr10_700_nit_panel_advances_past_luminance(self, client, session_id):
+        self._to_luminance(client, session_id, "HDR10")
+        self._measure_white(client, session_id, 700.0)
+        resp = client.post(f"/api/session/{session_id}/next")
+        assert resp.status_code == 200
+        assert resp.json()["step"] == "white_balance"
+
+    def test_hdr10_1480_nit_panel_advances_past_luminance(self, client, session_id):
+        # Exact repro from the issue: a 1500-nit-class panel measuring 1480 nits
+        # at 100% white used to hard-block with "48.0% off" — HDR peak is
+        # panel-limited, not tunable down to the 1000-nit mastering reference.
+        self._to_luminance(client, session_id, "HDR10")
+        self._measure_white(client, session_id, 1480.0)
+        resp = client.post(f"/api/session/{session_id}/next")
+        assert resp.status_code == 200
+        assert resp.json()["step"] == "white_balance"
+
+    def test_dolby_vision_panel_measured_peak_advances_past_luminance(self, client, session_id):
+        self._to_luminance(client, session_id, "Dolby Vision")
+        self._measure_white(client, session_id, 850.0)
+        resp = client.post(f"/api/session/{session_id}/next")
+        assert resp.status_code == 200
+        assert resp.json()["step"] == "white_balance"
+
+    def test_hdr10_implausible_reading_still_rejected(self, client, session_id):
+        # Sanity bounds (validate_peak_luminance) still apply to HDR — only the
+        # ±5%-of-target match requirement is skipped.
+        self._to_luminance(client, session_id, "HDR10")
+        self._measure_white(client, session_id, 6000.0)
+        resp = client.post(f"/api/session/{session_id}/next")
+        assert resp.status_code == 400
+
+    def test_sdr_keeps_pct_luminance_gate(self, client, session_id):
+        # SDR's target nits are an achievable Backlight setting, so the ±5%
+        # match requirement must still block advancement.
+        self._to_luminance(client, session_id, "SDR")
+        self._measure_white(client, session_id, 200.0)  # SDR target is 120 nits
+        resp = client.post(f"/api/session/{session_id}/next")
+        assert resp.status_code == 400
+        assert "% off" in resp.json()["detail"]
+
+    def test_sdr_within_tolerance_advances_past_luminance(self, client, session_id):
+        self._to_luminance(client, session_id, "SDR")
+        self._measure_white(client, session_id, 120.0)  # SDR target is 120 nits
+        resp = client.post(f"/api/session/{session_id}/next")
+        assert resp.status_code == 200
+        assert resp.json()["step"] == "white_balance"
+
+
 # ── ZRO per-step instructions ─────────────────────────────────────────────────
 
 class TestZROInstructions:


### PR DESCRIPTION
## 📺 Overview

Closes #546

### What does this PR do?
* **Type of change:** [x] Bug fix
* **Component(s) affected:** `calibrator/session.py` (`next_step` luminance gate), `calibrator/quality.py` (`step_quality` luminance gate)

---

## 🛠️ Technical Context & Implementation

* **The Problem:** The SDR luminance gate ("measured 100% white must be within ±5% of `target.peak_luminance_nits`") was applied mode-blind to HDR10/Dolby Vision. Those targets carry a nominal 1000-nit mastering reference, not an achievable or desirable Backlight setting — HDR peak is panel-limited and tone mapping handles the rest. A 700-nit panel could never pass; a 1500-nit panel was told to cap its peak at 1000 nits, the opposite of correct HDR10 practice. `jump` only allows backward jumps, so the calibration run dead-ended at the Luminance step.
* **The Solution:** `next_step()` now only applies the ±5%-of-target match requirement when `target.mode == CalMode.SDR`. For HDR modes it still runs `validate_peak_luminance`'s sanity-bounds check (1–5000 nits) and records the measured peak as the session reference, but skips the match requirement. `step_quality()`'s `luminance` quality gate (which also drives the "Continue" button on the Luminance page in the frontend) got the same mode-aware treatment so the UI doesn't independently re-block HDR sessions the backend now allows through.
* **Impact on existing workflows/APIs:** SDR behavior is unchanged. HDR10/Dolby Vision sessions can now advance past the Luminance step with any panel-plausible peak reading; the luminance quality gate label/detail differs for HDR (`"Peak within {min}-{max} nits"`) vs SDR (`"Peak nits ±5%"`).

### Mathematical / Data Integrity Checks (If Applicable)
* [ ] Matrix transformations or LUT calculations have been validated. (N/A — no math changed)
* [x] Floating-point precision or data truncation risks have been addressed. (reuses existing `validate_peak_luminance` bounds logic, unchanged)

---

## 🧪 Testing & Validation

### Environment Details
* **OS / Target Display:** N/A — backend/API logic change, verified via `TestClient`
* **Hardware/Mock Used:** Simulated ZRO CSV import (ColourSpace export format)

### Verification Steps
1. `python -m pytest tests/ -q` — full suite passes (previously-existing tests unaffected; coverage stays at 82%).
2. New `TestHDRLuminanceGate` class in `tests/test_server_api.py` reproduces the issue directly:
   - HDR10 session with a 700-nit and a 1480-nit (issue's exact repro number) 100% white reading both now advance past Luminance.
   - Dolby Vision with an 850-nit reading advances.
   - HDR10 still rejects an implausible 6000-nit reading (sanity bounds still apply).
   - SDR keeps the ±5% gate: a 200-nit reading against a 120-nit SDR target still 400s, and a 120-nit reading (within tolerance) still advances.

### Firmware / TV Settings
* [ ] Verified against target display firmware version (N/A — logic-only fix, not display-specific)
* [ ] Local Dimming set to Medium during test runs (N/A)
* [ ] Correct white point mode used (N/A)

---

## 📸 Visual Evidence (UI / Plot Changes)
No GUI changes — this is a backend gating fix. The frontend `Luminance.jsx` page already reads `session.quality_gates.luminance.passed` to enable its "Continue" button, so no frontend code changes were needed; it inherits the corrected gate automatically.

---

## 🧼 Checklist
* [x] Code adheres to project style guidelines (formatting, typing, linting).
* [x] Unit tests added/updated and passing.
* [ ] Documentation (README, inline docstrings) updated to reflect changes. (N/A — no user-facing docs describe this gate)
* [x] No credentials, local absolute paths, or hardware-specific hardcoding leaked.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Jo8zkZLUKjrWuoUFXPsFK6)_