### PR TITLE
Fix report_payload averaging ΔE over all accumulated passes instead of latest pass

### DIFF
--- a/calibrator/report_samples.py
+++ b/calibrator/report_samples.py
@@ -21,6 +21,7 @@ def _measurement(
     y: float = 0.3290,
     x_scale: float = 0.95,
     z_scale: float = 1.09,
+    timestamp: str = "2026-04-19T09:30:00",
 ) -> Measurement:
     stimulus = round(stimulus_pct * 255 / 100)
     return Measurement(
@@ -31,6 +32,7 @@ def _measurement(
         Z=y_value * z_scale,
         label=label,
         stimulus_rgb=(stimulus, stimulus, stimulus),
+        timestamp=timestamp,
     )
 
 
@@ -58,10 +60,10 @@ def build_sample_report() -> Dict[str, Any]:
         _measurement("80% Gray", 80, 82.1, x=0.3128, y=0.3292),
     ]
     gamma_measurements = [
-        _measurement("10% Gray", 10, 2.6, x=0.3125, y=0.3289),
-        _measurement("25% Gray", 25, 9.7, x=0.3125, y=0.3290),
-        _measurement("50% Gray", 50, 27.4, x=0.3126, y=0.3290),
-        _measurement("75% Gray", 75, 58.9, x=0.3127, y=0.3291),
+        _measurement("20% Gray", 20, 9.7, x=0.3125, y=0.3289),
+        _measurement("40% Gray", 40, 27.4, x=0.3125, y=0.3290),
+        _measurement("60% Gray", 60, 58.9, x=0.3126, y=0.3290),
+        _measurement("80% Gray", 80, 89.3, x=0.3127, y=0.3291),
     ]
 
     session = {

--- a/calibrator/reports.py
+++ b/calibrator/reports.py
@@ -45,15 +45,30 @@ def report_payload(session: Dict[str, Any]) -> Dict[str, Any]:
             "measurements": items,
         }
 
+    # latest_grayscale_pass / latest_gamma_pass reduce by walking timestamps
+    # backwards; if a bucket carries no timestamps (e.g. legacy/pre-#577 data),
+    # that walk finds nothing to anchor on and returns empty. Fall back to
+    # treating the whole bucket as one coherent pass rather than reporting
+    # None/empty stats for measurements that are actually there.
     grayscale_levels = grayscale_levels_for_ramp(session.get("grayscale_ramp_steps", 11))
     latest_pre = latest_grayscale_pass(
         session["pre_measurements"], max_count=len(grayscale_levels),
         signal_range=signal_range, code_scale=code_scale,
     )
+    if not latest_pre and session["pre_measurements"]:
+        latest_pre = latest_grayscale_pass(
+            session["pre_measurements"], max_count=len(grayscale_levels),
+            signal_range=signal_range, code_scale=code_scale, detect_sessions=False,
+        )
     latest_post = latest_grayscale_pass(
         session["post_measurements"], max_count=len(grayscale_levels),
         signal_range=signal_range, code_scale=code_scale,
     )
+    if not latest_post and session["post_measurements"]:
+        latest_post = latest_grayscale_pass(
+            session["post_measurements"], max_count=len(grayscale_levels),
+            signal_range=signal_range, code_scale=code_scale, detect_sessions=False,
+        )
     latest_wb = latest_wb_measurements(session["wb_measurements"])
     latest_cms: Dict[str, Any] = {}
     for measurement in session["cms_measurements"]:
@@ -63,6 +78,11 @@ def report_payload(session: Dict[str, Any]) -> Dict[str, Any]:
     latest_gamma = latest_gamma_pass(
         session["gamma_measurements"], gamma_levels, signal_range, code_scale
     )
+    if not latest_gamma and session["gamma_measurements"]:
+        latest_gamma = latest_gamma_pass(
+            session["gamma_measurements"], gamma_levels, signal_range, code_scale,
+            detect_sessions=False,
+        )
 
     pre = stats(latest_pre)
     post = stats(latest_post)

--- a/calibrator/reports.py
+++ b/calibrator/reports.py
@@ -7,7 +7,14 @@ from typing import Any, Dict, List, Optional
 
 from fastapi import HTTPException
 
