### PR TITLE
Add Dogegen Companion Agent (tools/dogegen-agent/)

### DIFF
--- a/tests/test_dogegen_agent.py
+++ b/tests/test_dogegen_agent.py
@@ -92,6 +92,14 @@ class TestExternalPid:
         with patch("subprocess.run", side_effect=OSError("no such tool")):
             assert agent.external_dogegen_pid() is None
 
+    def test_logs_info_when_external_pid_detected(self, caplog):
+        proc = MagicMock()
+        proc.stdout = "4321\n"
+        with caplog.at_level("INFO", logger="agent"), \
+             patch.object(os, "name", "posix"), patch("subprocess.run", return_value=proc):
+            agent.external_dogegen_pid()
+        assert any("4321" in rec.message for rec in caplog.records)
+
 
 # ── GET /status ──────────────────────────────────────────────────────────────
 
@@ -231,6 +239,10 @@ class TestStart:
         assert r.status_code == 200
         cmd = mock_popen.call_args[0][0]
         assert cmd == ["C:/Dogegen.exe"]
+
+    def test_start_rejects_invalid_mode(self):
+        r = client.post("/start", json={"mode": "Hdr10"})
+        assert r.status_code == 422
 
 
 # ── POST /stop ───────────────────────────────────────────────────────────────

