### PR TITLE
Remove vestigial mode parameter from api.createSession

### DIFF
--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -55,7 +55,7 @@ export const api = {
   // Session
   getSession:    ()           => api.get('/api/session'),
   deleteSession: (sid)        => api.delete(`/api/session/${sid}`),
-  createSession: (tv, mode, sdrPeakNits) =>
+  createSession: (tv, sdrPeakNits) =>
     api.post('/api/session', { tv_key: tv, sdr_peak_nits: sdrPeakNits }),
   nextStep:      (sid)        => api.post(`/api/session/${sid}/next`),
   prevStep:      (sid)        => api.post(`/api/session/${sid}/prev`),

--- a/frontend/src/hooks/useSession.js
+++ b/frontend/src/hooks/useSession.js
@@ -257,9 +257,9 @@ export function useSession() {
     setLlmStreaming(false);
   }
 
-  async function createSession(tv, mode, sdrPeakNits) {
+  async function createSession(tv, sdrPeakNits) {
     stopLlmSSE();
-    const sess = await api.createSession(tv, mode, sdrPeakNits);
+    const sess = await api.createSession(tv, sdrPeakNits);
     setSession(sess);
     startSSE(sess.id);
     setLlmInsight(null);


### PR DESCRIPTION
## 📺 Overview

Closes #580

### What does this PR do?
* **Type of change:** [x] Refactoring
* **Component(s) affected:** UI/API client (`frontend/src/api/client.js`, `frontend/src/hooks/useSession.js`)

---

## 🛠️ Technical Context & Implementation

* **The Problem:** `api.createSession(tv, mode, sdrPeakNits)` accepted a `mode` argument but never sent it to the backend — mode is actually applied separately via `confirmMode` → `POST /api/session/{sid}/mode`. This dead parameter is a latent trap: a future caller could reasonably assume `createSession` sets the mode, and it silently would not.
* **The Solution:** Dropped the unused `mode` parameter from `api.createSession` and its `useSession.createSession` wrapper, so the signature reflects what the call actually does (`createSession(tv, sdrPeakNits)`).
* **Impact on existing workflows/APIs:** None. The only caller, `Setup.jsx`, already invoked `onCreateSession(selectedTv)` without a mode argument, then called `onConfirmMode` separately.

### Mathematical / Data Integrity Checks (If Applicable)
* [ ] Matrix transformations or LUT calculations have been validated.
* [ ] Floating-point precision or data truncation risks have been addressed.

---

## 🧪 Testing & Validation

No behavior change; verified by inspection that the sole caller (`Setup.jsx`) never passed a `mode` argument, so removing the unused parameter is a no-op for existing call sites.

---

## 🧼 Checklist
* [x] Code adheres to project style guidelines (formatting, typing, linting).
* [ ] Unit tests added/updated and passing.
* [ ] Documentation (README, inline docstrings) updated to reflect changes.
* [x] No credentials, local absolute paths, or hardware-specific hardcoding leaked.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QZXK7t2EzX79XoWzAUnaqk)_