-from .session import m_to_dict
+from .session import (
+    gamma_levels_for_session,
+    grayscale_levels_for_ramp,
+    latest_gamma_pass,
+    latest_grayscale_pass,
+    latest_wb_measurements,
+    m_to_dict,
+)
 
 
 def report_payload(session: Dict[str, Any]) -> Dict[str, Any]:
@@ -38,11 +45,30 @@ def report_payload(session: Dict[str, Any]) -> Dict[str, Any]:
             "measurements": items,
         }
 
-    pre = stats(session["pre_measurements"])
-    post = stats(session["post_measurements"])
-    wb = stats(session["wb_measurements"])
-    cms = stats(session["cms_measurements"])
-    gamma = gamma_stats(session["gamma_measurements"])
+    grayscale_levels = grayscale_levels_for_ramp(session.get("grayscale_ramp_steps", 11))
+    latest_pre = latest_grayscale_pass(
+        session["pre_measurements"], max_count=len(grayscale_levels),
+        signal_range=signal_range, code_scale=code_scale,
+    )
+    latest_post = latest_grayscale_pass(
+        session["post_measurements"], max_count=len(grayscale_levels),
+        signal_range=signal_range, code_scale=code_scale,
+    )
+    latest_wb = latest_wb_measurements(session["wb_measurements"])
+    latest_cms: Dict[str, Any] = {}
+    for measurement in session["cms_measurements"]:
+        colour = (measurement.label or "").replace(" 100%", "")
+        latest_cms[colour] = measurement
+    gamma_levels = gamma_levels_for_session(session)
+    latest_gamma = latest_gamma_pass(
+        session["gamma_measurements"], gamma_levels, signal_range, code_scale
+    )
+
+    pre = stats(latest_pre)
+    post = stats(latest_post)
+    wb = stats([m for m in latest_wb.values() if m is not None])
+    cms = stats(list(latest_cms.values()))
+    gamma = gamma_stats(latest_gamma)
     improvement = None
     if pre["avg_de"] is not None and post["avg_de"] is not None and pre["avg_de"] > 0:
         improvement = round((1 - post["avg_de"] / pre["avg_de"]) * 100, 1)

--- a/calibrator/session.py
+++ b/calibrator/session.py
@@ -1137,30 +1137,34 @@ def latest_gamma_pass(
     levels: Tuple[int, ...] = GAMMA_TRACKING_LEVELS,
     signal_range: str = "auto",
     code_scale: str = "8bit",
+    detect_sessions: bool = True,
 ) -> List[Measurement]:
-    latest_reversed: List[Measurement] = []
-    prev_dt: Optional[datetime] = None
-    for measurement in reversed(measurements):
-        ts = measurement.timestamp
-        if not ts:
-            if latest_reversed:
-                break
-            continue
-        try:
-            current_dt = datetime.fromisoformat(ts)
-        except ValueError:
-            if latest_reversed:
-                break
-            continue
-        if prev_dt is not None:
-            if current_dt > prev_dt:
-                break
-            gap = (prev_dt - current_dt).total_seconds()
-            if gap >= ZRO_SESSION_BREAK_SECONDS:
-                break
-        latest_reversed.append(measurement)
-        prev_dt = current_dt
-    latest = list(reversed(latest_reversed))
+    if detect_sessions:
+        latest_reversed: List[Measurement] = []
+        prev_dt: Optional[datetime] = None
+        for measurement in reversed(measurements):
+            ts = measurement.timestamp
+            if not ts:
+                if latest_reversed:
+                    break
+                continue
+            try:
+                current_dt = datetime.fromisoformat(ts)
+            except ValueError:
+                if latest_reversed:
+                    break
+                continue
+            if prev_dt is not None:
+                if current_dt > prev_dt:
+                    break
+                gap = (prev_dt - current_dt).total_seconds()
+                if gap >= ZRO_SESSION_BREAK_SECONDS:
+                    break
+            latest_reversed.append(measurement)
+            prev_dt = current_dt
+        latest = list(reversed(latest_reversed))
+    else:
+        latest = list(measurements)
     latest_by_target: Dict[int, Measurement] = {}
     for measurement in latest:
         target_pct = gamma_target_for_measurement(

--- a/tests/test_delta_report.py
+++ b/tests/test_delta_report.py
@@ -67,6 +67,7 @@ def _make_session_with_measurements(client, mode="SDR"):
             Z=float(pct) * 1.09,
             label=f"{pct}% Gray",
             stimulus_rgb=(pct * 2, pct * 2, pct * 2),
+            timestamp="2024-01-01T10:00:00",
         )
         for pct in [10, 20, 30, 40, 50, 60, 70, 80, 90, 100]
     ]
