### PR TITLE
Fix history_summary session_count saturating at display cap

### DIFF
--- a/calibrator/history.py
+++ b/calibrator/history.py
@@ -151,7 +151,10 @@ def count_sessions(tv_key: str) -> int:
     """Return the total number of recorded sessions for this TV.
 
     Unlike load_history(), this counts every line in sessions.jsonl and is
-    not capped by the display limit.
+    not capped by the display limit. A line that fails to parse as JSON
+    (e.g. a partial line from a concurrent in-progress append) is skipped
+    rather than counted, so this is a conservative lower bound if
+    record_session() is writing at the exact moment this is called.
     """
     path = _sessions_path(tv_key)
     if not path.exists():
@@ -268,6 +271,8 @@ def history_summary(tv_key: str) -> Dict[str, Any]:
     """Return a lightweight summary dict for API exposure.
 
     Keys: session_count, latest_date, latest_post_de, baseline_post_de.
+    session_count is the total number of recorded sessions (via
+    count_sessions), not capped by load_history()'s display limit.
     """
     history = load_history(tv_key)
     baseline = load_baseline(tv_key)

--- a/calibrator/history.py
+++ b/calibrator/history.py
@@ -147,6 +147,33 @@ def load_history(tv_key: str, limit: int = 10) -> List[Dict[str, Any]]:
     return list(reversed(entries))[:limit]
 
 
+def count_sessions(tv_key: str) -> int:
+    """Return the total number of recorded sessions for this TV.
+
+    Unlike load_history(), this counts every line in sessions.jsonl and is
+    not capped by the display limit.
+    """
+    path = _sessions_path(tv_key)
+    if not path.exists():
+        return 0
+
+    count = 0
+    try:
+        with open(path, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if line:
+                    try:
+                        json.loads(line)
+                        count += 1
+                    except json.JSONDecodeError:
+                        pass
+    except OSError:
+        return 0
+
+    return count
+
+
 def load_baseline(tv_key: str) -> Optional[Dict[str, Any]]:
     """Return the first-ever calibration baseline for this TV, or None."""
     path = _baseline_path(tv_key)
@@ -248,7 +275,7 @@ def history_summary(tv_key: str) -> Dict[str, Any]:
         return {"session_count": 0, "latest_date": None, "latest_post_de": None, "baseline_post_de": None}
     latest = history[0]
     return {
-        "session_count": len(history),
+        "session_count": count_sessions(tv_key),
         "latest_date": latest.get("date"),
         "latest_post_de": latest.get("post_grayscale_avg_de"),
         "baseline_post_de": baseline.get("post_grayscale_avg_de") if baseline else None,

--- a/tests/test_history_metrics.py
+++ b/tests/test_history_metrics.py
@@ -12,7 +12,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from calibrator import Measurement
-from calibrator.history import load_history, record_session
+from calibrator.history import history_summary, load_history, record_session
 import server as server_module
 from server import app, _sessions
 
@@ -276,3 +276,29 @@ class TestRecordSessionIdempotent:
         entries = load_history("u8g", limit=100)
         assert len(entries) == 1
         assert entries[0]["session_id"] == "sid-3"
+
+
+class TestHistorySummarySessionCount:
+    """#578: history_summary()["session_count"] must not saturate at the display cap."""
+
+    @pytest.fixture(autouse=True)
+    def _history_dir(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("TVCAL_HISTORY_DIR", str(tmp_path))
+
+    def _report(self) -> dict:
+        return {
+            "pre_cal": {"avg_de": 5.0},
+            "post_cal": {"avg_de": 1.2},
+            "gamma": {"avg_gamma": 2.2},
+            "peak_luminance": 500.0,
+            "improvement_pct": 76.0,
+            "white_balance": {"avg_de": 0.8},
+            "color_tuner": {"avg_de": 1.5},
+        }
+
+    def test_session_count_not_capped_at_display_limit(self):
+        for i in range(12):
+            record_session(
+                tv_key="u8g", session_id=f"sid-{i}", mode="SDR", report=self._report(),
+            )
+        assert history_summary("u8g")["session_count"] == 12

--- a/tests/test_history_metrics.py
+++ b/tests/test_history_metrics.py
@@ -12,7 +12,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from calibrator import Measurement
-from calibrator.history import history_summary, load_history, record_session
+from calibrator.history import count_sessions, history_summary, load_history, record_session
 import server as server_module
 from server import app, _sessions
 
@@ -302,3 +302,16 @@ class TestHistorySummarySessionCount:
                 tv_key="u8g", session_id=f"sid-{i}", mode="SDR", report=self._report(),
             )
         assert history_summary("u8g")["session_count"] == 12
+
+    def test_partial_trailing_line_is_skipped_conservatively(self, tmp_path):
+        """A truncated/malformed trailing line (e.g. concurrent in-progress
+        append) must not crash count_sessions and is excluded from the count."""
+        for i in range(3):
+            record_session(
+                tv_key="u8g", session_id=f"sid-{i}", mode="SDR", report=self._report(),
+            )
+        sessions_path = tmp_path / "u8g" / "sessions.jsonl"
+        with open(sessions_path, "a", encoding="utf-8") as fh:
+            fh.write('{"session_id": "sid-partial", "date": "2026-0')
+
+        assert count_sessions("u8g") == 3


### PR DESCRIPTION
## 📺 Overview

Closes #578

### What does this PR do?
* **Type of change:** [x] Bug fix
* **Component(s) affected:** `calibrator/history.py` (history summary / LLM context)

---

## 🛠️ Technical Context & Implementation

* **The Problem:** `history_summary()` computed `session_count` as `len(load_history(tv_key))`, but `load_history()` defaults to a display cap of `limit=10`. Once a TV had more than 10 recorded calibration sessions, `session_count` saturated at 10, understating the real history depth reported via `GET /api/session/{sid}/llm/history-summary`.
* **The Solution:** Added `count_sessions(tv_key)` which counts every valid JSON line in `sessions.jsonl` directly, without the display cap. `history_summary()` now uses `count_sessions()` for `session_count` instead of the length of the capped `load_history()` result. The `latest_*` fields are unaffected since they only ever read the first (most recent) entry.
* **Impact on existing workflows/APIs:** None beyond the corrected count — `load_history()`'s default cap and behavior are unchanged for callers that intentionally want the truncated, most-recent-first list (e.g. detailed history views).

---

## 🧪 Testing & Validation

### Verification Steps
1. Run `python -m pytest tests/test_history_metrics.py -q --no-cov`
2. New test `TestHistorySummarySessionCount::test_session_count_not_capped_at_display_limit` records 12 sessions and asserts `history_summary("u8g")["session_count"] == 12`.

---

## 🧼 Checklist
* [x] Code adheres to project style guidelines (formatting, typing, linting).
* [x] Unit tests added/updated and passing.
* [ ] Documentation (README, inline docstrings) updated to reflect changes. (not applicable — internal fix)
* [x] No credentials, local absolute paths, or hardware-specific hardcoding leaked.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NfPcmTiZU5xqVS2fPCvJ2t)_