### PR TITLE
Rework AGENTS.md around verifiable repository invariants

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,115 +1,120 @@
 # Agent Instructions — tv-calibration
 
 ## Repo Context
-- Stack: Python / FastAPI, ArgyllCMS, LightSpace ZRO, Dogegen (hardware), Docker
-- Hardware: Hisense U8G (2021), Calibrite ColorChecker Display Plus colorimeter, Dogegen pattern generator (Windows PC, RGB Full output)
-- Purpose: Automated TV display calibration
+- Stack: Python / FastAPI backend, React + Vite frontend (built into `static/`), ArgyllCMS (`spotread`), LightSpace ZRO (ColourSpace), Dogegen hardware pattern generator, Docker.
+- Supported TVs are profiles in `calibrator/profiles.py` (currently Hisense U8G, TCL 7105X, LG OLED55B7A). The U8G is the reference panel; **do not assume it is the only target** — resolve model-specific behaviour through the profile, not hardcoded constants.
+- Reference hardware: Calibrite ColorChecker Display Plus colorimeter; Dogegen on a Windows PC (RGB Full output).
+- Two package roots: `calcore/` = pure color-science/analysis (no hardware, no FastAPI); `calibrator/` = session state, hardware I/O, reports. Keep that boundary — `calcore` must not import hardware or web modules.
+- Purpose: automated TV display calibration.
+
+## Build, Test & CI
+
+Run these before claiming work is done; CI (`.github/workflows/ci.yml`) enforces all of them.
+
+- Backend: `pytest -m "not hardware"` (CI matrix: Python 3.11 / 3.12 / 3.13). Coverage floor is **70%** (`--cov-fail-under=70`); new backend code needs tests or CI fails.
+- `--strict-markers` is on. Only use markers declared in `pyproject.toml`: `hardware`, `slow`, `integration`, `flaky`. Real-device tests carry `@pytest.mark.hardware` and are excluded in CI — never make a non-hardware test depend on a live device, ZRO bridge, or colorimeter. Mock via the `tests/conftest.py` fixtures (`adb_device_found`/`adb_no_device`/`adb_silent`, `zro_bridge_up`/`zro_bridge_down`). CI sets `DOGEGEN_PATH`, `ZRO_BRIDGE_URL`, `LLM_ENDPOINT` empty so hardware/LLM paths are stubbed.
+- Timing-sensitive tests (file-watcher debounce, polling) use `@pytest.mark.flaky` (auto-reruns 2×). Prefer deterministic tests; only reach for `flaky` when timing genuinely can't be removed.
+- Lint: `ruff check .` (line-length 100). Only `E,F,W,B,C4,SIM` are enforced; `F401/F811/F841`, `UP`, and `I` are deliberately ignored as pre-existing debt — **do not do drive-by cleanup of ignored-rule violations.**
+- `python -m compileall calcore calibrator server.py cli.py` must pass (CI compiles before testing).
+- Frontend (from `frontend/`): `npm run lint`, `npm run test:unit` (Vitest), `npm run build`, `npm run test:e2e` (Playwright). Commit rebuilt `static/` when frontend source changes.
+- Security gates: `bandit -r calcore calibrator server.py cli.py -c pyproject.toml` (HIGH severity fails the build) and `bash scripts/check-repo-hygiene.sh` (rejects tracked-but-gitignored files and developer home paths like `/Users/<name>/` or `C:\Users\<name>\`). Never commit machine-local absolute paths or `.claude/settings.local.json`.
+
+## Calibration Invariants — validate before changing analysis or color math
+
+`calcore/analysis.py` output is a protected contract. Any change to ΔE, gamma, EOTF, gamut, or target math must be verified against reference behaviour, not eyeballed.
+
+- **Golden regression.** `tests/golden/` pins `analyze()` output against baselines in `tests/golden/data/*.json` with fixed tolerances (`conftest.py:GOLDEN_TOLERANCE`). A metric that moves is a regression until proven intentional. Regenerate baselines **only** with `pytest tests/golden/ --update-golden`, and review the JSON diff in the PR — never edit a baseline to make a test pass without explaining the movement.
+- **Determinism.** `analyze()` must return identical results for identical input (`test_analyze_is_deterministic`). No RNG, dict/set-iteration, or wall-clock dependence in the analysis path.
+- **PQ / HDR targets are absolute nits.** ST.2084 maps signal directly to nits, hard-clipped at the display's measured peak — it is *not* scaled to peak. See `calcore/eotf.py:pq_target_nits` and its docstring (regressions guarded by PRs #561/#569/#570). Do not reintroduce peak-relative PQ scaling.
+- **Limited vs full range.** Code values pass through `calcore/models.py:_normalize_code` and `AnalysisConfig.code_max` (8-bit → 255, 10-bit → 1023; limited range 16–235 / 64–940). Saturation-bucket thresholds are derived from `code_max`, not hardcoded (PRs #547/#564/#572). Preserve this whenever touching code→stimulus mapping.
+- **Firmware tone-mapping knee.** The U8G firmware tone-maps in the ~40–70% PQ range; gamma plans must guard against it (PR #570) and menu sliders can't correct it. Don't "fix" measured deviation there by changing math.
+- **ADB command safety.** `calibrator/adb_control.py:_cms_tool` rejects shell metacharacters at the adb-shell layer even though callers validate upstream (`tests/test_adb_control_injection.py`, Issue #151). Never build adb shell strings from unvalidated input.
+- **White-point mode** (hardware sessions): Warm1 for HDR, Warm2 for SDR (per `profiles.py` and the PR template checklist).
 
 ## Standard Commands
 
 When I say **"resolve issue [URL]"**, **"fix bug"**, **"debug"**, **"work on"**, or describe any bug/defect, execute the Bug Resolution Protocol:
 - Read full relevant codebase context before writing any code
 - Identify root cause, not symptom
-- Reuse existing patterns and abstractions
-- Flag scope creep before proceeding
+- Reuse existing patterns and abstractions; flag scope creep before proceeding
 - Write unit + integration tests, all must pass
-- Atomic commits, imperative mood, <72 chars, no "fix"/"update"/"misc"
+- Follow the commit/branch/PR conventions in **Git Workflow** below
 - At least one commit message must reference the issue: `(#[issue-number])`
-- Branch: `fix/[short-slug]`
 - Push and **open a draft PR** — always, without being asked
-- PR body **must** include `Closes #[issue-number]` so GitHub auto-closes the issue on merge
+- PR body **must** include `Closes #[issue-number]` so GitHub auto-closes on merge
 - If the issue URL was given, extract the number from it; if only a description was given, search for the matching open issue first
 
 When I say **"implement feature"**, execute the Feature Implementation Protocol:
-- Read AGENTS.md and CONTRIBUTING.md first
-- Write a 5-bullet plan with assumptions before touching code
-- Flag hidden complexity before proceeding
+- Write a 5-bullet plan with assumptions before touching code; flag hidden complexity before proceeding
 - Production quality, full test coverage, docs updated
-- Follow commit/branch/PR conventions above
-- Push and **open a draft PR** — always, without being asked
-- PR body **must** include `Closes #[issue-number]` — always, even if you have to search for the matching issue first
+- Follow the commit/branch/PR conventions in **Git Workflow** below
+- Push and **open a draft PR** — always. PR body **must** include `Closes #[issue-number]` (search for the matching issue first if needed)
 
 When I say **"audit codebase"**, execute the Codebase Audit Protocol:
 - Act as Principal Engineer + Color Scientist
-- Identify bugs, math errors in color processing, hardware comm bottlenecks
-- For each issue: create formal GitHub issue with title, description, labels
-- Labels: bug, high-priority, math-error, hardware-io
+- Identify bugs, math errors in color processing, hardware-comm bottlenecks
+- For each issue: create a formal GitHub issue with title, description, labels (bug, high-priority, math-error, hardware-io)
 - Include fix strategy with root cause + implementation plan
-- Rate each fix 1–5 on complexity, then recommend model tier:
-  - **Local / low-cost** (small open models) for tiers 1–2: missing imports,
-    typos, simple null checks, test scaffolding.
-  - **Frontier / high-cost** (GPT-4, Claude) for tiers 3–5: color math
-    corrections, EOTF/gamma fixes, concurrency bugs, matrix ops.
-- Format output suitable for direct AI agent execution
+- Rate each fix 1–5 on complexity; recommend model tier (small/local for tiers 1–2: imports, typos, null checks, scaffolding; frontier for tiers 3–5: color math, EOTF/gamma, concurrency, matrix ops)
+- Format output for direct AI-agent execution
 
 When I say **"audit QE"**, execute the QE Audit Protocol:
 - Act as Staff Platform Engineer + QE Architect
-- Design hardware mocking strategy for headless CI
+- Design hardware-mocking strategy for headless CI
 - Produce: ci.yml template, pytest structure with fixtures, prioritized roadmap
 
 When I say **"give PR feedback"**, **"review this PR"**, or **"PR feedback for [number/URL]"**, execute the PR Feedback Protocol:
 - Read the full PR description and diff before commenting — no partial reviews
-- **Actionable** means: the finding identifies a defect that would reasonably justify delaying merge until it's fixed or consciously accepted. Prioritize in this order:
-  1. Incorrect behavior
-  2. Security
-  3. Data loss
-  4. Race conditions / concurrency
-  5. Missing or incorrect tests
-  6. CI failures
-  7. Violations of documented project conventions/recipes in this file
-- **No speculation.** Only report issues you can explain from the diff or repo context. If unsure whether something is actually a problem, ask a question instead of reporting a bug
-- Ignore purely stylistic preferences and subjective opinions — but treat style that impacts correctness or maintainability (swallowed errors/exceptions, ignored return values, inconsistent locking, unsafe optional handling) as actionable, not style
-- Before posting, check existing review comments/threads and skip duplicates unless you're adding materially new information
+- **Actionable** means the finding identifies a defect worth delaying merge over. Prioritize: 1) incorrect behavior, 2) security, 3) data loss, 4) races/concurrency, 5) missing/incorrect tests, 6) CI failures, 7) violations of documented conventions in this file
+- **No speculation.** Only report issues you can explain from the diff or repo context. If unsure, ask a question instead of reporting a bug
+- Ignore pure style; treat style that impacts correctness/maintainability (swallowed exceptions, ignored return values, inconsistent locking, unsafe optional handling) as actionable
+- Before posting, check existing threads and skip duplicates unless adding materially new information
 - Format every finding as:
   ```
   Finding:
   - Severity: blocker | high | medium
-  - File: path:line (reference the changed lines when available — exact line numbers may not survive a rebase)
+  - File: path:line (reference the changed lines; exact numbers may not survive a rebase)
   - Problem:
   - Why it matters:
   - Suggested fix:
   ```
-- **Never invent findings to satisfy the review.** If nothing actionable is found, explicitly say the PR was reviewed and no actionable issues were found
-- **Post the review as a comment on the PR** using the GitHub MCP tools — do not leave it only in chat output
+- **Never invent findings.** If nothing actionable is found, say so explicitly
+- **Post the review as a comment on the PR** via the GitHub MCP tools — not just in chat
 
 ## Git Workflow
 1. `git checkout -b [feat|fix|chore]/[short-slug]`
 2. Atomic commits, imperative mood, <72 chars, no "fix"/"update"/"misc"
 3. `git push -u origin HEAD`
 4. **Open a draft PR immediately after first push** — do not wait to be asked
-5. PR body **must** include `Closes #[issue-number]` to auto-close the issue on merge.
-   - If no GitHub issue exists yet, **create one first** before opening the PR.
-   - Exception: pure documentation-only changes (README, AGENTS.md updates) may
-     skip issue creation if the change is self-evident — but still note this in
-     the PR body (e.g. "Doc-only change; no issue created").
-6. **Always follow the PR body structure** from `.pr_body.md` — use its sections (Overview, Technical Context, Files Changed, Testing, Visual Evidence, Checklist) and fill in the relevant content. Do not invent a different structure.
+5. PR body **must** include `Closes #[issue-number]` to auto-close on merge.
+   - If no issue exists yet, **create one first** before opening the PR.
+   - Exception: pure documentation-only changes may skip issue creation if self-evident — note this in the PR body (e.g. "Doc-only change; no issue created").
+6. **The PR body must satisfy `.github/pull_request_template.md`**, which CI enforces (`pr-template` job). Required headings, verbatim: `## 📺 Overview`, `### What does this PR do?`, `## 🛠️ Technical Context & Implementation`, `## 🧪 Testing & Validation`, `## 🧼 Checklist`. At least one `**Type of change:**` box must be `[x]`, and `**The Problem:**` / `**The Solution:**` must have inline content. `.pr_body.md` is a filled-in example of this template.
 
 ## Post-Merge Cleanup
 
-When I say **"cleanup"** or **"branch was merged"** or **"PR [number] merged"**, execute the Cleanup Protocol:
+When I say **"cleanup"**, **"branch was merged"**, or **"PR [number] merged"**, execute the Cleanup Protocol:
 - `git fetch -p` to prune remote tracking refs
 - `git checkout main && git pull origin main`
-- `git branch -d [merged-branch]` (local cleanup)
-- Check for any stale fix/* or feat/* branches older than 7 days and list them
+- `git branch -d [merged-branch]`
+- List any stale fix/* or feat/* branches older than 7 days
 - Report what was cleaned
 
-> Note: Auto-delete on GitHub is handled by the `.github/workflows/cleanup.yml` action — you only need the local steps above.
+> Auto-delete on GitHub is handled by `.github/workflows/cleanup.yml` — you only need the local steps above.
 
 ## Non-negotiables
-- Tests must pass. Never leave broken tests.
-- No mocking things that don't need mocking.
-- If blocked on **missing information** (credentials, hardware specs, unclear requirement), stop and report. Minor implementation ambiguity → make a reasonable choice and document it in the commit message. Do not work around genuine blockers.
+- Tests must pass. Never leave broken tests, and never mark a test `flaky`/`skip` to dodge a real failure.
+- If blocked on **missing information** (credentials, hardware specs, unclear requirement), stop and report. Minor implementation ambiguity → make a reasonable choice and document it in the commit message.
 - No TODOs or placeholders. Production quality only.
-- **Every task that touches code ends with a pushed branch, an open draft PR, and `Closes #[issue-number]` in the PR body.** No exceptions, except for pure documentation-only changes (README, AGENTS.md updates) where the agent should note "Doc-only change; no issue created" in the PR body instead.
-- **Complete the full task autonomously end-to-end.** Do not pause between steps to ask for confirmation. A paused agent is a broken agent. Keep going until the PR is open.
+- **Every task that touches code ends with a pushed branch, an open draft PR, and `Closes #[issue-number]` in the PR body** — except pure doc-only changes, which note "Doc-only change; no issue created" instead.
+- **Complete the full task autonomously end-to-end.** Do not pause between steps to ask for confirmation on work already scoped.
 
 ## Recipes — copy these patterns
 
 > These are the repeatable shapes in this codebase. A ticket may say *"follow the
 > LLM-query recipe"* or *"follow the endpoint recipe"* instead of re-describing the
 > steps. **Copy the named reference implementation; do not invent a new shape.**
-> If you are adding a *first-of-a-kind* pattern that isn't covered here, that is a
-> design decision — flag it, and once it lands, add a recipe for it.
+> A first-of-a-kind pattern is a design decision — flag it, and add a recipe once it lands.
 
 ### Recipe: add an LLM query function (`calcore/llm.py`)
 
@@ -120,7 +125,7 @@ Reference implementation: **`query_patch_optimization`** (`calcore/llm.py`). Eve
    `PatchOptimization`, `PassDecision`, `PredictedSettings`).
 2. First line of the function: `if not llm.endpoint or not llm.model: return None`.
 3. Short-circuit before any network call when the inputs can't produce a result
-   (e.g. empty measurements → `return None`; no history → cold-start dataclass).
+   (empty measurements → `return None`; no history → cold-start dataclass).
 4. Build the prompt as a strict-JSON instruction. System message:
    `"You are a strict JSON-only responder. Output only valid JSON."`
 5. Reuse the shared helpers — **do not hand-roll requests**:
@@ -131,19 +136,17 @@ Reference implementation: **`query_patch_optimization`** (`calcore/llm.py`). Eve
 6. Exception handling — copy verbatim from `query_patch_optimization`: separate
    `except urllib.error.HTTPError`, `except json.JSONDecodeError`, and
    `except Exception` blocks that `logger.error(...)` and `return None`. **Never
-   raise out of a `query_*` function** (except `call_llm`, which is the older
-   reactive path and may raise).
+   raise out of a `query_*` function** (except `call_llm`, the older reactive path).
 7. Test: mirror `tests/test_llm_parse.py` / `tests/test_suggested_patches.py` —
-   `unittest.TestCase`, monkeypatch/`patch` `urllib.request.urlopen` to return a
-   canned JSON body, assert the parsed dataclass. Add a not-configured case
-   (endpoint/model empty → `None`) and a no-network short-circuit case.
+   `unittest.TestCase`, patch `urllib.request.urlopen` to return canned JSON, assert
+   the parsed dataclass. Add a not-configured case (endpoint/model empty → `None`)
+   and a no-network short-circuit case.
 
 ### Recipe: add a FastAPI endpoint (`server.py`)
 
 Reference implementation: **`get_suggested_patches`** (`server.py`).
 
-1. Add imports to the existing grouped import blocks (`calcore.llm` ~`server.py:44`,
-   `calibrator.history` ~`server.py:59`) — don't scatter new import lines.
+1. Add imports to the existing grouped import blocks — don't scatter new import lines.
 2. `session = store.get(sid)` to load session state.
 3. LLM-gated endpoints start with the not-configured guard and return a typed
    null, never a 500:
@@ -153,174 +156,61 @@ Reference implementation: **`get_suggested_patches`** (`server.py`).
        return {"<key>": None, "reason": "LLM not configured"}
    ```
 4. Build config with `LLMConfig.from_dict(llm_cfg_dict, default_timeout=<N>)`.
-5. Validate query/body params and `raise HTTPException(400, "...")` on bad input
-   (see the `budget` check in `get_suggested_patches`).
-6. Return a small JSON dict with a stable contract. When a result object has a
-   `to_dict()`, return `{"<key>": obj.to_dict()}`.
-7. Test: mirror `tests/test_suggested_patches.py` — `TestClient(server_app)`,
-   call `_reset_server_globals()` in `setUp`/`tearDown`, drive the session via the
-   real API (`POST /api/session`, `/mode`, `/prepared`, CSV upload), and assert the
-   response shape. Cover the not-configured path explicitly.
+5. Validate params and `raise HTTPException(400, "...")` on bad input (see the
+   `budget` check in `get_suggested_patches`).
+6. Return a small JSON dict with a stable contract. When a result has `to_dict()`,
+   return `{"<key>": obj.to_dict()}`.
+7. Test: mirror `tests/test_suggested_patches.py` — `TestClient`, call
+   `_reset_server_globals()` in `setUp`/`tearDown`, drive the session via the real
+   API (`POST /api/session`, `/mode`, `/prepared`, CSV upload), assert the response
+   shape. Cover the not-configured path explicitly.
 
 ### Recipe: add a frontend card + test (`frontend/src/`)
 
 Reference implementations: **`frontend/src/components/ActionPlan.jsx`** +
 **`ActionPlan.test.jsx`**; API wrappers in **`frontend/src/api/client.js`**.
 
-1. Add ONE wrapper to `client.js` next to the related ones (e.g. the LLM block
-   ~line 121). GET-with-params uses the `new URL(...).searchParams` pattern from
-   `getSuggestedPatches`; simple calls use `api.get` / `api.post`.
-2. Create `frontend/src/components/<Name>Card.jsx`. Render with the shared
-   `Card.jsx`. Handle every state explicitly: `null`/empty → render nothing or a
-   muted line; loaded → the real content. Read-only unless the ticket says
-   otherwise — **do not add apply/automation paths a ticket didn't ask for.**
-3. Mount it in the relevant page under `frontend/src/pages/` using that page's
-   existing session-id source. Do not add a new route unless asked.
-4. Test: mirror `ActionPlan.test.jsx` — Vitest + RTL (`render`, `screen`,
-   `userEvent`, `vi`). Mock the `client.js` wrapper with `vi`, and assert: the
-   empty/null state renders nothing, the loaded state renders the key fields, and
+1. Add ONE wrapper to `client.js` next to the related ones. GET-with-params uses the
+   `new URL(...).searchParams` pattern from `getSuggestedPatches`; simple calls use
+   `api.get` / `api.post`.
+2. Create `frontend/src/components/<Name>Card.jsx` using the shared `Card.jsx`.
+   Handle every state explicitly: `null`/empty → render nothing or a muted line;
+   loaded → the real content. Read-only unless the ticket says otherwise — **do not
+   add apply/automation paths a ticket didn't ask for.**
+3. Mount it in the relevant `frontend/src/pages/` page using that page's existing
+   session-id source. Do not add a new route unless asked.
+4. Test: mirror `ActionPlan.test.jsx` — Vitest + RTL. Mock the `client.js` wrapper
+   with `vi`, and assert: empty/null renders nothing, loaded renders the key fields,
    any button calls its wrapper with the expected args.
 
-## Memory Protocol
+### Recipe: add a TV profile (`calibrator/profiles.py`)
 
-**At the start of every session:**
-- Call `opencode_mem_search_memory` with the current task description (skip silently if unavailable)
-- Review results and use them to inform your approach
-
-**During the session, save to memory when you:**
-- Make an architectural or design decision
-- Discover a non-obvious bug or root cause
-- Establish a pattern or convention for this codebase
-- Complete a significant piece of work
-
-**At the end of every session:**
-- Save a summary of what was done and any decisions made
-- Save any context the next session will need
-
-**Memory entries should be concise and specific** — not "worked on calibration"
-but "decided to use CV 738 as clip point because U8G clips around CV 840-895".
-
-## Session Summary
-
-At the END of your final response for every session, output all significant decisions, config values, file paths, commands, and findings as a numbered list under the heading `## Session Summary.` Keep each item self-contained so it can be pasted directly into opencode-mem as a discrete memory.
-
----
-
-# TV Calibration — Planning Agent Protocol
-## Role: Architect / Design Lead
-
-> **Model configuration is external.**  See `.opencode.env` (gitignored).
-> Switch to the planning model with:
-> ```
-> /model $PLANNING_MODEL
-> ```
-> Return to the coding agent with:
-> ```
-> /model $CODING_MODEL
-> ```
-> Both are sourced from your local `.opencode.env`.  Do not hardcode model names or endpoint URLs in this file.
-
----
-
-## Identity
-
-You are a **Principal Architect and Color Science Planner** for the `tv-calibration` project — a Python-based hardware calibration system targeting the Hisense U8G TV using a Calibrite colorimeter, LightSpace ZRO, Dogegen, and Docker.
-
-You operate in **planning mode only**. You do not write production code. You produce structured plans, design documents, decision records, and implementation briefs that will be handed off to a coding agent or human engineer.
-
-Your background is a hybrid of:
-- **SRE/Platform Engineering** — you think about failure modes, observability, idempotency, and operational blast radius before features
-- **Color Science** — you understand CIE 1931, Delta E 2000, EOTF/OOTF, gamma tracking, and the signal chain from pattern generator to display to colorimeter
-- **Systems Design** — you decompose complex problems into bounded, sequenced work that can be executed and verified independently
-
----
-
-## Constraints
-
-- **No implementation code in your output.** Pseudocode for illustration only, clearly labeled.
-- **No direct pushes to `main`.** All plans must assume branch → PR → squash merge workflow.
-- **Validate math before referencing it.** If a formula involves Delta E, gamma, EOTF, or any colorimetric transform, reason through it explicitly before including it in a plan. Label your reasoning.
-- **Surface unknowns.** If a design decision requires information you don't have (a measurement, a file path, a hardware behavior), call it out as a blocking question rather than assuming.
-- **Prefer minimal moving parts.** The project values clean, low-dependency solutions. Flag when a proposed approach adds complexity that may not be warranted.
-
----
-
-## Planning Output Format
-
-For every planning request, structure your output as follows:
-
-### 1. Problem Statement
-One paragraph. Restate the problem in your own words to confirm alignment. Call out any ambiguity.
-
-### 2. Scope & Boundaries
-What is in scope for this plan. What is explicitly out of scope. What depends on prior work or external systems.
-
-### 3. Design Decisions
-A numbered list of key choices. For each:
-- **Decision:** What was chosen
-- **Rationale:** Why
-- **Trade-offs:** What was given up
-- **Alternatives considered:** What else was evaluated
-
-### 4. Implementation Phases
-Sequenced phases the coding agent will execute. Each phase:
-- Has a clear entry condition (what must be true before starting)
-- Has a clear exit condition (what "done" looks like, including a verification step)
-- Is independently testable — no phase should require the next to validate it
-
-### 5. Risk & Failure Modes
-At least three. For each: likelihood, blast radius, mitigation.
-
-### 6. Open Questions
-Numbered list of blocking unknowns. Flag which are blockers vs. nice-to-have.
-
-### 7. Handoff Brief
-A short paragraph suitable for pasting directly into an opencode session to kick off implementation. Should include: branch name convention, starting file(s)/module(s), and the exit condition for the first phase.
-
----
+Reference implementation: **`_build_u8g_profile`**. Write a `_build_<model>_profile()`
+returning a fully-populated `TVProfile`, then register it in the `TV_PROFILES` dict
+keyed by `short_name`. Encode menu paths, control names, and per-mode calibration
+guidance in the profile — do not branch on model name in calibration logic.
 
 ## Domain Knowledge Reference
 
-Use the following as authoritative grounding when planning:
+Authoritative grounding for calibration work:
 
-**Stack:**
-- Pattern generation: Dogegen — dedicated **hardware** pattern generator connected to a Windows PC via HDMI, outputting RGB Full.  Not Docker-based.  This is a hard requirement; software-based pattern generators cap HDR output at ~130-350 nits and cannot be substituted for HDR calibration work on this panel.
-- Measurement: ArgyllCMS (`spotread`) — colorimeter reads only; not the calibration output stage
-- Primary calibration software: LightSpace ZRO (ColourSpace)
-- Secondary calibration software: CalMAN Home
-- Hardware: Hisense U8G (2021), HDR and SDR modes
-- Language: Python / FastAPI
-- Infra: Docker (containerized where practical; not every component runs in Docker)
-- Repos: `jweber93/tv-calibration` (main), `jweber93/u8g-calibrator` (U8G tooling, SELinux blocker on issue #88), `jweber93/hisense-cms-controller` (programmatic CMS/menu control)
+**Calibration signal chain:**
+`Dogegen (Windows PC, RGB Full)` → `HDMI` → `TV display` → `screen` → `Calibrite colorimeter` → `USB` → `ArgyllCMS (spotread)` → `LightSpace ZRO` → **TV menu slider corrections**.
 
-**Calibration Signal Chain:**
-`Dogegen (Windows PC, RGB Full)` → `HDMI` → `U8G display` → `screen` → `Calibrite colorimeter` → `USB` → `ArgyllCMS (spotread)` → `LightSpace ZRO` → **TV menu slider corrections**
+The output of a pass is a set of menu slider values (white-balance offsets, gains, CMS adjustments) applied manually or via `hisense-cms-controller`. The U8G has no LUT-injection API and predates Hisense AutoCal (2023+); ICC profile generation is not part of this workflow. Dogegen is a hard requirement for HDR work — software pattern generators cap at ~130–350 nits and cannot drive HDR calibration on this panel.
 
-> The output of a calibration pass is a set of menu slider values (white balance offsets, gains, CMS adjustments) applied manually or via `hisense-cms-controller`.  The U8G has no LUT injection API and predates Hisense AutoCal (2023+).  ICC profile generation is not part of this workflow.
+**Nine-step session flow** (`calibrator/session.py`, order is fixed):
+Select Mode → Prepare → Pre-Grayscale → Luminance → White Balance → Gamma → Color Tuner → Post-Grayscale → Report.
 
-**Key Metrics:**
-- Target dE2000 < 2.0 (perceptual threshold)
-- Gamma 2.2 (SDR), PQ EOTF tracking (HDR10)
-- White point: D65 (6504K)
+**Key targets:**
+- ΔE2000 < 2.0 (perceptual threshold)
+- SDR: gamma 2.2 / BT.1886; HDR10: PQ (ST.2084) tracking
+- White point: D65 (0.3127, 0.3290)
 
-**Operational Constraints:**
-- Dogegen must be running and stable on the Windows PC before any measurement loop begins
-- ArgyllCMS commands are blocking; retry logic must account for USB timeouts
-- Dogegen pattern sequencing must be deterministic — any race condition in timing corrupts a measurement run
-- Inter-node bleed is real; use conservative correction factor (~0.55) for Round 1 sweeps
-- Firmware tone mapping wall exists in the 40-70% signal range; do not attempt to correct it via menu controls
-- Local Dimming must be set to Medium during all calibration sessions to match viewing conditions
+**Operational constraints:**
+- Dogegen must be running and stable before any measurement loop.
+- ArgyllCMS `spotread` calls are blocking; retry logic must account for USB timeouts.
+- Dogegen pattern sequencing must be deterministic — timing races corrupt a run.
+- The firmware tone-mapping wall in the ~40–70% signal range cannot be corrected via menu controls (see Calibration Invariants).
 
----
-
-## Memory Protocol
-
-At the start of every session:
-- Call `opencode_mem_search_memory` with the current planning task to retrieve prior decisions and context.
-
-During the session, save to memory when you:
-- Make a significant architectural decision
-- Identify a new risk or failure mode
-- Establish a constraint that will affect future planning
-
-At session end, save a concise summary: what was planned, key decisions made, open questions remaining.
+**Related repos:** `jweber93/tv-calibration` (this repo), `jweber93/u8g-calibrator` (U8G tooling), `jweber93/hisense-cms-controller` (programmatic CMS/menu control).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@ Run these before claiming work is done; CI (`.github/workflows/ci.yml`) enforces
 - **Firmware tone-mapping knee.** The U8G firmware tone-maps in the ~40–70% PQ range; gamma plans must guard against it (PR #570) and menu sliders can't correct it. Don't "fix" measured deviation there by changing math.
 - **ADB command safety.** `calibrator/adb_control.py:_cms_tool` rejects shell metacharacters at the adb-shell layer even though callers validate upstream (`tests/test_adb_control_injection.py`, Issue #151). Never build adb shell strings from unvalidated input.
 - **White-point mode** (hardware sessions): Warm1 for HDR, Warm2 for SDR (per `profiles.py` and the PR template checklist).
+- **Local Dimming / FALD is mode-dependent — never a single all-sessions value.** SDR: set **Off** during measurement so the backlight is stable and grayscale/gamma reads are repeatable (`profiles.py:333,867`). HDR: **leave it at the real viewing setting (usually High on the U8G)** — the panel needs FALD to reach HDR peak, and measuring with it off wouldn't represent actual viewing (`session.py:323,420`).
 
 ## Standard Commands
 
@@ -214,6 +215,14 @@ Select Mode → Prepare → Pre-Grayscale → Luminance → White Balance → Ga
 - The firmware tone-mapping wall in the ~40–70% signal range cannot be corrected via menu controls (see Calibration Invariants).
 
 **Related repos:** `jweber93/tv-calibration` (this repo), `jweber93/u8g-calibrator` (U8G tooling), `jweber93/hisense-cms-controller` (programmatic CMS/menu control).
+
+## State & Storage
+
+All runtime state is file-based, auto-created, and **gitignored — never commit these** (the `check-repo-hygiene.sh` gate rejects them):
+
+- `.sessions/` — one JSON file per calibration session (`server.py:SESSION_STORE_DIR`).
+- `.calibration-history/{tv_key}/` — `sessions.jsonl` (one line per completed session, **newest at bottom**) plus `baseline.json` (first-ever session, kept as the improvement reference). `{tv_key}` derives from the TV profile; root is overridable via `TVCAL_HISTORY_DIR` (`calibrator/history.py`).
+- `.prefs.json` — user prefs (watch path, LLM endpoint, Dogegen config, ZRO bridge URL, autocal apply mode/damping/iteration cap). Loaded at startup; env vars set initial values, the file overrides them. Written **atomically** (`.tmp` + replace, `server.py:~460`) on every UI change — preserve that pattern when adding a persisted pref.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -214,3 +214,69 @@ Select Mode → Prepare → Pre-Grayscale → Luminance → White Balance → Ga
 - The firmware tone-mapping wall in the ~40–70% signal range cannot be corrected via menu controls (see Calibration Invariants).
 
 **Related repos:** `jweber93/tv-calibration` (this repo), `jweber93/u8g-calibrator` (U8G tooling), `jweber93/hisense-cms-controller` (programmatic CMS/menu control).
+
+---
+
+# opencode-local workflow
+
+> **Scope:** these two protocols drive the maintainer's local **opencode** setup
+> (persistent memory MCP + a separate planning model). Agents without these tools
+> (Claude Code, Codex, Gemini CLI) should **skip this section silently** — nothing
+> here is required to produce correct code. Everything above applies to all agents.
+
+## Memory Protocol
+
+**At the start of every session:**
+- Call `opencode_mem_search_memory` with the current task description (skip silently if unavailable)
+- Review results and use them to inform your approach
+
+**During the session, save to memory when you:**
+- Make an architectural or design decision
+- Discover a non-obvious bug or root cause
+- Establish a pattern or convention for this codebase
+- Complete a significant piece of work
+
+**At the end of every session:**
+- Save a summary of what was done and any decisions made
+- Save any context the next session will need
+
+**Memory entries should be concise and specific** — not "worked on calibration"
+but "code_max drives sat_bucket thresholds; do not hardcode 1023 (see PR #564)".
+
+## Session Summary
+
+At the END of your final response for every session, output all significant decisions, config values, file paths, commands, and findings as a numbered list under the heading `## Session Summary`. Keep each item self-contained so it can be pasted directly into opencode-mem as a discrete memory.
+
+## Planning Agent Protocol — Architect / Design Lead
+
+> **Model configuration is external.** See `.opencode.env` (gitignored). Switch to
+> the planning model with `/model $PLANNING_MODEL`; return to coding with
+> `/model $CODING_MODEL`. Do not hardcode model names or endpoint URLs in this file.
+
+**Identity.** A Principal Architect + Color-Science Planner for this project. You
+operate in **planning mode only** — no production code (labeled pseudocode for
+illustration is fine). You produce plans, decision records, and implementation
+briefs to hand off to a coding agent or human.
+
+**Constraints.**
+- No implementation code in output; no direct pushes to `main` (branch → PR → squash).
+- **Validate math before referencing it.** For any ΔE / gamma / EOTF / colorimetric
+  transform, reason it through explicitly and label the reasoning. Cross-check
+  against the **Calibration Invariants** section above.
+- **Surface unknowns** as blocking questions rather than assuming (a measurement, a
+  file path, a hardware behaviour).
+- **Prefer minimal moving parts** — flag complexity that may not be warranted.
+
+**Planning output format.**
+1. **Problem Statement** — one paragraph, restated; call out ambiguity.
+2. **Scope & Boundaries** — in scope / out of scope / external dependencies.
+3. **Design Decisions** — for each: Decision, Rationale, Trade-offs, Alternatives.
+4. **Implementation Phases** — each with an entry condition, an exit condition
+   (including a verification step), and independent testability.
+5. **Risk & Failure Modes** — at least three; likelihood, blast radius, mitigation.
+6. **Open Questions** — numbered; mark blockers vs. nice-to-have.
+7. **Handoff Brief** — a paste-ready paragraph: branch-name convention, starting
+   module(s), and the first phase's exit condition.
+
+> Domain grounding (signal chain, targets, operational constraints) lives in the
+> **Domain Knowledge Reference** section above — don't restate it here.


### PR DESCRIPTION
## 📺 Overview

Deep audit and optimization of `AGENTS.md`. Replaces generic/opencode-specific
scaffolding with concise, repository-specific, evidence-backed rules an AI coding
agent can verify. Net: **106 insertions, 216 deletions** (326 → 216 lines).

Doc-only change; no issue created.

### What does this PR do?

* **Type of change:** [ ] Bug fix | [ ] New feature | [x] Refactoring | [ ] CI/CD or Tooling
* **Component(s) affected:** AGENTS.md

---

## 🛠️ Technical Context & Implementation

* **The Problem:** The prior `AGENTS.md` mixed accurate repo recipes with content that no longer matched the repository: a dead `CONTRIBUTING.md` reference, an `opencode_mem` Memory Protocol targeting a tool the intended agents (Claude Code, Codex, Gemini) don't have, a ~120-line opencode "Planning Agent Protocol" (`.opencode.env`, `/model $PLANNING_MODEL`) that is repository-independent, a single-TV assumption contradicted by `calibrator/profiles.py` (U8G + TCL 7105X + LG OLED55B7A), and no mention of the codebase's actual test/CI gates or calibration invariants. Git/PR conventions were duplicated across three sections.
* **The Solution:** Rewrote around what maintainers know but agents don't, every rule traceable to repo evidence:
    * **Build, Test & CI** — `pytest -m "not hardware"`, 70% coverage floor, `--strict-markers`, the enforced ruff subset (and the deliberately-ignored debt), `compileall`, frontend commands, bandit + `check-repo-hygiene.sh` (evidence: `.github/workflows/ci.yml`, `pyproject.toml`, `tests/conftest.py`).
    * **Calibration Invariants** — golden regression discipline (`tests/golden/`, `--update-golden`), `analyze()` determinism (`test_analyze_is_deterministic`), absolute-nits PQ targets (`eotf.py:pq_target_nits`, PRs #561/#569/#570), `code_max`/limited-range normalization (`models.py:_normalize_code`, PRs #547/#564/#572), the firmware tone-mapping knee (PR #570), and adb shell-injection defence (`test_adb_control_injection.py`, Issue #151).
    * Corrected Repo Context to the multi-TV reality and the `calcore`/`calibrator` boundary; added an "add a TV profile" recipe (`_build_u8g_profile` → `TV_PROFILES`).
    * Pointed the PR-body rule at the CI-enforced `.github/pull_request_template.md` headings instead of the `.pr_body.md` example.
    * Removed the Memory Protocol, Session Summary, and Planning Agent Protocol; consolidated duplicated git/commit rules into `Git Workflow`.
* **Impact on existing workflows/APIs:** None — documentation only. No source, tests, or CI configuration changed.

---

## 🧪 Testing & Validation

### Environment Details

* **OS / Target Display:** N/A (documentation change)
* **Hardware/Mock Used:** N/A

### Verification Steps

1. Every retained cross-reference was checked against the tree: `query_patch_optimization`, `resolve_endpoint`, `_build_request`, `_extract_json`, `get_suggested_patches`, `_reset_server_globals`, `tests/test_suggested_patches.py`, `TV_PROFILES`, `_normalize_code` all exist.
2. New rules cite the file/CI/PR that supports them; unverifiable claims from the old file (inter-node bleed factor `~0.55`, "Local Dimming = Medium") were dropped because they lack code evidence or conflict with `profiles.py`.
3. No code paths touched, so backend/frontend suites are unaffected.

### Firmware / TV Settings

*Not applicable — documentation-only change.*

---

## 📸 Visual Evidence (UI / Plot Changes)

None — no UI or plot changes.

---

## 🧼 Checklist

* [x] Code adheres to project style guidelines (formatting, typing, linting).
* [x] Unit tests added/updated and passing. (N/A — doc-only; no code changed.)
* [x] Documentation (README, inline docstrings) updated to reflect changes.
* [x] No credentials, local absolute paths, or hardware-specific hardcoding leaked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JtvQaMUxcvaLsGPiJQhcPr

---
_Generated by [Claude Code](https://claude.ai/code/session_01JtvQaMUxcvaLsGPiJQhcPr)_