@@ -80,6 +81,7 @@ def _make_session_with_measurements(client, mode="SDR"):
             Z=float(pct) * 1.07,
             label=f"{pct}% Gray",
             stimulus_rgb=(pct * 2, pct * 2, pct * 2),
+            timestamp="2024-01-01T10:00:00",
         )
         for pct in [10, 20, 30, 40, 50, 60, 70, 80, 90, 100]
     ]
@@ -232,6 +234,7 @@ class TestComparisonEdgeCases:
                 X=0.0, Z=0.0,
                 label=f"{pct}% Gray",
                 stimulus_rgb=(pct * 2, pct * 2, pct * 2),
+                timestamp="2024-01-01T10:00:00",
             )
             for pct in [10, 20, 30, 40, 50, 60, 70, 80, 90, 100]
         ]
@@ -271,6 +274,7 @@ class TestComparisonEdgeCases:
                 Z=float("nan"),
                 label="Invalid",
                 stimulus_rgb=(128, 128, 128),
+                timestamp="2024-01-01T10:00:00",
             )
         ]
         _sessions[sid_a]["pre_measurements"] = invalid_measurements
@@ -282,6 +286,102 @@ class TestComparisonEdgeCases:
         assert report_a["pre_cal"]["avg_de"] is None
         assert report_a["pre_cal"]["invalid_count"] == 1
         assert report_a["improvement_pct"] is None
+
+
+class TestReportUsesLatestPassOnly:
+    """Issue #577: report_payload must reduce each bucket to the latest pass
+    before averaging, matching the live grayscale view / quality gate."""
+
+    def test_report_uses_latest_grayscale_pass(self, client):
+        from calibrator.reports import report_payload
+
+        sid = _make_session_with_measurements(client)
+        sess = _sessions[sid]
+
+        bad_pass = [
+            Measurement(
+                x=0.3127 + 0.05, y=0.3290 + 0.05,
+                Y=float(pct), X=float(pct) * 0.95, Z=float(pct) * 1.09,
+                label=f"{pct}% Gray",
+                stimulus_rgb=(pct * 2, pct * 2, pct * 2),
+                timestamp="2024-01-01T10:00:00",
+            )
+            for pct in [10, 20, 30, 40, 50, 60, 70, 80, 90, 100]
+        ]
+        good_pass = [
+            Measurement(
+                x=0.3127, y=0.3290,
+                Y=float(pct), X=float(pct) * 0.95, Z=float(pct) * 1.09,
+                label=f"{pct}% Gray",
+                stimulus_rgb=(pct * 2, pct * 2, pct * 2),
+                timestamp="2024-01-01T11:00:00",
+            )
+            for pct in [10, 20, 30, 40, 50, 60, 70, 80, 90, 100]
+        ]
+        good_only_sess = dict(sess)
+        good_only_sess["pre_measurements"] = good_pass
+        good_only_report = report_payload(good_only_sess)
+
+        sess["pre_measurements"] = bad_pass + good_pass
+        report = report_payload(sess)
+
+        # The combined bucket (bad pass + good re-measured pass) must report the
+        # same avg_de as the good pass alone, not a blend of both passes.
+        assert report["pre_cal"]["avg_de"] == good_only_report["pre_cal"]["avg_de"]
+        assert report["pre_cal"]["max_de"] == good_only_report["pre_cal"]["max_de"]
+        assert len(report["pre_cal"]["measurements"]) == len(good_pass)
+
+    def test_report_uses_latest_cms_reading_per_colour(self, client):
+        from calibrator.reports import report_payload
+
+        sid = _make_session_with_measurements(client)
+        sess = _sessions[sid]
+        target = sess["target"]
+
+        stale = Measurement(
+            x=target.white_point_xy[0] + 0.05, y=target.white_point_xy[1] + 0.05,
+            Y=100.0, X=90.0, Z=100.0,
+            label="Red 100%",
+            stimulus_rgb=(255, 0, 0),
+        )
+        fresh = Measurement(
+            x=target.white_point_xy[0], y=target.white_point_xy[1],
+            Y=100.0, X=90.0, Z=100.0,
+            label="Red 100%",
+            stimulus_rgb=(255, 0, 0),
+        )
+        sess["cms_measurements"] = [stale, fresh]
+
+        report = report_payload(sess)
+        assert report["color_tuner"]["avg_de"] == 0.0
+        assert report["color_tuner"]["max_de"] == 0.0
+
+    def test_report_uses_latest_gamma_pass(self, client):
+        from calibrator.reports import report_payload
+        from calibrator.session import GAMMA_TRACKING_LEVELS
+
+        sid = _make_session_with_measurements(client)
+        sess = _sessions[sid]
+
+        level = GAMMA_TRACKING_LEVELS[0]
+        code_value = round(level / 100.0 * 255)
+        stale = Measurement(
+            x=0.3127, y=0.3290, Y=1.0, X=0.95, Z=1.09,
+            label=f"Gamma {level}%",
+            stimulus_rgb=(code_value, code_value, code_value),
+            timestamp="2024-01-01T10:00:00",
+        )
+        fresh = Measurement(
+            x=0.3127, y=0.3290, Y=50.0, X=0.95, Z=1.09,
+            label=f"Gamma {level}%",
+            stimulus_rgb=(code_value, code_value, code_value),
+            timestamp="2024-01-01T11:00:00",
+        )
+        sess["gamma_measurements"] = [stale, fresh]
+
+        report = report_payload(sess)
+        assert len(report["gamma_measurements"]) == 1
+        assert report["gamma_measurements"][0]["Y"] == 50.0
 
 
 class TestReportPayloadEdgeCases:
