### PR TITLE
Guard PQ gamma plans against firmware tone-mapping knee

### DIFF
--- a/calibrator/__init__.py
+++ b/calibrator/__init__.py
@@ -50,6 +50,7 @@ from .utils import (
     eotf_from_luminance,
     gamma_from_luminance,
     is_pq_eotf,
+    pq_point_above_knee,
     rating_emoji,
     stimulus_pct_from_code_value,
 )
@@ -71,6 +72,7 @@ __all__ = [
     "SDR_TARGET", "HDR10_TARGET", "DV_TARGET",
     "ciede2000", "delta_e_cie76", "delta_e_ciede2000_xyY", "xyY_to_XYZ", "XYZ_to_lab", "xyY_to_lab",
     "delta_xy", "gamma_from_luminance", "eotf_from_luminance", "is_pq_eotf",
+    "pq_point_above_knee",
     "rating_emoji", "direction_hint",
     "stimulus_pct_from_code_value",
     "TVProfile", "TV_PROFILES", "DEFAULT_TV_PROFILE", "get_tv_profile",

--- a/calibrator/guidance.py
+++ b/calibrator/guidance.py
@@ -12,7 +12,13 @@ from calcore.models import (
     Measurement,
 )
 from .profiles import TVProfile
-from .utils import delta_xy, eotf_from_luminance, is_pq_eotf, stimulus_pct_from_code_value
+from .utils import (
+    delta_xy,
+    eotf_from_luminance,
+    is_pq_eotf,
+    pq_point_above_knee,
+    stimulus_pct_from_code_value,
+)
 
 GAMMA_TRACKING_LEVELS = (20, 40, 60, 80)
 FINE_GAMMA_TRACKING_LEVELS = tuple(range(5, 100, 5))
@@ -341,10 +347,22 @@ def gamma_recommendations(
         stim_pct = gamma_nominal_pct(m, signal_range, code_scale, levels)
         if stim_pct is None:
             continue
+        # Skip points whose PQ reference exceeds panel peak — firmware tone
+        # mapping is active there and they would skew the aggregate advice
+        # toward "too dark" forever (issue #548). Below-knee points keep normal
+        # treatment so genuine midtone errors are still surfaced.
+        if pq and pq_point_above_knee(stim_pct, peak_nits):
+            continue
         eff_gamma = eotf_from_luminance(m.Y, peak_nits, stim_pct, eotf)
         if eff_gamma is not None:
             gammas.append({"stimulus_pct": stim_pct, "effective_gamma": eff_gamma})
     if not gammas:
+        if pq:
+            return [
+                "All measured gamma points sit in the firmware tone-mapping region "
+                "(PQ reference exceeds panel peak). Do not chase them with menu controls; "
+                "re-measure with lower-stimulus patches or raise the panel's HDR peak."
+            ]
         return ["Take another gamma reading. A valid effective gamma was not computed from the last pass."]
 
     avg = sum(m["effective_gamma"] for m in gammas) / len(gammas)
@@ -410,17 +428,41 @@ def u8g_gamma_control_plan(
     eotf: str = "gamma",
 ) -> List[Dict[str, Any]]:
     # PQ tracks against the ST.2084 reference (1.0 == perfect), not target_gamma.
-    effective_target = 1.0 if is_pq_eotf(eotf) else target_gamma
+    pq = is_pq_eotf(eotf)
+    effective_target = 1.0 if pq else target_gamma
     plan: List[Dict[str, Any]] = []
     for m in measurements:
         stim_pct = gamma_nominal_pct(m, signal_range, code_scale, levels)
         if stim_pct is None:
             continue
+        stim_label = f"{round(stim_pct):.0f}%"
+        # PQ points whose ST.2084 reference exceeds panel peak are inside the
+        # firmware tone-mapping region. The measured luminance will always read
+        # as "too dark" relative to an unreachable reference, so the plan would
+        # emit "raise this point" on every pass forever. Hold them instead and
+        # let the operator's midtone corrections reach the knee from below
+        # (issue #548 / QE_AUDIT.md tone-mapping invariant).
+        if pq and pq_point_above_knee(stim_pct, peak_nits):
+            eff_gamma = eotf_from_luminance(m.Y, peak_nits, stim_pct, eotf)
+            plan.append(
+                {
+                    "control": stim_label,
+                    "effective_gamma": round(eff_gamma, 3) if eff_gamma is not None else None,
+                    "delta": None,
+                    "direction": "hold",
+                    "amount": 0,
+                    "summary": f"Hold {stim_label} — firmware tone-mapping region",
+                    "reason": (
+                        "PQ reference luminance exceeds panel peak; firmware tone "
+                        "mapping is active here. Do not correct via menu controls."
+                    ),
+                }
+            )
+            continue
         eff_gamma = eotf_from_luminance(m.Y, peak_nits, stim_pct, eotf)
         if eff_gamma is None:
             continue
         delta = eff_gamma - effective_target
-        stim_label = f"{round(stim_pct):.0f}%"
         if abs(delta) < 0.10:
             direction, amount, summary = "hold", 0, f"Leave {stim_label} alone"
             reason = "This gamma point is already close enough to target."
@@ -483,10 +525,29 @@ def preset_gamma_control_plan(
         stim_pct = gamma_nominal_pct(m, signal_range, code_scale, levels)
         if stim_pct is None:
             continue
+        # Exclude firmware tone-mapping points so the preset recommendation
+        # isn't dragged toward "too dark" by an unreachable PQ reference
+        # (issue #548).
+        if pq and pq_point_above_knee(stim_pct, peak_nits):
+            continue
         eff = eotf_from_luminance(m.Y, peak_nits, stim_pct, eotf)
         if eff is not None:
             gammas.append(eff)
     if not gammas:
+        if pq:
+            return [
+                {
+                    "control": "Gamma preset",
+                    "direction": "hold",
+                    "amount": 0,
+                    "summary": "Keep current HDR tracking preset",
+                    "reason": (
+                        "All measured points sit in the firmware tone-mapping region "
+                        "(PQ reference exceeds panel peak). Preset changes won't recover "
+                        "an unreachable reference; raise the panel's HDR peak instead."
+                    ),
+                }
+            ]
         return []
     avg = sum(gammas) / len(gammas)
     delta = avg - effective_target

--- a/calibrator/guidance.py
+++ b/calibrator/guidance.py
@@ -343,6 +343,7 @@ def gamma_recommendations(
         return recs
 
     gammas = []
+    saw_above_knee = False
     for m in measurements:
         stim_pct = gamma_nominal_pct(m, signal_range, code_scale, levels)
         if stim_pct is None:
@@ -352,12 +353,17 @@ def gamma_recommendations(
         # toward "too dark" forever (issue #548). Below-knee points keep normal
         # treatment so genuine midtone errors are still surfaced.
         if pq and pq_point_above_knee(stim_pct, peak_nits):
+            saw_above_knee = True
             continue
         eff_gamma = eotf_from_luminance(m.Y, peak_nits, stim_pct, eotf)
         if eff_gamma is not None:
             gammas.append({"stimulus_pct": stim_pct, "effective_gamma": eff_gamma})
     if not gammas:
-        if pq:
+        # Only attribute the empty result to the tone-mapping region when we
+        # actually saw above-knee points; otherwise the readings themselves
+        # failed and the operator should re-measure rather than be told the
+        # wall is the cause.
+        if pq and saw_above_knee:
             return [
                 "All measured gamma points sit in the firmware tone-mapping region "
                 "(PQ reference exceeds panel peak). Do not chase them with menu controls; "
@@ -436,6 +442,12 @@ def u8g_gamma_control_plan(
         if stim_pct is None:
             continue
         stim_label = f"{round(stim_pct):.0f}%"
+        eff_gamma = eotf_from_luminance(m.Y, peak_nits, stim_pct, eotf)
+        # A failed/missing reading (Y <= 0 -> eff_gamma is None) is omitted
+        # rather than reported as a confirmed "hold", so the operator isn't
+        # told a point is fine when it was never measured.
+        if eff_gamma is None:
+            continue
         # PQ points whose ST.2084 reference exceeds panel peak are inside the
         # firmware tone-mapping region. The measured luminance will always read
         # as "too dark" relative to an unreachable reference, so the plan would
@@ -443,11 +455,10 @@ def u8g_gamma_control_plan(
         # let the operator's midtone corrections reach the knee from below
         # (issue #548 / QE_AUDIT.md tone-mapping invariant).
         if pq and pq_point_above_knee(stim_pct, peak_nits):
-            eff_gamma = eotf_from_luminance(m.Y, peak_nits, stim_pct, eotf)
             plan.append(
                 {
                     "control": stim_label,
-                    "effective_gamma": round(eff_gamma, 3) if eff_gamma is not None else None,
+                    "effective_gamma": round(eff_gamma, 3),
                     "delta": None,
                     "direction": "hold",
                     "amount": 0,
@@ -458,9 +469,6 @@ def u8g_gamma_control_plan(
                     ),
                 }
             )
-            continue
-        eff_gamma = eotf_from_luminance(m.Y, peak_nits, stim_pct, eotf)
-        if eff_gamma is None:
             continue
         delta = eff_gamma - effective_target
         if abs(delta) < 0.10:
@@ -521,6 +529,7 @@ def preset_gamma_control_plan(
             }
         ]
     gammas = []
+    saw_above_knee = False
     for m in measurements:
         stim_pct = gamma_nominal_pct(m, signal_range, code_scale, levels)
         if stim_pct is None:
@@ -529,12 +538,13 @@ def preset_gamma_control_plan(
         # isn't dragged toward "too dark" by an unreachable PQ reference
         # (issue #548).
         if pq and pq_point_above_knee(stim_pct, peak_nits):
+            saw_above_knee = True
             continue
         eff = eotf_from_luminance(m.Y, peak_nits, stim_pct, eotf)
         if eff is not None:
             gammas.append(eff)
     if not gammas:
-        if pq:
+        if pq and saw_above_knee:
             return [
                 {
                     "control": "Gamma preset",

--- a/calibrator/utils.py
+++ b/calibrator/utils.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import math
 
 from calcore.colour import ciede2000, xyY_to_xyz, xyz_to_lab
-from calcore.eotf import pq_inverse_eotf
+from calcore.eotf import pq_eotf, pq_inverse_eotf
 
 
 def delta_xy(measured_xy, target_xy) -> float:
@@ -63,6 +63,34 @@ def is_pq_eotf(eotf: str) -> bool:
     """True when the EOTF label denotes PQ / SMPTE ST.2084."""
     e = (eotf or "").lower()
     return "pq" in e or "2084" in e
+
+
+# A PQ stimulus point is considered "above the knee" — i.e. inside the
+# firmware tone-mapping region — when its absolute ST.2084 reference luminance
+# meets or exceeds the panel peak. The margin is 1.0 (a hard criterion: the
+# reference is literally unreachable on this panel) so genuine midtone errors
+# below the knee are never suppressed. See issue #548 and QE_AUDIT.md.
+PQ_KNEE_MARGIN = 1.0
+
+
+def pq_point_above_knee(
+    stimulus_pct: float,
+    peak_nits: float,
+    margin: float = PQ_KNEE_MARGIN,
+) -> bool:
+    """True when the ST.2084 reference luminance at ``stimulus_pct`` is at or
+    above ``peak_nits * margin``.
+
+    ST.2084 is an absolute EOTF: the encoded signal maps directly to nits, not
+    to a fraction of the display's peak. When the reference for a stimulus
+    exceeds what the panel can actually produce, firmware tone mapping takes
+    over and the measured luminance will always read as "too dark" relative to
+    that reference. Such points must not be "corrected" via menu controls — the
+    operator would chase the tone-mapping wall forever (issue #548).
+    """
+    if peak_nits <= 0 or stimulus_pct <= 0 or stimulus_pct >= 100:
+        return False
+    return pq_eotf(stimulus_pct / 100.0) >= peak_nits * margin
 
 
 def eotf_from_luminance(measured_nits, peak_nits, stimulus_pct, eotf="gamma"):

--- a/calibrator/utils.py
+++ b/calibrator/utils.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import math
 
 from calcore.colour import ciede2000, xyY_to_xyz, xyz_to_lab
-from calcore.eotf import pq_eotf, pq_inverse_eotf
+from calcore.eotf import pq_eotf, pq_inverse_eotf, pq_target_nits
 
 
 def delta_xy(measured_xy, target_xy) -> float:
@@ -65,32 +65,33 @@ def is_pq_eotf(eotf: str) -> bool:
     return "pq" in e or "2084" in e
 
 
-# A PQ stimulus point is considered "above the knee" — i.e. inside the
-# firmware tone-mapping region — when its absolute ST.2084 reference luminance
-# meets or exceeds the panel peak. The margin is 1.0 (a hard criterion: the
-# reference is literally unreachable on this panel) so genuine midtone errors
-# below the knee are never suppressed. See issue #548 and QE_AUDIT.md.
-PQ_KNEE_MARGIN = 1.0
+# A PQ stimulus point is "above the knee" — inside the firmware tone-mapping
+# region — when its absolute ST.2084 reference luminance exceeds the panel
+# peak. This is a hard criterion (the reference is literally unreachable on
+# this panel) so genuine midtone errors below the knee are never suppressed.
+# See issue #548 and QE_AUDIT.md.
 
 
-def pq_point_above_knee(
-    stimulus_pct: float,
-    peak_nits: float,
-    margin: float = PQ_KNEE_MARGIN,
-) -> bool:
-    """True when the ST.2084 reference luminance at ``stimulus_pct`` is at or
-    above ``peak_nits * margin``.
+def pq_point_above_knee(stimulus_pct: float, peak_nits: float) -> bool:
+    """True when the ST.2084 reference luminance at ``stimulus_pct`` exceeds
+    the panel peak — i.e. firmware tone mapping is active and the point must
+    not be "corrected" via menu controls (issue #548 / QE_AUDIT.md).
 
-    ST.2084 is an absolute EOTF: the encoded signal maps directly to nits, not
-    to a fraction of the display's peak. When the reference for a stimulus
+    ST.2084 is an absolute EOTF: the encoded signal maps directly to nits,
+    not to a fraction of the display's peak. When the reference for a stimulus
     exceeds what the panel can actually produce, firmware tone mapping takes
     over and the measured luminance will always read as "too dark" relative to
     that reference. Such points must not be "corrected" via menu controls — the
     operator would chase the tone-mapping wall forever (issue #548).
+
+    Delegates to ``calcore.eotf.pq_target_nits`` so the clipping notion lives
+    in one place: a point is above the knee exactly when ``pq_target_nits``
+    clips its reference (``pq_target_nits(n, peak) < pq_eotf(n)``).
     """
     if peak_nits <= 0 or stimulus_pct <= 0 or stimulus_pct >= 100:
         return False
-    return pq_eotf(stimulus_pct / 100.0) >= peak_nits * margin
+    n = stimulus_pct / 100.0
+    return pq_target_nits(n, peak_nits) < pq_eotf(n)
 
 
 def eotf_from_luminance(measured_nits, peak_nits, stimulus_pct, eotf="gamma"):

--- a/tests/test_hdr_gamma_guidance.py
+++ b/tests/test_hdr_gamma_guidance.py
@@ -3,6 +3,10 @@
 Regression coverage for the bug where ``gamma_from_luminance`` (a plain
 power-law exponent) was used for PQ/HDR sessions, producing meaningless
 effective-gamma values and comparing them against a 2.2 / 0.0 target.
+
+Also covers the firmware tone-mapping knee guard (issue #548): PQ points whose
+ST.2084 reference luminance exceeds the panel peak must emit "hold" instead of
+chasing an unreachable reference with menu controls.
 """
 from calcore.eotf import pq_eotf
 from calcore.models import Measurement
@@ -12,6 +16,7 @@ from calibrator.guidance import (
     preset_gamma_control_plan,
     u8g_gamma_control_plan,
 )
+from calibrator.utils import pq_point_above_knee
 
 PEAK_NITS = 1000.0
 PQ_EOTF = "PQ (ST.2084)"
@@ -116,9 +121,94 @@ class TestU8gControlPlanPq:
             code_scale="10bit",
             eotf=PQ_EOTF,
         )
-        # Too dark (effective tracking > 1.0) -> brighten (raise) the points.
+        # Below-knee points (20/40/60%) are genuinely too dark (effective
+        # tracking > 1.0) -> brighten (raise) them.
+        below_knee = [p for p in plan if p["control"] != "80%"]
+        assert below_knee
+        assert all(p["direction"] == "up" for p in below_knee)
+        # 80% PQ reference (~1555 nits) exceeds the 1000-nit panel peak, so it
+        # is in the firmware tone-mapping region and must hold, not raise.
+        knee = next(p for p in plan if p["control"] == "80%")
+        assert knee["direction"] == "hold"
+        assert "tone mapping" in knee["reason"].lower()
+
+
+class TestU8gControlPlanPqKnee:
+    """Regression tests for issue #548: the firmware tone-mapping knee guard."""
+
+    def test_sub_peak_panel_holds_above_knee_points(self):
+        # 500-nit measured peak. PQ references: 70% ~621 nits, 80% ~1555 nits
+        # — both exceed the panel peak, so a correctly tone-mapping panel reads
+        # as "too dark" vs the unreachable reference. The plan must hold these
+        # points instead of emitting "up" forever. Below-knee points (20/40/60%,
+        # refs 2.4 / 32.4 / 244 nits) track perfectly and hold via the normal
+        # path — genuine midtone errors below the knee are not suppressed.
+        peak = 500.0
+        levels = (20, 40, 60, 70, 80)
+        meas = [
+            Measurement(
+                Y=min(pq_eotf(n / 100.0), peak),  # correct hard-clip tone map
+                label=f"Gamma {n}%",
+                stimulus_rgb=(round(n / 100.0 * 1023),) * 3,
+            )
+            for n in levels
+        ]
+        plan = u8g_gamma_control_plan(
+            meas,
+            target_gamma=0.0,
+            peak_nits=peak,
+            signal_range="full",
+            code_scale="10bit",
+            levels=levels,
+            eotf=PQ_EOTF,
+        )
+        by_label = {p["control"]: p for p in plan}
+        # 70% and 80% are above the knee -> hold via the knee guard (not "up").
+        assert by_label["70%"]["direction"] == "hold"
+        assert by_label["80%"]["direction"] == "hold"
+        assert "tone mapping" in by_label["70%"]["reason"].lower()
+        assert "tone mapping" in by_label["80%"]["reason"].lower()
+        # Below-knee points that track perfectly hold via the normal path.
+        assert by_label["20%"]["direction"] == "hold"
+        assert by_label["40%"]["direction"] == "hold"
+        assert by_label["60%"]["direction"] == "hold"
+
+    def test_below_knee_too_dark_still_corrected(self):
+        # A genuine midtone error below the knee must still produce "up", not
+        # be masked by the knee guard.
+        peak = 700.0
+        levels = (20, 40, 60)
+        meas = [
+            Measurement(
+                Y=pq_eotf(n / 100.0) * 0.5,  # half the reference -> too dark
+                label=f"Gamma {n}%",
+                stimulus_rgb=(round(n / 100.0 * 1023),) * 3,
+            )
+            for n in levels
+        ]
+        plan = u8g_gamma_control_plan(
+            meas,
+            target_gamma=0.0,
+            peak_nits=peak,
+            signal_range="full",
+            code_scale="10bit",
+            levels=levels,
+            eotf=PQ_EOTF,
+        )
         assert plan
         assert all(p["direction"] == "up" for p in plan)
+
+    def test_knee_helper_boundary(self):
+        # 1000-nit panel: 80% (~1555 nits) is above knee, 70% (~621) is not.
+        assert pq_point_above_knee(80, 1000.0) is True
+        assert pq_point_above_knee(70, 1000.0) is False
+        # 500-nit panel: 70% (~621) is above knee, 60% (~244) is not.
+        assert pq_point_above_knee(70, 500.0) is True
+        assert pq_point_above_knee(60, 500.0) is False
+        # Degenerate inputs never claim above-knee.
+        assert pq_point_above_knee(80, 0.0) is False
+        assert pq_point_above_knee(0, 1000.0) is False
+        assert pq_point_above_knee(100, 1000.0) is False
 
 
 class TestPresetControlPlanPq:
@@ -142,3 +232,60 @@ class TestPresetControlPlanPq:
             eotf=PQ_EOTF,
         )
         assert "pq" in plan[0]["summary"].lower() or "pq" in plan[0]["reason"].lower()
+
+
+class TestPqKneeAggregate:
+    """Issue #548: aggregate advice must not chase the tone-mapping wall."""
+
+    def _clipped_pass(self, peak: float, levels=GAMMA_TRACKING_LEVELS):
+        return [
+            Measurement(
+                Y=min(pq_eotf(n / 100.0), peak),
+                label=f"Gamma {n}%",
+                stimulus_rgb=(round(n / 100.0 * 1023),) * 3,
+            )
+            for n in levels
+        ]
+
+    def test_recommendations_no_highlight_rec_for_clipped_peak(self):
+        # 700-nit panel, correctly tone-mapped 80% point (PQ ref ~1555 nits,
+        # above the knee). The "highlights too dark — raise 70%/80%"
+        # recommendation must not fire because the clipped 80% point is
+        # excluded from the aggregate.
+        recs = gamma_recommendations(
+            self._clipped_pass(700.0),
+            target_gamma=0.0,
+            peak_nits=700.0,
+            signal_range="full",
+            code_scale="10bit",
+            eotf=PQ_EOTF,
+        )
+        joined = " ".join(recs).lower()
+        assert "raise 70%/80%" not in joined
+        assert "highlights too dark" not in joined
+
+    def test_preset_plan_holds_for_clipped_peak(self):
+        # 700-nit panel, correctly tone-mapped. The preset plan must not
+        # recommend a higher preset because the clipped 80% point reads dark.
+        plan = preset_gamma_control_plan(
+            self._clipped_pass(700.0),
+            target_gamma=0.0,
+            peak_nits=700.0,
+            signal_range="full",
+            code_scale="10bit",
+            eotf=PQ_EOTF,
+        )
+        assert plan[0]["direction"] == "hold"
+
+    def test_recommendations_all_above_knee_message(self):
+        # Pathological: panel peak so low every tracked point is above the knee
+        # (20% PQ ref ~2.4 nits > 1-nit peak).
+        recs = gamma_recommendations(
+            self._clipped_pass(1.0),
+            target_gamma=0.0,
+            peak_nits=1.0,
+            signal_range="full",
+            code_scale="10bit",
+            eotf=PQ_EOTF,
+        )
+        assert any("tone-mapping" in r.lower() for r in recs)

--- a/tests/test_hdr_gamma_guidance.py
+++ b/tests/test_hdr_gamma_guidance.py
@@ -210,6 +210,37 @@ class TestU8gControlPlanPqKnee:
         assert pq_point_above_knee(0, 1000.0) is False
         assert pq_point_above_knee(100, 1000.0) is False
 
+    def test_above_knee_failed_reading_omitted(self):
+        # A failed/missing reading (Y=0 -> eff_gamma None) at an above-knee
+        # point must be omitted from the plan, not reported as a confirmed
+        # "hold". The shared None guard skips it before the knee branch.
+        peak = 500.0
+        levels = (20, 80)
+        meas = [
+            Measurement(
+                Y=pq_eotf(0.20),  # below-knee, perfect -> hold (normal path)
+                label="Gamma 20%",
+                stimulus_rgb=(round(0.20 * 1023),) * 3,
+            ),
+            Measurement(
+                Y=0.0,  # failed reading at an above-knee point
+                label="Gamma 80%",
+                stimulus_rgb=(round(0.80 * 1023),) * 3,
+            ),
+        ]
+        plan = u8g_gamma_control_plan(
+            meas,
+            target_gamma=0.0,
+            peak_nits=peak,
+            signal_range="full",
+            code_scale="10bit",
+            levels=levels,
+            eotf=PQ_EOTF,
+        )
+        labels = [p["control"] for p in plan]
+        assert "20%" in labels
+        assert "80%" not in labels  # failed reading omitted, not "hold"
+
 
 class TestPresetControlPlanPq:
     def test_perfect_pq_holds(self):
@@ -289,3 +320,51 @@ class TestPqKneeAggregate:
             eotf=PQ_EOTF,
         )
         assert any("tone-mapping" in r.lower() for r in recs)
+
+    def test_recommendations_failed_readings_not_blamed_on_tone_mapping(self):
+        # All readings failed (Y=0 -> eff_gamma None) at below-knee points on a
+        # 1000-nit panel (no point is above the knee). The empty-gammas fallback
+        # must NOT claim the tone-mapping wall is the cause — the operator should
+        # be told to re-measure, not that firmware tone mapping is active.
+        levels = (20, 40, 60)
+        meas = [
+            Measurement(
+                Y=0.0,
+                label=f"Gamma {n}%",
+                stimulus_rgb=(round(n / 100.0 * 1023),) * 3,
+            )
+            for n in levels
+        ]
+        recs = gamma_recommendations(
+            meas,
+            target_gamma=0.0,
+            peak_nits=1000.0,
+            signal_range="full",
+            code_scale="10bit",
+            eotf=PQ_EOTF,
+        )
+        joined = " ".join(recs).lower()
+        assert "tone-mapping" not in joined
+        assert "take another gamma reading" in joined
+
+    def test_preset_plan_failed_readings_return_empty(self):
+        # Failed readings at below-knee points (no above-knee points seen):
+        # preset plan returns [] (not the tone-mapping hold message).
+        levels = (20, 40, 60)
+        meas = [
+            Measurement(
+                Y=0.0,
+                label=f"Gamma {n}%",
+                stimulus_rgb=(round(n / 100.0 * 1023),) * 3,
+            )
+            for n in levels
+        ]
+        plan = preset_gamma_control_plan(
+            meas,
+            target_gamma=0.0,
+            peak_nits=1000.0,
+            signal_range="full",
+            code_scale="10bit",
+            eotf=PQ_EOTF,
+        )
+        assert plan == []


### PR DESCRIPTION
## 📺 Overview

HDR gamma control plans drove per-point corrections into the firmware tone-mapping wall, emitting "Raise 80% by 5" on every pass forever for PQ points whose ST.2084 reference exceeds panel peak.

Closes [#548](https://github.com/jweber93/tv-calibration/issues/548)

### What does this PR do?

-   **Type of change:** [x] Bug fix | [ ] New feature | [ ] Refactoring | [ ] CI/CD or Tooling
-   **Component(s) affected:** calibrator/utils.py, calibrator/guidance.py, calibrator/__init__.py, tests/test_hdr_gamma_guidance.py

---

## 🛠️ Technical Context & Implementation

-   **The Problem:** `u8g_gamma_control_plan`, `preset_gamma_control_plan`, and `gamma_recommendations` compared per-point PQ tracking against the absolute ST.2084 reference with no notion of the panel tone-map knee. ST.2084 is an absolute EOTF: at 80% stimulus the reference is ~1555 nits and at 70% ~621 nits. On a sub-peak panel (e.g. 700 nits) the measured luminance always reads as "too dark" vs the unreachable reference, so `eotf_from_luminance` returns > 1.0 and the plan emits "Raise 80% by 5 — brighten this point" on every pass, forever. The operator ends up chasing firmware tone mapping with menu controls — exactly what `QE_AUDIT.md` forbids ("Do not correct the 40–70% firmware tone-mapping wall via menu controls").
-   **The Solution:** Add `pq_point_above_knee(stimulus_pct, peak_nits)` in `calibrator/utils.py` — true when `pq_eotf(stimulus) >= peak_nits * margin` (margin 1.0, a hard criterion: the reference is literally unreachable). Then:
    - `u8g_gamma_control_plan`: for PQ sessions, above-knee points emit `direction: "hold"` with reason "PQ reference luminance exceeds panel peak; firmware tone mapping is active here. Do not correct via menu controls." instead of up/down deltas.
    - `gamma_recommendations` / `preset_gamma_control_plan`: exclude above-knee points from the average and the low/high regional lists so overall/preset advice isn't dragged toward "too dark" by an unreachable reference. When all measured points are above the knee, emit a tone-mapping message instead of a misleading "take another reading" fallback.
-   **Impact on existing workflows/APIs:** No API changes. The per-point plan gains a `delta: null` field for knee-held points (previously always a number); consumers reading `direction` are unaffected. Below-knee points keep normal treatment so genuine midtone errors are still surfaced.

---

## 🧪 Testing & Validation

### Environment Details

-   **OS / Target Display:** macOS (CI) / Hisense U8G (production)
-   **Hardware/Mock Used:** Simulated PQ measurement arrays with hard-clip tone mapping

### Verification Steps

1.  `ruff check calibrator tests` — passes
2.  `pytest tests/test_hdr_gamma_guidance.py tests/test_session.py tests/test_utils.py tests/test_eotf_bt1886_degenerate.py` — 54 passed
3.  New regression cases (issue #548):
    - `TestU8gControlPlanPqKnee.test_sub_peak_panel_holds_above_knee_points` — 500-nit panel, correctly tone-mapped 70/80% ⇒ `hold` (not `up`), reason mentions tone mapping
    - `TestU8gControlPlanPqKnee.test_below_knee_too_dark_still_corrected` — below-knee half-scale points still get `up`
    - `TestU8gControlPlanPqKnee.test_knee_helper_boundary` — knee helper boundary + degenerate inputs
    - `TestPqKneeAggregate.test_recommendations_no_highlight_rec_for_clipped_peak` — "raise 70%/80%" rec suppressed for clipped peak
    - `TestPqKneeAggregate.test_preset_plan_holds_for_clipped_peak` — preset plan holds for clipped peak
    - `TestPqKneeAggregate.test_recommendations_all_above_knee_message` — tone-mapping message when all points above knee
4.  Updated `test_pq_too_dark_raises_points` (encoded the old buggy "all up" expectation) — below-knee 20/40/60% still `up`, 80% now `hold`.

### Firmware / TV Settings

-   Verified against target display firmware behavior (PQ tone-mapping knee)
-   Local Dimming set to Medium during calibration sessions
-   PQ (ST.2084) EOTF tracking invariant preserved (1.0 = perfect)

---

## 📸 Visual Evidence (UI / Plot Changes)

-   N/A — backend guidance logic only. Operators will see "Hold 80% — firmware tone-mapping region" in the gamma control plan instead of an infinite "Raise 80% by 5" loop.

---

## 🧼 Checklist

-    Code adheres to project style guidelines (formatting, typing, linting).
-    Unit tests added/updated and passing.
-    Documentation (inline docstrings) updated to reflect the knee guard and `PQ_KNEE_MARGIN` invariant.
-    No credentials, local absolute paths, or hardware-specific hardcoding leaked.