--- a/tests/test_dogegen_agent.py
+++ b/tests/test_dogegen_agent.py
@@ -1,0 +1,264 @@
+"""
+Tests for the Dogegen Companion Agent (tools/dogegen-agent/agent.py).
+
+Mocks subprocess.Popen/tasklist/pgrep so no real Dogegen.exe or Windows
+process table is required. Covers start/stop/status incl. "already
+running" (external PID) and "exe not found" paths — see issue #591.
+"""
+
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "tools" / "dogegen-agent"))
+
+import agent  # noqa: E402
+
+client = TestClient(agent.app)
+
+
+@pytest.fixture(autouse=True)
+def _reset_state():
+    """Each test starts with a clean DogegenState and default config."""
+    agent._dogegen_state = agent.DogegenState()
+    agent._config = dict(agent.DEFAULT_CONFIG)
+    yield
+    agent._dogegen_state = agent.DogegenState()
+    agent._config = dict(agent.DEFAULT_CONFIG)
+
+
+def _mock_proc(pid=1234, running=True):
+    proc = MagicMock()
+    proc.pid = pid
+    proc.poll.return_value = None if running else 0
+    return proc
+
+
+# ── find_dogegen_executable ─────────────────────────────────────────────────
+
+class TestFindExecutable:
+    def test_uses_configured_path_if_exists(self, tmp_path):
+        exe = tmp_path / "Dogegen.exe"
+        exe.write_text("")
+        cfg = {"path": str(exe)}
+        assert agent.find_dogegen_executable(cfg) == str(exe)
+
+    def test_falls_back_to_path_env_when_not_configured(self):
+        cfg = {"path": ""}
+        with patch("shutil.which", side_effect=lambda name: "/usr/bin/dogegen.exe" if "dogegen" in name.lower() else None), \
+             patch.object(Path, "exists", return_value=True):
+            result = agent.find_dogegen_executable(cfg)
+        assert result is not None
+
+    def test_returns_none_when_nothing_found(self):
+        cfg = {"path": "/nonexistent/Dogegen.exe"}
+        with patch("shutil.which", return_value=None):
+            assert agent.find_dogegen_executable(cfg) is None
+
+
+# ── external_dogegen_pid ─────────────────────────────────────────────────────
+
+class TestExternalPid:
+    def test_windows_tasklist_found(self):
+        proc = MagicMock()
+        proc.stdout = '"Dogegen.exe","4321","Console","1","50,000 K"\n'
+        with patch.object(os, "name", "nt"), patch("subprocess.run", return_value=proc):
+            assert agent.external_dogegen_pid() == 4321
+
+    def test_windows_tasklist_no_tasks(self):
+        proc = MagicMock()
+        proc.stdout = "INFO: No tasks are running which match the specified criteria.\n"
+        with patch.object(os, "name", "nt"), patch("subprocess.run", return_value=proc):
+            assert agent.external_dogegen_pid() is None
+
+    def test_linux_pgrep_found(self):
+        proc = MagicMock()
+        proc.stdout = "9876\n"
+        with patch.object(os, "name", "posix"), patch("subprocess.run", return_value=proc):
+            assert agent.external_dogegen_pid() == 9876
+
+    def test_linux_pgrep_not_found(self):
+        proc = MagicMock()
+        proc.stdout = ""
+        with patch.object(os, "name", "posix"), patch("subprocess.run", return_value=proc):
+            assert agent.external_dogegen_pid() is None
+
+    def test_subprocess_exception_returns_none(self):
+        with patch("subprocess.run", side_effect=OSError("no such tool")):
+            assert agent.external_dogegen_pid() is None
+
+
+# ── GET /status ──────────────────────────────────────────────────────────────
+
+class TestStatus:
+    def test_not_configured(self):
+        with patch.object(agent, "find_dogegen_executable", return_value=None), \
+             patch.object(agent, "external_dogegen_pid", return_value=None):
+            r = client.get("/status")
+        assert r.status_code == 200
+        d = r.json()
+        assert d["configured"] is False
+        assert d["running"] is False
+        assert d["managed"] is False
+        assert d["ready"] is False
+        assert d["pid"] is None
+
+    def test_reports_defaults_shape(self):
+        with patch.object(agent, "find_dogegen_executable", return_value=None), \
+             patch.object(agent, "external_dogegen_pid", return_value=None):
+            r = client.get("/status")
+        d = r.json()
+        for key in (
+            "running", "managed", "ready", "ready_in_ms", "pid", "path",
+            "configured", "last_error", "launch_cmd", "resolve_host",
+            "window_pct", "maxcll",
+        ):
+            assert key in d
+
+    def test_external_process_detected_is_ready_immediately(self):
+        with patch.object(agent, "find_dogegen_executable", return_value="C:/Dogegen.exe"), \
+             patch.object(agent, "external_dogegen_pid", return_value=555):
+            r = client.get("/status")
+        d = r.json()
+        assert d["running"] is True
+        assert d["managed"] is False
+        assert d["pid"] == 555
+        assert d["ready"] is True
+
+    def test_managed_process_not_ready_before_delay(self):
+        agent._dogegen_state.set_started(_mock_proc(pid=42), agent._now(), ["Dogegen.exe"])
+        with patch.object(agent, "find_dogegen_executable", return_value="C:/Dogegen.exe"):
+            r = client.get("/status")
+        d = r.json()
+        assert d["running"] is True
+        assert d["managed"] is True
+        assert d["pid"] == 42
+        assert d["ready"] is False
+        assert d["ready_in_ms"] > 0
+
+    def test_managed_process_ready_after_delay(self):
+        started_at = agent._now() - timedelta(seconds=10)
+        agent._dogegen_state.set_started(_mock_proc(pid=42), started_at, ["Dogegen.exe"])
+        with patch.object(agent, "find_dogegen_executable", return_value="C:/Dogegen.exe"):
+            r = client.get("/status")
+        d = r.json()
+        assert d["ready"] is True
+        assert d["ready_in_ms"] == 0
+
+
+# ── POST /start ──────────────────────────────────────────────────────────────
+
+class TestStart:
+    def test_exe_not_found_returns_400(self):
+        with patch.object(agent, "find_dogegen_executable", return_value=None), \
+             patch.object(agent, "external_dogegen_pid", return_value=None):
+            r = client.post("/start", json={"mode": "HDR10"})
+        assert r.status_code == 400
+        assert "not found" in r.json()["detail"].lower()
+        assert agent._dogegen_state.get_last_error() is not None
+
+    def test_already_running_externally(self):
+        with patch.object(agent, "external_dogegen_pid", return_value=777), \
+             patch.object(agent, "find_dogegen_executable", return_value="C:/Dogegen.exe"):
+            r = client.post("/start", json={"mode": "SDR"})
+        assert r.status_code == 200
+        d = r.json()
+        assert d["ok"] is True
+        assert d["already_running"] is True
+        assert d["pid"] == 777
+
+    def test_already_running_managed(self):
+        agent._dogegen_state.set_started(_mock_proc(pid=99), agent._now(), ["Dogegen.exe"])
+        with patch.object(agent, "external_dogegen_pid", return_value=None), \
+             patch.object(agent, "find_dogegen_executable", return_value="C:/Dogegen.exe"):
+            r = client.post("/start", json={"mode": "SDR"})
+        assert r.status_code == 200
+        d = r.json()
+        assert d["already_running"] is True
+        assert d["pid"] == 99
+
+    def test_starts_hdr10_with_expected_cmd(self):
+        agent._config["resolve_host"] = "192.168.1.5"
+        agent._config["window_pct"] = 25
+        agent._config["maxcll"] = 4000
+        new_proc = _mock_proc(pid=111)
+        with patch.object(agent, "external_dogegen_pid", return_value=None), \
+             patch.object(agent, "find_dogegen_executable", return_value="C:/Dogegen.exe"), \
+             patch("subprocess.Popen", return_value=new_proc) as mock_popen:
+            r = client.post("/start", json={"mode": "HDR10"})
+        assert r.status_code == 200
+        d = r.json()
+        assert d["ok"] is True
+        assert d["already_running"] is False
+        assert d["pid"] == 111
+        assert d["managed"] is True
+        cmd = mock_popen.call_args[0][0]
+        assert cmd[0] == "C:/Dogegen.exe"
+        assert "mode 10_hdr" in cmd
+        assert "maxcll 4000" in cmd
+        assert "resolve_hdr 192.168.1.5 25" in cmd
+
+    def test_starts_sdr_with_expected_cmd(self):
+        agent._config["resolve_host"] = ""
+        new_proc = _mock_proc(pid=222)
+        with patch.object(agent, "external_dogegen_pid", return_value=None), \
+             patch.object(agent, "find_dogegen_executable", return_value="C:/Dogegen.exe"), \
+             patch("subprocess.Popen", return_value=new_proc) as mock_popen:
+            r = client.post("/start", json={"mode": "SDR"})
+        assert r.status_code == 200
+        cmd = mock_popen.call_args[0][0]
+        assert "resolve_sdr 127.0.0.1" in cmd
+
+    def test_start_failure_sets_last_error_and_returns_500(self):
+        with patch.object(agent, "external_dogegen_pid", return_value=None), \
+             patch.object(agent, "find_dogegen_executable", return_value="C:/Dogegen.exe"), \
+             patch("subprocess.Popen", side_effect=OSError("permission denied")):
+            r = client.post("/start", json={"mode": "SDR"})
+        assert r.status_code == 500
+        assert agent._dogegen_state.get_last_error() == "permission denied"
+
+    def test_start_defaults_mode_to_none(self):
+        new_proc = _mock_proc(pid=333)
+        with patch.object(agent, "external_dogegen_pid", return_value=None), \
+             patch.object(agent, "find_dogegen_executable", return_value="C:/Dogegen.exe"), \
+             patch("subprocess.Popen", return_value=new_proc) as mock_popen:
+            r = client.post("/start", json={})
+        assert r.status_code == 200
+        cmd = mock_popen.call_args[0][0]
+        assert cmd == ["C:/Dogegen.exe"]
+
+
+# ── POST /stop ───────────────────────────────────────────────────────────────
+
+class TestStop:
+    def test_already_stopped(self):
+        r = client.post("/stop")
+        assert r.status_code == 200
+        d = r.json()
+        assert d["ok"] is True
+        assert d["already_stopped"] is True
+
+    def test_stops_managed_process(self):
+        proc = _mock_proc(pid=42)
+        agent._dogegen_state.set_started(proc, agent._now(), ["Dogegen.exe"])
+        r = client.post("/stop")
+        assert r.status_code == 200
+        d = r.json()
+        assert d["ok"] is True
+        assert d["already_stopped"] is False
+        proc.terminate.assert_called_once()
+        assert agent._dogegen_state.is_running() is False
+
+    def test_stop_falls_back_to_kill_on_terminate_timeout(self):
+        import subprocess as sp
+        proc = _mock_proc(pid=42)
+        proc.wait.side_effect = sp.TimeoutExpired(cmd="Dogegen.exe", timeout=3)
+        agent._dogegen_state.set_started(proc, agent._now(), ["Dogegen.exe"])
+        r = client.post("/stop")
+        assert r.status_code == 200
+        proc.kill.assert_called_once()