@@ -322,6 +422,7 @@ class TestReportPayloadEdgeCases:
             X=0.0, Z=0.0,
             label="50% Gray",
             stimulus_rgb=(100, 100, 100),
+            timestamp="2024-01-01T10:00:00",
         )
         slightly_off = Measurement(
             x=target.white_point_xy[0] + 0.01,
@@ -330,6 +431,7 @@ class TestReportPayloadEdgeCases:
             X=0.0, Z=0.0,
             label="51% Gray",
             stimulus_rgb=(102, 102, 102),
+            timestamp="2024-01-01T10:00:00",
         )
 
         sess["pre_measurements"] = [perfect]

--- a/tests/test_delta_report.py
+++ b/tests/test_delta_report.py
@@ -383,6 +383,44 @@ class TestReportUsesLatestPassOnly:
         assert len(report["gamma_measurements"]) == 1
         assert report["gamma_measurements"][0]["Y"] == 50.0
 
+    def test_report_falls_back_to_whole_bucket_when_no_timestamps(self, client):
+        """Legacy/pre-#577 data may have no timestamps at all. latest_grayscale_pass
+        and latest_gamma_pass return empty in that case (they can't anchor a
+        backward walk), so report_payload must fall back to treating the whole
+        bucket as a single pass rather than reporting empty/None stats."""
+        from calibrator.reports import report_payload
+        from calibrator.session import GAMMA_TRACKING_LEVELS
+
+        sid = _make_session_with_measurements(client)
+        sess = _sessions[sid]
+
+        no_ts_grayscale = [
+            Measurement(
+                x=0.3127, y=0.3290,
+                Y=float(pct), X=float(pct) * 0.95, Z=float(pct) * 1.09,
+                label=f"{pct}% Gray",
+                stimulus_rgb=(pct * 2, pct * 2, pct * 2),
+            )
+            for pct in [10, 20, 30, 40, 50, 60, 70, 80, 90, 100]
+        ]
+        sess["pre_measurements"] = no_ts_grayscale
+
+        level = GAMMA_TRACKING_LEVELS[0]
+        code_value = round(level / 100.0 * 255)
+        no_ts_gamma = [
+            Measurement(
+                x=0.3127, y=0.3290, Y=50.0, X=0.95, Z=1.09,
+                label=f"Gamma {level}%",
+                stimulus_rgb=(code_value, code_value, code_value),
+            )
+        ]
+        sess["gamma_measurements"] = no_ts_gamma
+
+        report = report_payload(sess)
+        assert report["pre_cal"]["avg_de"] is not None
+        assert len(report["pre_cal"]["measurements"]) == len(no_ts_grayscale)
+        assert len(report["gamma_measurements"]) == 1
+
 
 class TestReportPayloadEdgeCases:
     def test_report_payload_empty_measurements_no_crash(self, client):

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -2041,11 +2041,13 @@ class TestImprovementPercentZeroDeltaE:
         })()
         _sessions[session_id]["pre_measurements"] = [
             Measurement(x=0.35, y=0.35, Y=50.0, X=48.0, Z=56.0,
-                        stimulus_rgb=(255, 0, 0), label="Red 100%"),
+                        stimulus_rgb=(255, 0, 0), label="Red 100%",
+                        timestamp="2024-01-01T10:00:00"),
         ]
         _sessions[session_id]["post_measurements"] = [
             Measurement(x=0.3127, y=0.3290, Y=50.0, X=48.3, Z=55.1,
-                        stimulus_rgb=(255, 0, 0), label="Red 100%"),
+                        stimulus_rgb=(255, 0, 0), label="Red 100%",
+                        timestamp="2024-01-01T10:00:00"),
         ]
         _sessions[session_id]["wb_measurements"] = []
         _sessions[session_id]["gamma_measurements"] = []
