### PR TITLE
Fix mixed above-knee/failed-reading misattribution in gamma aggregate fallbacks

### DIFF
--- a/calibrator/guidance.py
+++ b/calibrator/guidance.py
@@ -356,6 +356,8 @@ def gamma_recommendations(
         if pq and pq_point_above_knee(stim_pct, peak_nits):
             saw_above_knee = True
             continue
+        # Mark that we saw at least one non-above-knee point, regardless of
+        # whether its reading succeeded.
         saw_below_knee = True
         eff_gamma = eotf_from_luminance(m.Y, peak_nits, stim_pct, eotf)
         if eff_gamma is not None:
@@ -544,6 +546,8 @@ def preset_gamma_control_plan(
         if pq and pq_point_above_knee(stim_pct, peak_nits):
             saw_above_knee = True
             continue
+        # Mark that we saw at least one non-above-knee point, regardless of
+        # whether its reading succeeded.
         saw_below_knee = True
         eff = eotf_from_luminance(m.Y, peak_nits, stim_pct, eotf)
         if eff is not None:

--- a/calibrator/guidance.py
+++ b/calibrator/guidance.py
@@ -344,6 +344,7 @@ def gamma_recommendations(
 
     gammas = []
     saw_above_knee = False
+    saw_below_knee = False
     for m in measurements:
         stim_pct = gamma_nominal_pct(m, signal_range, code_scale, levels)
         if stim_pct is None:
@@ -355,15 +356,17 @@ def gamma_recommendations(
         if pq and pq_point_above_knee(stim_pct, peak_nits):
             saw_above_knee = True
             continue
+        saw_below_knee = True
         eff_gamma = eotf_from_luminance(m.Y, peak_nits, stim_pct, eotf)
         if eff_gamma is not None:
             gammas.append({"stimulus_pct": stim_pct, "effective_gamma": eff_gamma})
     if not gammas:
-        # Only attribute the empty result to the tone-mapping region when we
-        # actually saw above-knee points; otherwise the readings themselves
-        # failed and the operator should re-measure rather than be told the
-        # wall is the cause.
-        if pq and saw_above_knee:
+        # Only attribute the empty result to the tone-mapping region when
+        # every measured point was above the knee. If any below-knee point
+        # was seen too, the empty result means readings failed there, and
+        # blaming the wall would send the operator to raise the panel's HDR
+        # peak instead of re-measuring the points that actually failed.
+        if pq and saw_above_knee and not saw_below_knee:
             return [
                 "All measured gamma points sit in the firmware tone-mapping region "
                 "(PQ reference exceeds panel peak). Do not chase them with menu controls; "
@@ -530,6 +533,7 @@ def preset_gamma_control_plan(
         ]
     gammas = []
     saw_above_knee = False
+    saw_below_knee = False
     for m in measurements:
         stim_pct = gamma_nominal_pct(m, signal_range, code_scale, levels)
         if stim_pct is None:
@@ -540,11 +544,16 @@ def preset_gamma_control_plan(
         if pq and pq_point_above_knee(stim_pct, peak_nits):
             saw_above_knee = True
             continue
+        saw_below_knee = True
         eff = eotf_from_luminance(m.Y, peak_nits, stim_pct, eotf)
         if eff is not None:
             gammas.append(eff)
     if not gammas:
-        if pq and saw_above_knee:
+        # Only blame the tone-mapping wall when every measured point was
+        # above the knee. A below-knee point in the mix means readings
+        # failed there instead, and this preset advice would misdirect the
+        # operator toward raising the panel's HDR peak.
+        if pq and saw_above_knee and not saw_below_knee:
             return [
                 {
                     "control": "Gamma preset",

--- a/tests/test_hdr_gamma_guidance.py
+++ b/tests/test_hdr_gamma_guidance.py
@@ -368,3 +368,55 @@ class TestPqKneeAggregate:
             eotf=PQ_EOTF,
         )
         assert plan == []
+
+    def test_recommendations_mixed_failure_and_knee_not_blamed_on_tone_mapping(self):
+        # 1000-nit panel, levels (20, 40, 60, 80). 20/40/60% are below the knee
+        # but failed to read (Y=0 -> eff_gamma None); 80% is genuinely above
+        # the knee (PQ ref ~1555 nits > 1000). Only one of the four points is
+        # actually in the tone-mapping region, so the fallback must not claim
+        # "All measured gamma points" are there — that would send the operator
+        # to raise the panel's HDR peak instead of re-measuring the three
+        # points that simply never registered a reading.
+        levels = (20, 40, 60, 80)
+        meas = [
+            Measurement(
+                Y=0.0,
+                label=f"Gamma {n}%",
+                stimulus_rgb=(round(n / 100.0 * 1023),) * 3,
+            )
+            for n in levels
+        ]
+        recs = gamma_recommendations(
+            meas,
+            target_gamma=0.0,
+            peak_nits=1000.0,
+            signal_range="full",
+            code_scale="10bit",
+            eotf=PQ_EOTF,
+        )
+        joined = " ".join(recs).lower()
+        assert "tone-mapping" not in joined
+        assert "take another gamma reading" in joined
+
+    def test_preset_plan_mixed_failure_and_knee_returns_empty(self):
+        # Same mixed scenario as above: one genuinely above-knee point plus
+        # several failed below-knee readings. The preset plan must fall back
+        # to [] (re-measure), not the "all in tone-mapping region" hold.
+        levels = (20, 40, 60, 80)
+        meas = [
+            Measurement(
+                Y=0.0,
+                label=f"Gamma {n}%",
+                stimulus_rgb=(round(n / 100.0 * 1023),) * 3,
+            )
+            for n in levels
+        ]
+        plan = preset_gamma_control_plan(
+            meas,
+            target_gamma=0.0,
+            peak_nits=1000.0,
+            signal_range="full",
+            code_scale="10bit",
+            eotf=PQ_EOTF,
+        )
+        assert plan == []

--- a/tests/test_hdr_gamma_guidance.py
+++ b/tests/test_hdr_gamma_guidance.py
@@ -420,3 +420,36 @@ class TestPqKneeAggregate:
             eotf=PQ_EOTF,
         )
         assert plan == []
+
+    def test_recommendations_single_above_knee_point_message(self):
+        # A single-measurement pass with just one point, genuinely above the
+        # knee: saw_above_knee=True, saw_below_knee=False -> tone-mapping
+        # message still fires correctly at the minimum input size.
+        recs = gamma_recommendations(
+            self._clipped_pass(1000.0, levels=(80,)),
+            target_gamma=0.0,
+            peak_nits=1000.0,
+            signal_range="full",
+            code_scale="10bit",
+            eotf=PQ_EOTF,
+        )
+        assert any("tone-mapping" in r.lower() for r in recs)
+
+    def test_recommendations_single_failed_point_no_tone_mapping_blame(self):
+        # A single-measurement pass with one below-knee point that failed to
+        # read: saw_above_knee=False, saw_below_knee=True -> generic
+        # "take another reading" fallback, not the tone-mapping message.
+        meas = [
+            Measurement(Y=0.0, label="Gamma 20%", stimulus_rgb=(round(0.20 * 1023),) * 3)
+        ]
+        recs = gamma_recommendations(
+            meas,
+            target_gamma=0.0,
+            peak_nits=1000.0,
+            signal_range="full",
+            code_scale="10bit",
+            eotf=PQ_EOTF,
+        )
+        joined = " ".join(recs).lower()
+        assert "tone-mapping" not in joined
+        assert "take another gamma reading" in joined


### PR DESCRIPTION
## 📺 Overview

Follow-up to #570 (issue #548). `gamma_recommendations` and `preset_gamma_control_plan` can misattribute an empty aggregate result to the firmware tone-mapping wall when the real cause is unrelated failed readings.

### What does this PR do?
* **Type of change:** [x] Bug fix | [ ] New feature | [ ] Refactoring | [ ] CI/CD or Tooling
* **Component(s) affected:** calibrator/guidance.py, tests/test_hdr_gamma_guidance.py

---

## 🛠️ Technical Context & Implementation

* **The Problem:** #570 added a `saw_above_knee` flag to `gamma_recommendations`/`preset_gamma_control_plan` so the empty-`gammas` fallback could tell "all points are in the tone-mapping region" apart from "readings failed." But the flag is set the moment *any* point is above the knee, while the fallback message claims "**All** measured gamma points sit in the firmware tone-mapping region." On a panel where some below-knee points simply failed to read (`Y <= 0` → `eff_gamma is None`) while a separate point happens to be genuinely above the knee, the message fires and wrongly tells the operator to "raise the panel's HDR peak" instead of re-measuring the points that actually failed.
* **The Solution:** Track a second flag, `saw_below_knee`, for any point that wasn't excluded by the knee guard (regardless of whether its `eff_gamma` came back `None`). The tone-mapping message is now only returned when `saw_above_knee and not saw_below_knee` — i.e. every measured point was genuinely above the knee, not just at least one.
* **Impact on existing workflows/APIs:** No API changes. The pure "all above knee" and "all failed, none above knee" cases from #570 are unaffected (already covered by existing tests); this only changes the previously-untested mixed case to return the generic "take another reading" fallback instead of the tone-mapping message.

---

## 🧪 Testing & Validation

### Environment Details
* **OS / Target Display:** CI / N/A (backend guidance logic only)
* **Hardware/Mock Used:** Simulated PQ measurement arrays

### Verification Steps
1. `ruff check calibrator tests` — passes
2. `pytest tests/test_hdr_gamma_guidance.py tests/test_session.py tests/test_utils.py tests/test_eotf_bt1886_degenerate.py` — all passing
3. New regression cases:
   - `test_recommendations_mixed_failure_and_knee_not_blamed_on_tone_mapping` — 1000-nit panel, 20/40/60% failed readings + genuinely above-knee 80% ⇒ "take another gamma reading," not the tone-mapping message
   - `test_preset_plan_mixed_failure_and_knee_returns_empty` — same mixed scenario ⇒ preset plan returns `[]`, not the tone-mapping hold

---

## 🧼 Checklist
* [x] Code adheres to project style guidelines (formatting, typing, linting).
* [x] Unit tests added/updated and passing.
* [x] Documentation (inline comments) updated to reflect the `saw_below_knee` invariant.
* [x] No credentials, local absolute paths, or hardware-specific hardcoding leaked.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KJv3BfWDpY13iKaw7ThUSp)_