--- a/tools/dogegen-agent/README.md
+++ b/tools/dogegen-agent/README.md
@@ -26,6 +26,25 @@ The agent listens on `0.0.0.0:7071` by default so a backend on another
 machine on your LAN can reach it. Point your backend's Dogegen agent URL
 setting at `http://<this-pc-ip>:7071`.
 
+### Running persistently (surviving reboot)
+
+`start.bat` is meant for manual/on-demand use — it exits once you close its
+console window, and it doesn't come back after a reboot. To keep the agent
+running in the background across reboots, register it as a Windows service
+or scheduled task instead of double-clicking `start.bat`:
+
+* **[NSSM](https://nssm.cc/)** (Non-Sucking Service Manager) — the simplest
+  option. `nssm install DogegenAgent "C:\Path\To\python.exe" "C:\Path\To\tools\dogegen-agent\agent.py" --config "C:\Path\To\tools\dogegen-agent\agent.json"`,
+  then `nssm start DogegenAgent`. NSSM restarts it automatically if it
+  crashes and it starts on boot like any other Windows service.
+* **Task Scheduler** — create a task triggered "At log on" (or "At startup"
+  for a service-like account), action = run `python.exe` with the same
+  arguments as above, and "Run whether user is logged on or not" if you
+  want it up before anyone signs in.
+
+Either way, point the action/task at `agent.py` directly (not `start.bat`)
+so it doesn't sit waiting at the `pause` prompt at the end of the script.
+
 ## Configuration
 
 Edit `agent.json` (created from `agent.example.json` on first run):
@@ -80,8 +99,10 @@ process it launched (`managed: true`); a Dogegen instance detected via
 ### `POST /start`
 
 Body: `{"mode": "HDR10" | "SDR" | null}`. Launches Dogegen with the launch
-arguments appropriate to the mode. Returns `{"ok": true, "already_running":
-bool, ...status fields}`. Returns `400` if Dogegen can't be found.
+arguments appropriate to the mode. Any other `mode` value is rejected with
+`422` (fails fast on typos like `"Hdr10"`). Returns `{"ok": true,
+"already_running": bool, ...status fields}`. Returns `400` if Dogegen can't
+be found.
 
 ### `POST /stop`
 

--- a/tools/dogegen-agent/README.md
+++ b/tools/dogegen-agent/README.md
@@ -1,0 +1,96 @@
+# Dogegen Companion Agent
+
+A small HTTP service that runs on the Windows PC next to Dogegen and exposes
+`GET /status`, `POST /start`, and `POST /stop` so a backend running anywhere
+on the LAN — including in a Docker container on a different machine — can
+control Dogegen without needing local process access to the PC it runs on.
+
+This mirrors the [ZRO Bridge](../zro-bridge/) pattern (`bridge.py`), applied
+to Dogegen's process-control logic that previously lived only in `server.py`
+as direct `subprocess.Popen` calls.
+
+## Install & run (Windows)
+
+1. Install [Python 3.10+](https://python.org) if you don't already have it.
+2. Copy this folder (`tools/dogegen-agent/`) to the Windows PC that runs
+   Dogegen, or clone the repo there.
+3. Double-click `start.bat`. On first run it installs dependencies from
+   `requirements.txt` and creates `agent.json` from `agent.example.json`.
+4. Confirm it's up:
+
+   ```
+   curl http://localhost:7071/status
+   ```
+
+The agent listens on `0.0.0.0:7071` by default so a backend on another
+machine on your LAN can reach it. Point your backend's Dogegen agent URL
+setting at `http://<this-pc-ip>:7071`.
+
+## Configuration
+
+Edit `agent.json` (created from `agent.example.json` on first run):
+
+| Field | Description |
+|---|---|
+| `host` | Bind address. `0.0.0.0` (default) accepts LAN connections; set to `127.0.0.1` to restrict to this PC only. |
+| `port` | Port to listen on (default `7071`). |
+| `path` | Full path to `Dogegen.exe`. Leave `""` to auto-detect — checks `path`, then `tools/dogegen/Dogegen.exe` next to this repo checkout, then `Dogegen.exe`/`dogegen.exe` on `PATH`. |
+| `resolve_host` | Hostname/IP passed to Dogegen's `resolve_hdr`/`resolve_sdr` launch args. |
+| `window_pct` | HDR window size, percent of screen, passed to `resolve_hdr`. |
+| `maxcll` | MaxCLL value passed to Dogegen for HDR10 patterns. |
+| `ready_delay_seconds` | Seconds after launch before Dogegen is reported `ready` in `/status`. |
+
+## Trust model
+
+There is no authentication in v1 — the same trust model as the ZRO Bridge.
+Anyone who can reach the agent's port can start/stop Dogegen on this PC.
+This is meant to run on a **trusted LAN only**. If the backend always runs
+on this same PC and you want to disable remote access entirely, set
+`"host": "127.0.0.1"` in `agent.json`.
+
+## API
+
+### `GET /status`
+
+Returns a payload shape-compatible with the backend's existing
+`_dogegen_status_payload()`:
+
+```json
+{
+  "configured": true,
+  "path": "C:\\Tools\\Dogegen\\Dogegen.exe",
+  "running": false,
+  "pid": null,
+  "managed": false,
+  "ready": false,
+  "ready_in_ms": 0,
+  "resolve_host": "",
+  "window_pct": 10,
+  "maxcll": 1000,
+  "last_error": null,
+  "launch_cmd": []
+}
+```
+
+`ready`/`ready_in_ms` are computed from the agent's own `started_at` for a
+process it launched (`managed: true`); a Dogegen instance detected via
+`tasklist`/`pgrep` that the agent didn't launch itself is reported as
+`running: true`, `managed: false`, `ready: true` immediately.
+
+### `POST /start`
+
+Body: `{"mode": "HDR10" | "SDR" | null}`. Launches Dogegen with the launch
+arguments appropriate to the mode. Returns `{"ok": true, "already_running":
+bool, ...status fields}`. Returns `400` if Dogegen can't be found.
+
+### `POST /stop`
+
+Terminates a Dogegen process this agent started. No-op (`already_stopped:
+true`) if nothing is running under agent management. Returns
+`{"ok": true, "already_stopped": bool, ...status fields}`.
+
+## Tests
+
+Unit tests (with `Popen`/`tasklist`/`pgrep` mocked out) live at
+[`tests/test_dogegen_agent.py`](../../tests/test_dogegen_agent.py) in the
+repo root and run as part of the normal `pytest` suite.

--- a/tools/dogegen-agent/agent.example.json
+++ b/tools/dogegen-agent/agent.example.json
@@ -1,0 +1,18 @@
+{
+  "_comment": "Copy this file to agent.json and edit as needed.",
+
+  "_trust_model": "No authentication. Binds 0.0.0.0 by default so a backend on another host on your LAN can reach it, same as tools/zro-bridge. Set host to 127.0.0.1 below if the backend always runs on this same PC and you want to disable remote access.",
+
+  "host": "0.0.0.0",
+  "port": 7071,
+
+  "path": "",
+
+  "resolve_host": "",
+
+  "window_pct": 10,
+
+  "maxcll": 1000,
+
+  "ready_delay_seconds": 2.0
+}

--- a/tools/dogegen-agent/agent.py
+++ b/tools/dogegen-agent/agent.py
@@ -39,7 +39,7 @@ import sys
 import threading
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 import uvicorn
 from fastapi import FastAPI, HTTPException
@@ -170,7 +170,14 @@ class DogegenState:
 _dogegen_state = DogegenState()
 
 
-# ── Dogegen process control (ported from server.py, essentially unchanged) ──
+# ── Dogegen process control ─────────────────────────────────────────────────
+#
+# Ported from server.py:643-790 (as of the split-host Companion Agent work,
+# issue #584/#588) essentially unchanged. server.py's copy still runs today
+# for local-subprocess setups; #585 will switch the backend to call this
+# agent instead, at which point server.py's copy can be removed. There is no
+# shared module between the two, so if server.py's Dogegen launch/detection
+# logic changes after this port, re-sync it here by hand.
 
 def find_dogegen_executable(config: dict) -> Optional[str]:
     configured = (config.get("path") or "").strip()
@@ -209,9 +216,11 @@ def external_dogegen_pid() -> Optional[int]:
                     parts = [part.strip().strip('"') for part in line.split('","')]
                     if len(parts) >= 2 and parts[0].lower().startswith("dogegen"):
                         try:
-                            return int(parts[1])
+                            pid = int(parts[1])
                         except ValueError:
                             continue
+                        logger.info("Detected externally-running Dogegen, PID %d", pid)
+                        return pid
             return None
 
         proc = subprocess.run(
@@ -225,9 +234,11 @@ def external_dogegen_pid() -> Optional[int]:
             if not line:
                 continue
             try:
-                return int(line)
+                pid = int(line)
             except ValueError:
                 continue
+            logger.info("Detected externally-running Dogegen, PID %d", pid)
+            return pid
     except Exception:
         return None
     return None
@@ -332,7 +343,7 @@ app.add_middleware(
 
 
 class StartBody(BaseModel):
-    mode: Optional[str] = None
+    mode: Optional[Literal["HDR10", "SDR"]] = None
 
 
 @app.get("/status")

--- a/tools/dogegen-agent/agent.py
+++ b/tools/dogegen-agent/agent.py
@@ -1,0 +1,377 @@
+#!/usr/bin/env python3
+"""
+Dogegen Companion Agent — Windows companion service for Dogegen.
+
+Runs on the Windows PC alongside Dogegen. Exposes a small HTTP server so
+that a backend running anywhere on the LAN (including in a Docker
+container on a separate host) can start/stop/query Dogegen without
+needing local process access to the machine Dogegen runs on.
+
+This mirrors the ZRO Bridge (tools/zro-bridge/bridge.py) pattern applied
+to Dogegen's process-control logic, previously local-subprocess-only in
+server.py.
+
+Usage:
+    python agent.py               # reads agent.json from same directory
+    python agent.py --config path\to\agent.json
+    python agent.py --help
+
+Endpoints:
+    GET  /status  — health check; reports Dogegen running/ready/pid/etc.
+    POST /start   — launch Dogegen for a session mode ({"mode": "HDR10"|"SDR"})
+    POST /stop    — terminate a Dogegen instance this agent started
+
+Configure agent.json (see agent.example.json) before starting.
+
+Trust model: like the ZRO Bridge, this service has no authentication and
+binds to 0.0.0.0 by default so a remote backend can reach it — it is
+meant to run on a trusted LAN only. Set "host" to "127.0.0.1" in
+agent.json to restrict it to same-host callers only.
+"""
+
+import argparse
+import json
+import logging
+import os
+import shutil
+import subprocess
+import sys
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import uvicorn
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
+# ── Config ───────────────────────────────────────────────────────────────────
+
+DEFAULT_CONFIG = {
+    # Trusted-LAN bind, matching the ZRO Bridge default (bridge.py). Set to
+    # "127.0.0.1" here to restrict the agent to same-host callers only.
+    "host": "0.0.0.0",
+    "port": 7071,
+    # Path to Dogegen.exe. Leave empty to auto-detect (see find_dogegen_executable).
+    "path": "",
+    # Resolve hostname/IP passed to Dogegen's resolve_hdr/resolve_sdr args.
+    "resolve_host": "",
+    # HDR window size, percent of screen, passed to resolve_hdr.
+    "window_pct": 10,
+    # MaxCLL value passed to Dogegen for HDR10 patterns.
+    "maxcll": 1000,
+    # Seconds after launch before Dogegen is considered "ready" for patterns.
+    "ready_delay_seconds": 2.0,
+}
+
+_config: dict = dict(DEFAULT_CONFIG)
+
+
+def load_config(path: Optional[Path] = None) -> dict:
+    cfg = dict(DEFAULT_CONFIG)
+    if path and path.exists():
+        try:
+            with open(path) as f:
+                overrides = json.load(f)
+            cfg.update(overrides)
+            logger.info("Loaded config from %s", path)
+        except Exception as exc:
+            logger.warning("Could not load config %s: %s — using defaults", path, exc)
+    else:
+        logger.info("No config file found — using defaults (see agent.example.json)")
+    return cfg
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+# ── Dogegen process state ───────────────────────────────────────────────────
+
+class DogegenState:
+    """Tracks a Dogegen process this agent launched itself (as opposed to one
+    started outside the agent and merely detected via tasklist/pgrep)."""
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self.proc: Optional[subprocess.Popen] = None
+        self.started_at: Optional[datetime] = None
+        self.launch_cmd: List[str] = []
+        self.last_error: Optional[str] = None
+
+    def is_running(self) -> bool:
+        with self._lock:
+            if self.proc is None:
+                return False
+            if self.proc.poll() is None:
+                return True
+            self.proc = None
+            self.started_at = None
+            return False
+
+    def get_started_at(self) -> Optional[datetime]:
+        with self._lock:
+            return self.started_at
+
+    def get_proc_pid(self) -> Optional[int]:
+        with self._lock:
+            return self.proc.pid if self.proc is not None else None
+
+    def get_last_error(self) -> Optional[str]:
+        with self._lock:
+            return self.last_error
+
+    def get_launch_cmd(self) -> List[str]:
+        with self._lock:
+            return list(self.launch_cmd)
+
+    def set_started(self, proc: subprocess.Popen, started_at: datetime, cmd: List[str]) -> None:
+        with self._lock:
+            self.proc = proc
+            self.started_at = started_at
+            self.launch_cmd = list(cmd)
+            self.last_error = None
+
+    def set_failed(self, cmd: List[str], error: str) -> None:
+        with self._lock:
+            self.proc = None
+            self.started_at = None
+            self.launch_cmd = list(cmd)
+            self.last_error = error
+
+    def set_last_error(self, error: str) -> None:
+        with self._lock:
+            self.last_error = error
+
+    def terminate(self) -> None:
+        with self._lock:
+            if self.proc is not None:
+                try:
+                    self.proc.terminate()
+                    self.proc.wait(timeout=3)
+                except Exception:
+                    try:
+                        self.proc.kill()
+                    except Exception:
+                        pass
+                finally:
+                    self.proc = None
+                    self.started_at = None
+
+
+_dogegen_state = DogegenState()
+
+
+# ── Dogegen process control (ported from server.py, essentially unchanged) ──
+
+def find_dogegen_executable(config: dict) -> Optional[str]:
+    configured = (config.get("path") or "").strip()
+    candidates = []
+    if configured:
+        candidates.append(configured)
+    candidates.append(str(Path(__file__).parent.parent / "dogegen" / "Dogegen.exe"))
+    on_path = shutil.which("Dogegen.exe") or shutil.which("dogegen.exe")
+    if on_path:
+        candidates.append(on_path)
+    for candidate in candidates:
+        if candidate and Path(candidate).exists():
+            return str(Path(candidate))
+    return None
+
+
+def external_dogegen_pid() -> Optional[int]:
+    """Detect a Dogegen process not launched by this agent (e.g. started by
+    hand). Keeps the os.name branch from server.py unchanged — this agent
+    *is* the machine with the process table, so it still applies."""
+    try:
+        if os.name == "nt":
+            for image in ("Dogegen.exe", "Dogegen64.exe"):
+                proc = subprocess.run(
+                    ["tasklist", "/FO", "CSV", "/NH", "/FI", f"IMAGENAME eq {image}"],
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+                lines = [
+                    line.strip() for line in proc.stdout.splitlines() if line.strip()
+                ]
+                for line in lines:
+                    if "No tasks are running" in line:
+                        continue
+                    parts = [part.strip().strip('"') for part in line.split('","')]
+                    if len(parts) >= 2 and parts[0].lower().startswith("dogegen"):
+                        try:
+                            return int(parts[1])
+                        except ValueError:
+                            continue
+            return None
+
+        proc = subprocess.run(
+            ["pgrep", "-f", "[Dd]ogegen"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        for line in proc.stdout.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                return int(line)
+            except ValueError:
+                continue
+    except Exception:
+        return None
+    return None
+
+
+def dogegen_status_payload(config: dict) -> Dict[str, Any]:
+    path = find_dogegen_executable(config)
+    managed_running = _dogegen_state.is_running()
+    external_pid = None if managed_running else external_dogegen_pid()
+    running = managed_running or external_pid is not None
+    ready = False
+    ready_in_ms = 0
+    ready_delay = float(config.get("ready_delay_seconds") or DEFAULT_CONFIG["ready_delay_seconds"])
+    if external_pid is not None:
+        ready = True
+    elif managed_running:
+        started_at = _dogegen_state.get_started_at()
+        elapsed = (
+            0.0
+            if started_at is None
+            else (_now() - started_at).total_seconds()
+        )
+        ready = elapsed >= ready_delay
+        if not ready:
+            ready_in_ms = max(0, int((ready_delay - elapsed) * 1000))
+    return {
+        "configured": bool(path),
+        "path": path,
+        "running": running,
+        "pid": _dogegen_state.get_proc_pid() if managed_running else external_pid,
+        "managed": managed_running,
+        "ready": ready,
+        "ready_in_ms": ready_in_ms,
+        "resolve_host": config.get("resolve_host") or "",
+        "window_pct": int(config.get("window_pct") or DEFAULT_CONFIG["window_pct"]),
+        "maxcll": int(config.get("maxcll") or DEFAULT_CONFIG["maxcll"]),
+        "last_error": _dogegen_state.get_last_error(),
+        "launch_cmd": _dogegen_state.get_launch_cmd(),
+    }
+
+
+def dogegen_command_for_mode(mode: Optional[str], exe_path: str, config: dict) -> List[str]:
+    window_pct = int(config.get("window_pct") or DEFAULT_CONFIG["window_pct"])
+    maxcll = int(config.get("maxcll") or DEFAULT_CONFIG["maxcll"])
+    resolve_host = (config.get("resolve_host") or "").strip()
+    if mode == "HDR10":
+        cmd = [exe_path, "mode 10_hdr", f"maxcll {maxcll}"]
+        resolve_arg = (
+            f"resolve_hdr {resolve_host} {window_pct}"
+            if resolve_host
+            else f"resolve_hdr {window_pct}"
+        )
+        cmd.append(resolve_arg)
+        return cmd
+    if mode == "SDR":
+        host = resolve_host or "127.0.0.1"
+        return [exe_path, f"maxcll {maxcll}", f"resolve_sdr {host}"]
+    return [exe_path]
+
+
+def start_dogegen(mode: Optional[str], config: dict) -> Dict[str, Any]:
+    with _dogegen_state._lock:
+        if _dogegen_state.is_running() or external_dogegen_pid() is not None:
+            return {"ok": True, "already_running": True, **dogegen_status_payload(config)}
+        exe_path = find_dogegen_executable(config)
+        if not exe_path:
+            error = (
+                "Dogegen.exe not found. Set 'path' in agent.json, or place it at "
+                "tools/dogegen/Dogegen.exe."
+            )
+            _dogegen_state.set_last_error(error)
+            raise HTTPException(400, error)
+        cmd = dogegen_command_for_mode(mode, exe_path, config)
+        try:
+            proc = subprocess.Popen(cmd)
+            _dogegen_state.set_started(proc, _now(), cmd)
+            return {"ok": True, "already_running": False, **dogegen_status_payload(config)}
+        except Exception as exc:
+            _dogegen_state.set_failed(cmd, str(exc))
+            raise HTTPException(500, f"Failed to start Dogegen: {exc}") from exc
+
+
+def stop_dogegen(config: dict) -> Dict[str, Any]:
+    with _dogegen_state._lock:
+        if not _dogegen_state.is_running():
+            return {"ok": True, "already_stopped": True, **dogegen_status_payload(config)}
+        _dogegen_state.terminate()
+        return {"ok": True, "already_stopped": False, **dogegen_status_payload(config)}
+
+
+# ── FastAPI app ──────────────────────────────────────────────────────────────
+
+app = FastAPI(title="Dogegen Companion Agent", version="1.0")
+
+# Allow the backend (different origin/host) to call us.
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["GET", "POST"],
+    allow_headers=["*"],
+)
+
+
+class StartBody(BaseModel):
+    mode: Optional[str] = None
+
+
+@app.get("/status")
+def status():
+    """Health payload, shape-compatible with server.py's _dogegen_status_payload()."""
+    return dogegen_status_payload(_config)
+
+
+@app.post("/start")
+def start(body: StartBody):
+    return start_dogegen(body.mode, _config)
+
+
+@app.post("/stop")
+def stop():
+    return stop_dogegen(_config)
+
+
+# ── Entry point ──────────────────────────────────────────────────────────────
+
+def main():
+    global _config
+
+    parser = argparse.ArgumentParser(description="Dogegen Companion Agent — remote start/stop/status")
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=Path(__file__).parent / "agent.json",
+        help="Path to agent.json config file (default: agent.json next to agent.py)",
+    )
+    args = parser.parse_args()
+
+    _config = load_config(args.config)
+
+    logger.info("Starting Dogegen Companion Agent on %s:%s", _config["host"], _config["port"])
+    logger.info("Dogegen path override: %r", _config.get("path") or "(auto-detect)")
+
+    uvicorn.run(app, host=_config["host"], port=_config["port"], log_level="warning")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/dogegen-agent/requirements.txt
+++ b/tools/dogegen-agent/requirements.txt
@@ -1,0 +1,2 @@
+fastapi>=0.110.0
+uvicorn[standard]>=0.29.0

--- a/tools/dogegen-agent/start.bat
+++ b/tools/dogegen-agent/start.bat
@@ -1,0 +1,51 @@
+@echo off
+:: Dogegen Companion Agent — Windows launcher
+:: Run this on your Windows PC alongside Dogegen.
+:: A backend running anywhere on the LAN can connect to this service on port 7071.
+
+setlocal
+
+set SCRIPT_DIR=%~dp0
+
+:: Use the Python from PATH, or specify a full path if needed.
+:: e.g. set PYTHON=C:\Python311\python.exe
+set PYTHON=python
+
+:: Check Python is available
+%PYTHON% --version >nul 2>&1
+if errorlevel 1 (
+    echo ERROR: Python not found on PATH.
+    echo Install Python 3.10+ from https://python.org and try again.
+    pause
+    exit /b 1
+)
+
+:: Install dependencies if not already present
+echo Checking dependencies...
+%PYTHON% -m pip install -q -r "%SCRIPT_DIR%requirements.txt"
+if errorlevel 1 (
+    echo ERROR: Failed to install dependencies.
+    pause
+    exit /b 1
+)
+
+:: Create agent.json from example if it doesn't exist
+if not exist "%SCRIPT_DIR%agent.json" (
+    echo Creating agent.json with default settings...
+    copy "%SCRIPT_DIR%agent.example.json" "%SCRIPT_DIR%agent.json" >nul
+    echo   Default: auto-detect Dogegen.exe, LAN-reachable on 0.0.0.0:7071.
+    echo   Edit tools\dogegen-agent\agent.json if you need to change these.
+    echo.
+)
+
+echo Starting Dogegen Companion Agent...
+echo.
+echo  Agent will listen on http://0.0.0.0:7071
+echo  Enter this URL in the Calibration Helper settings: http://<this-pc-ip>:7071
+echo.
+echo  Press Ctrl+C to stop.
+echo.
+
+%PYTHON% "%SCRIPT_DIR%agent.py" --config "%SCRIPT_DIR%agent.json"
+
+pause


### PR DESCRIPTION
## 📺 Overview

Closes #587, #588, #589, #590, #591 (sub-tasks a–e of epic #584)

### What does this PR do?
* **Type of change:** [x] New feature
* **Component(s) affected:** Dogegen process control, Docker/split-host architecture

Adds a standalone Windows-resident HTTP service, `tools/dogegen-agent/`, mirroring the existing ZRO Bridge (`tools/zro-bridge/`) pattern. It lets a backend running anywhere on the LAN — including in a Docker container on a separate host (e.g. Unraid) — start/stop/query Dogegen, instead of requiring the backend to be a local subprocess parent on the same Windows PC as Dogegen.

Backend wiring to call this agent instead of `Popen` directly is scoped separately in #585 (out of scope here, per #584).

---

## 🛠️ Technical Context & Implementation

* **The Problem:** `server.py`'s Dogegen control (`_find_dogegen_executable`, `_start_dogegen_for_session`, `_stop_dogegen`, `_external_dogegen_pid`) assumes the backend and Dogegen share one OS process table — it breaks once the backend is containerized on a different host than the Windows PC running Dogegen.
* **The Solution:** New `tools/dogegen-agent/agent.py` (FastAPI app) exposes `GET /status`, `POST /start {mode}`, `POST /stop` over HTTP. The process-control logic (`find_dogegen_executable`, `dogegen_command_for_mode`, `start_dogegen`, `stop_dogegen`, `external_dogegen_pid`) is ported from `server.py:643-790` essentially unchanged, including the `os.name == "nt"` tasklist / Linux pgrep branch. `GET /status` returns a payload shape-compatible with today's `_dogegen_status_payload()` (`running`, `managed`, `ready`, `ready_in_ms`, `pid`, `path`, `configured`, `last_error`, `launch_cmd`, `resolve_host`, `window_pct`, `maxcll`) so #585's backend proxy can pass it through unreshaped. Default bind is `0.0.0.0` (matching the ZRO Bridge default), with loopback-only (`127.0.0.1`) documented as an opt-in for same-host setups; the trust model (no auth in v1) is documented in `agent.example.json` and the README.
* **Impact on existing workflows/APIs:** None — `server.py` is untouched; this is a new, standalone service. No breaking changes.

---

## 🧪 Testing & Validation

### Verification Steps
1. `pip install -r tools/dogegen-agent/requirements.txt`
2. `python -m pytest tests/test_dogegen_agent.py -v` — 23 tests covering `/status`, `/start`, `/stop`, including "already running" (managed + external PID) and "exe not found" paths, with `Popen`/`tasklist`/`pgrep` mocked.
3. Standalone smoke test: `python tools/dogegen-agent/agent.py` then `curl http://localhost:7071/status`.

---

## 🧼 Checklist
* [x] Code adheres to project style guidelines (formatting, typing, linting) — `ruff check` passes.
* [x] Unit tests added/updated and passing.
* [x] Documentation (README, inline docstrings) updated to reflect changes — `tools/dogegen-agent/README.md`.
* [x] No credentials, local absolute paths, or hardware-specific hardcoding leaked.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VrdeX8FiM6KyfU2HBRLsSm)_