@@ -2068,11 +2070,13 @@ class TestImprovementPercentZeroDeltaE:
         })()
         _sessions[session_id]["pre_measurements"] = [
             Measurement(x=0.40, y=0.40, Y=50.0, X=40.0, Z=48.0,
-                        stimulus_rgb=(255, 0, 0), label="Red 100%"),
+                        stimulus_rgb=(255, 0, 0), label="Red 100%",
+                        timestamp="2024-01-01T10:00:00"),
         ]
         _sessions[session_id]["post_measurements"] = [
             Measurement(x=0.35, y=0.35, Y=50.0, X=48.0, Z=56.0,
-                        stimulus_rgb=(255, 0, 0), label="Red 100%"),
+                        stimulus_rgb=(255, 0, 0), label="Red 100%",
+                        timestamp="2024-01-01T10:00:00"),
         ]
         _sessions[session_id]["wb_measurements"] = []
         _sessions[session_id]["gamma_measurements"] = []
@@ -2330,19 +2334,22 @@ class TestReportPayloadInvalidMeasurements:
         })()
         _sessions[session_id]["pre_measurements"] = [
             Measurement(x=0.35, y=0.35, Y=50.0, X=48.0, Z=56.0,
-                        stimulus_rgb=(128, 128, 128), label="50% Gray"),
+                        stimulus_rgb=(128, 128, 128), label="50% Gray",
+                        timestamp="2024-01-01T10:00:00"),
             Measurement(x=-1.0, y=-1.0, Y=-1.0, X=48.0, Z=56.0,
-                        stimulus_rgb=(128, 128, 128), label="Bad Gray"),
+                        stimulus_rgb=(129, 129, 129), label="Bad Gray",
+                        timestamp="2024-01-01T10:00:01"),
         ]
         _sessions[session_id]["post_measurements"] = [
             Measurement(x=0.3127, y=0.3290, Y=50.0, X=48.3, Z=55.1,
-                        stimulus_rgb=(128, 128, 128), label="50% Gray"),
+                        stimulus_rgb=(128, 128, 128), label="50% Gray",
+                        timestamp="2024-01-01T10:00:00"),
         ]
         _sessions[session_id]["wb_measurements"] = [
             Measurement(x=-1.0, y=-1.0, Y=-1.0, X=48.0, Z=56.0,
-                        stimulus_rgb=(128, 128, 128), label="Bad WB"),
+                        stimulus_rgb=(128, 128, 128), label="Bad WB Offset 30%"),
             Measurement(x=0.3150, y=0.3280, Y=50.0, X=48.3, Z=55.1,
-                        stimulus_rgb=(128, 128, 128), label="Good WB"),
+                        stimulus_rgb=(128, 128, 128), label="Good WB Gain 80%"),
         ]
         _sessions[session_id]["gamma_measurements"] = []
         _sessions[session_id]["cms_measurements"] = []
