### PR TITLE
Deterministically clamp Round-1 LLM deltas to the damped fraction (#554)

### DIFF
--- a/calcore/llm.py
+++ b/calcore/llm.py
@@ -14,6 +14,11 @@ if TYPE_CHECKING:
 # Max repasses before flagging hardware ceiling
 _REPATCH_MAX_PASSES = 3
 
+# Conservative Round-1 correction factor for inter-node bleed (QE_AUDIT.md
+# ground truth). The prompt asks the model to self-damp; this is the
+# deterministic backstop so the invariant holds even if it doesn't (#554).
+_ROUND1_DAMPING_FACTOR = 0.55
+
 logger = logging.getLogger(__name__)
 
 _FENCE_RE = re.compile(r"```\s*(?:json\s*)?(.*?)\s*```", re.IGNORECASE | re.DOTALL)
@@ -1520,6 +1525,37 @@ def _format_adjustment_rounds(prior_rounds: List[Dict[str, Any]]) -> str:
     return "\n".join(lines)
 
 
+def _apply_round1_damping(
+    adjustments: List[Dict[str, Any]], rounds_used: int
+) -> List[Dict[str, Any]]:
+    """Clamp Round-1 deltas to ``_ROUND1_DAMPING_FACTOR`` of the LLM's suggested
+    correction, deterministically enforcing the "conservative Round-1
+    correction factor (~0.55) for inter-node bleed" invariant regardless of
+    whether the model actually complied with the prompt's damping instruction.
+
+    Only the first round is damped here (there is no prior residual to trend
+    against yet). Later rounds rely on the prior-rounds history fed back into
+    the prompt, which already tells the model what did and didn't work.
+    """
+    if rounds_used != 0:
+        return adjustments
+
+    damped: List[Dict[str, Any]] = []
+    for adj in adjustments:
+        from_val = _safe_float(adj.get("from"))
+        to_val = _safe_float(adj.get("to"))
+        if from_val is None or to_val is None or from_val == to_val:
+            damped.append(adj)
+            continue
+        new_to = from_val + _ROUND1_DAMPING_FACTOR * (to_val - from_val)
+        if isinstance(adj.get("from"), int) and isinstance(adj.get("to"), int):
+            new_to = round(new_to)
+        else:
+            new_to = round(new_to, 4)
+        damped.append({**adj, "to": new_to})
+    return damped
+
+
 def predict_next_settings(
     summary: "Summary",
     cfg: "AnalysisConfig",
@@ -1701,7 +1737,7 @@ def predict_next_settings(
             return None
 
         return NextSettingsPrediction(
-            adjustments=plan.adjustments,
+            adjustments=_apply_round1_damping(plan.adjustments, rounds_used),
             next_step=plan.next_step,
             confidence=plan.confidence,
             converged=False,

--- a/tests/test_adaptive_loop.py
+++ b/tests/test_adaptive_loop.py
@@ -15,6 +15,7 @@ from calcore.llm import (
     NextSettingsPrediction,
     PassDecision,
     _CONVERGENCE_STALL_EPSILON,
+    _ROUND1_DAMPING_FACTOR,
     assess_convergence,
     predict_next_settings,
     query_pass_decision,
@@ -1025,6 +1026,105 @@ class TestPredictNextSettings:
         assert len(result.adjustments) == 1
         assert result.next_step == "rerun_grayscale"
         assert result.confidence == 0.8
+
+    def test_round1_deltas_are_damped_regardless_of_llm_compliance(self):
+        # Round 1 (no prior_rounds): the LLM ignores the prompt's damping
+        # instruction and returns the full correction. The deterministic
+        # clamp must still only apply _ROUND1_DAMPING_FACTOR of it (#554).
+        llm = _llm_mock()
+        plan = {
+            "adjustments": [
+                {
+                    "menu": "White Balance",
+                    "setting": "R Gain",
+                    "from": 0,
+                    "to": -20,
+                    "scope": "global",
+                    "reason": "Full correction, undamped.",
+                }
+            ],
+            "next_step": "rerun_grayscale",
+            "confidence": 0.9,
+        }
+        p, mock_urlopen = _patch_urlopen(plan)
+        try:
+            result = predict_next_settings(
+                _summary(avg_de=5.0, max_de=7.0), _cfg_mock(), "post_grayscale", llm
+            )
+        finally:
+            p.stop()
+        assert result is not None
+        assert len(result.adjustments) == 1
+        expected_to = round(0 + _ROUND1_DAMPING_FACTOR * (-20 - 0))
+        assert result.adjustments[0]["to"] == expected_to
+        assert result.adjustments[0]["to"] != -20
+
+    def test_round1_damping_skips_adjustments_without_numeric_from(self):
+        llm = _llm_mock()
+        plan = {
+            "adjustments": [
+                {
+                    "menu": "Picture Mode",
+                    "setting": "Preset",
+                    "from": None,
+                    "to": "Movie",
+                    "scope": "global",
+                    "reason": "Switch preset; not a numeric delta.",
+                }
+            ],
+            "next_step": "rerun_grayscale",
+            "confidence": 0.9,
+        }
+        p, mock_urlopen = _patch_urlopen(plan)
+        try:
+            result = predict_next_settings(
+                _summary(avg_de=5.0, max_de=7.0), _cfg_mock(), "post_grayscale", llm
+            )
+        finally:
+            p.stop()
+        assert result is not None
+        assert result.adjustments[0]["to"] == "Movie"
+
+    def test_round2_deltas_are_not_damped_by_the_deterministic_clamp(self):
+        # rounds_used == 1 (one prior round already recorded): the clamp only
+        # backstops Round 1, so a full delta here should pass through as-is —
+        # later-round damping is left to the prompt's trend-based instruction.
+        llm = _llm_mock()
+        plan = {
+            "adjustments": [
+                {
+                    "menu": "White Balance",
+                    "setting": "R Gain",
+                    "from": 0,
+                    "to": -20,
+                    "scope": "global",
+                    "reason": "Second round correction.",
+                }
+            ],
+            "next_step": "rerun_grayscale",
+            "confidence": 0.9,
+        }
+        p, mock_urlopen = _patch_urlopen(plan)
+        try:
+            result = predict_next_settings(
+                _summary(avg_de=5.0, max_de=7.0),
+                _cfg_mock(),
+                "post_grayscale",
+                llm,
+                prior_rounds=[
+                    {
+                        "round": 1,
+                        "residual": {"avg_de": 6.0, "max_de": 8.0},
+                        "suggested": [
+                            {"menu": "White Balance", "setting": "R Gain", "to": -10}
+                        ],
+                    }
+                ],
+            )
+        finally:
+            p.stop()
+        assert result is not None
+        assert result.adjustments[0]["to"] == -20
 
     def test_unparseable_llm_response_returns_none(self):
         llm = _llm_mock()


### PR DESCRIPTION
## 📺 Overview

Closes #554

### What does this PR do?
* **Type of change:** [x] Bug fix
* **Component(s) affected:** `calcore/llm.py` reactive next-settings prediction (`predict_next_settings`)

---

## 🛠️ Technical Context & Implementation

* **The Problem:** `QE_AUDIT.md` lists a ground-truth invariant — a conservative Round-1 correction factor (~0.55) for inter-node bleed. The only implementation was prompt text ("apply a DAMPED fraction (about half) of the remaining correction") in `calcore/llm.py`. `predict_next_settings` applied no deterministic clamp to the deltas the LLM returned, so an overshooting or non-compliant response would pass straight through to `llm_adjustment_rounds` and the UI unmodified. The issue was filed as "Needs Evidence" since compliance can't be verified without live LLM traffic — the fix proposed there is to make the invariant enforceable in code regardless of model behavior.
* **The Solution:** Added `_apply_round1_damping`, a deterministic post-hoc clamp applied only to the first prediction round (`rounds_used == 0`, i.e. no prior residual history to trend against yet). For each adjustment with numeric `from`/`to` values, it scales the delta to `_ROUND1_DAMPING_FACTOR` (0.55) of what the model returned: `to = from + 0.55 * (to - from)`. Non-numeric or `from: null` adjustments (e.g. enum/preset changes) pass through unchanged since there's no delta to damp. Integer-valued settings are rounded back to an int. Rounds after the first are left to the existing prompt-based trend instruction, since deterministically damping them would require a residual-to-setting-value mapping the code doesn't have.
* **Impact on existing workflows/APIs:** `predict_next_settings` return shape (`NextSettingsPrediction.adjustments`) is unchanged; only the numeric `to` value of Round-1 adjustments is scaled down. Rounds 2+ are unaffected.

### Mathematical / Data Integrity Checks (If Applicable)
* [x] Floating-point precision or data truncation risks have been addressed (integer settings are rounded to int; others rounded to 4 decimals).

---

## 🧪 Testing & Validation

### Verification Steps
1. `python -m pytest tests/test_adaptive_loop.py -q --no-cov`
2. Added tests: Round-1 deltas are damped regardless of LLM compliance; adjustments without a numeric `from` pass through unchanged; Round-2+ deltas are *not* touched by this clamp (left to the prompt's trend-based instruction).
3. Full suite (`python -m pytest tests/ -q --no-cov`) passes.

---

## 🧼 Checklist
* [x] Code adheres to project style guidelines (formatting, typing, linting).
* [x] Unit tests added/updated and passing.
* [ ] Documentation (README, inline docstrings) updated to reflect changes — inline comments added; no user-facing docs affected.
* [x] No credentials, local absolute paths, or hardware-specific hardcoding leaked.


---
_Generated by [Claude Code](https://claude.ai/code/session_018vUXDKyihS5q1o4o5nxcpd)_