@@ -2370,9 +2377,11 @@ class TestReportPayloadInvalidMeasurements:
         })()
         _sessions[session_id]["pre_measurements"] = [
             Measurement(x=-1.0, y=-1.0, Y=-1.0, X=48.0, Z=56.0,
-                        stimulus_rgb=(128, 128, 128), label="Bad Gray 1"),
+                        stimulus_rgb=(128, 128, 128), label="Bad Gray 1",
+                        timestamp="2024-01-01T10:00:00"),
             Measurement(x=0.0, y=0.0, Y=0.0, X=48.0, Z=56.0,
-                        stimulus_rgb=(128, 128, 128), label="Bad Gray 2"),
+                        stimulus_rgb=(129, 129, 129), label="Bad Gray 2",
+                        timestamp="2024-01-01T10:00:01"),
         ]
         _sessions[session_id]["post_measurements"] = []
         _sessions[session_id]["wb_measurements"] = []


### PR DESCRIPTION
## 📺 Overview

Closes #577

### What does this PR do?
* **Type of change:** [x] Bug fix
* **Component(s) affected:** `calibrator/reports.py` (report generation / persisted history)

---

## 🛠️ Technical Context & Implementation

* **The Problem:** `report_payload` computed each bucket's `avg_de`/`max_de` (and `avg_gamma`) over the raw, append-only measurement list. Every other consumer (live grayscale/gamma views, quality gates) first reduces to the latest pass / latest reading per item. When a bucket accumulates more than one pass (operator re-measures and re-imports), the headline pre/post ΔE, `improvement_pct`, and the values persisted to per-TV history via `record_session` were diluted by stale earlier-pass readings.
* **The Solution:** `report_payload` now reduces each bucket before computing stats, mirroring the existing helpers in `calibrator/session.py` / `calibrator/quality.py`:
  * grayscale `pre`/`post` → `latest_grayscale_pass(bucket, max_count=len(grayscale_levels_for_ramp(...)), signal_range, code_scale)`
  * gamma → `latest_gamma_pass(bucket, gamma_levels_for_session(session), signal_range, code_scale)`
  * WB → `latest_wb_measurements(bucket)` (latest gain/offset reading)
  * CMS → latest reading per colour (mirrors `quality.py`'s per-colour dedup)
* **Impact on existing workflows/APIs:** `report_payload`'s output shape is unchanged; only the underlying averages/measurement lists now reflect the latest pass. Also updated `calibrator/report_samples.py`'s fixture to include `timestamp`s (required for the new reduction) and aligned its sample gamma stimulus points to the tracked levels (20/40/60/80%).

---

## 🧪 Testing & Validation

### Verification Steps
1. `python -m pytest tests/test_delta_report.py tests/test_server_api.py tests/test_report_samples.py -q`
2. Full suite: `python -m pytest -q` — all passing.

Added `TestReportUsesLatestPassOnly` in `tests/test_delta_report.py` covering:
* multi-pass grayscale (bad pass + re-measured good pass) → report matches the good-pass-only average
* multi-reading CMS (stale + fresh reading for the same colour) → report uses the latest reading
* multi-pass gamma (stale + fresh reading for the same tracked level) → report uses the latest reading

Also fixed several pre-existing test fixtures in `tests/test_delta_report.py` / `tests/test_server_api.py` that lacked `timestamp`s (a prerequisite for the pass-reduction helpers) or used WB labels that didn't match the recognized gain/offset patterns.

---

## 🧼 Checklist
* [x] Code adheres to project style guidelines (formatting, typing, linting).
* [x] Unit tests added/updated and passing.
* [ ] Documentation (README, inline docstrings) updated to reflect changes.
* [x] No credentials, local absolute paths, or hardware-specific hardcoding leaked.


---
_Generated by [Claude Code](https://claude.ai/code/session_011Zjiett4BmjrMBxhFcQsVh)_