### PR TITLE
Wire backend to the Dogegen Companion Agent for split-host deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project are documented here. Format loosely follows
+[Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project doesn't
+yet cut versioned releases, so entries live under `[Unreleased]` until that
+changes.
+
+## [Unreleased]
+
+### Added
+
+- **Split-host Dogegen support.** If you're moving the backend to Docker/Unraid
+  while keeping Dogegen on a Windows PC: install the
+  [Dogegen Companion Agent](tools/dogegen-agent/README.md) on that PC and set
+  `DOGEGEN_AGENT_URL` (env var, `.prefs.json`, or the Dogegen card's new
+  "Agent URL" field, which includes a "Test" button to check reachability
+  before saving) to point at it. The backend then proxies Dogegen
+  start/stop/status over HTTP instead of spawning a local process. Same-host
+  installs need no changes — leave `DOGEGEN_AGENT_URL` unset to keep today's
+  local-`Popen` behavior. See
+  [README: Dogegen — same-host vs. split-host](README.md#dogegen-same-host-vs-split-host).
+  (#585)

--- a/README.md
+++ b/README.md
@@ -280,9 +280,17 @@ AI features require a separately-reachable LLM endpoint; set `LITELLM_ENDPOINT` 
 | `LITELLM_ENDPOINT` | *(empty)* | URL of the LiteLLM proxy or any OpenAI-compatible endpoint |
 | `LITELLM_MODEL` | *(empty)* | Model name to send in chat completion requests |
 | `ZRO_BRIDGE_URL` | *(empty)* | URL of the ZRO Bridge for triggered measurements |
-| `DOGEGEN_PATH` | *(empty)* | Path to the Dogegen executable inside the container |
+| `DOGEGEN_PATH` | *(empty)* | Path to the Dogegen executable, for same-host setups only (see below) |
+| `DOGEGEN_AGENT_URL` | *(empty)* | URL of a [Dogegen Companion Agent](tools/dogegen-agent/README.md) for split-host setups (see below) |
 | `OPENROUTER_API_KEY` | *(empty)* | OpenRouter API key (read by the LiteLLM service) |
 | `TZ` | `UTC` | Timezone for the Samba sidecar |
+
+### Dogegen: same-host vs. split-host
+
+Dogegen is a Windows GUI application that needs a real desktop, GPU, and HDMI output — it cannot run inside the Linux backend container.
+
+- **Same-host** (backend and Dogegen on the *same* Windows PC, e.g. via Docker Desktop + WSL2): bind-mount `Dogegen.exe` into the container and set `DOGEGEN_PATH` to that in-container path, exactly as before. The backend launches it directly with `subprocess.Popen`.
+- **Split-host** (backend in Docker on a different machine — e.g. Unraid — while Dogegen stays on the Windows PC): a bind-mounted `.exe` path does nothing, since a Linux container cannot execute a Windows binary and cannot spawn a process on a different physical machine. Instead, run the **[Dogegen Companion Agent](tools/dogegen-agent/README.md)** on the Windows PC (`tools/dogegen-agent/start.bat`) and point the backend at it with `DOGEGEN_AGENT_URL=http://<windows-pc-ip>:7071` (env var, `.prefs.json`, or the Agent URL field on the Dogegen card in the app). The backend then proxies start/stop/status to the agent over HTTP instead of managing a local process. Leave `DOGEGEN_AGENT_URL` empty to keep today's same-host behavior unchanged.
 
 ---
 
@@ -315,13 +323,18 @@ Search for **tv-calibration** in the Community Applications plugin and click Ins
    | `/app/.sessions` | `/mnt/user/appdata/tv-calibration/.sessions` | Recommended |
    | `/app/.calibration-history` | `/mnt/user/appdata/tv-calibration/.calibration-history` | Recommended |
    | `/app/.prefs.json` | `/mnt/user/appdata/tv-calibration/.prefs.json` | Recommended |
-   | `/app/tools/dogegen` | path to Dogegen on host | Optional |
+
+   There is no path mapping for Dogegen — Unraid is a Linux host, so it can never bind-mount or execute a Windows `Dogegen.exe` directly. See "Dogegen on Unraid" below.
 
 4. Click **Apply**. Open `http://<UNRAID_IP>:8000` in your browser.
 
 **ZRO watch folder on Unraid:**
 
 Expose the `/mnt/user/downloads/zro-drops` directory as an Unraid SMB share (User Shares → Add Share, or enable an existing share). On your Windows machine, map that share as a network drive and point ColourSpace ZRO's export folder to it. The app's Watch Folder on the Prepare page should match the container path (`/data/zro-drops`).
+
+**Dogegen on Unraid (split-host):**
+
+Since Unraid runs Linux, Dogegen must stay on a separate Windows PC and be controlled over the network — a bind-mounted `.exe` path will not run. Install the **[Dogegen Companion Agent](tools/dogegen-agent/README.md)** on that Windows PC (`tools/dogegen-agent/start.bat`), then set `DOGEGEN_AGENT_URL` on the `tv-calibration` container to `http://<WINDOWS_PC_IP>:7071` — either as an extra parameter (`-e DOGEGEN_AGENT_URL=http://<WINDOWS_PC_IP>:7071`) or via the template's **Dogegen Agent URL** field. The app's Dogegen card also lets you set/change this URL at runtime without restarting the container.
 
 **AI assistant on Unraid:**
 
@@ -429,7 +442,7 @@ When Dogegen is selected as the pattern generator, the app manages the Dogegen p
 - Configures the recommended settings for HDR10: ST2084 Rec.2020, 10 bpc, RGB 4:4:4 Full, 10% window
 - Shows a status indicator in the header bar (green when running and ready)
 
-Configure the Dogegen executable path and signal settings in the **Dogegen Companion** card on the Prepare page.
+Configure the Dogegen executable path and signal settings in the **Dogegen Companion** card on the Prepare page. If Dogegen runs on a separate machine from the backend (e.g. backend in Docker on Unraid, Dogegen on a Windows PC), set the card's **Agent URL** to a [Dogegen Companion Agent](tools/dogegen-agent/README.md) instead — see [Dogegen: same-host vs. split-host](#dogegen-same-host-vs-split-host).
 
 ### LightSpace Connect
 

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -96,6 +96,7 @@ export const api = {
 
   // Dogegen
   getDogegenStatus: ()        => api.get('/api/dogegen/status'),
+  testDogegenAgent: (url)     => api.get(`/api/dogegen/status?url=${encodeURIComponent(url)}`),
   saveDogegenConfig: (body)   => api.post('/api/dogegen/config', body),
   startDogegen: (sid)         => api.post(`/api/session/${sid}/dogegen/start`),
   stopDogegen: ()             => api.post('/api/dogegen/stop'),

--- a/frontend/src/components/DogegenCard.jsx
+++ b/frontend/src/components/DogegenCard.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Button } from './Button';
+import { api } from '../api/client';
 
 export function DogegenCard({ dogegenStatus, session, onSaveConfig, onStart, onStop }) {
   const [path, setPath] = useState(dogegenStatus?.path || '');
@@ -10,6 +11,8 @@ export function DogegenCard({ dogegenStatus, session, onSaveConfig, onStart, onS
   const [showSettings, setShowSettings] = useState(false);
   const [busy, setBusy] = useState(false);
   const [msg, setMsg] = useState('');
+  const [testing, setTesting] = useState(false);
+  const [testResult, setTestResult] = useState(null);
 
   useEffect(() => {
     setMsg('');
@@ -18,6 +21,7 @@ export function DogegenCard({ dogegenStatus, session, onSaveConfig, onStart, onS
     setWindowPct(dogegenStatus?.window_pct || 10);
     setMaxcll(dogegenStatus?.maxcll || 1000);
     setAgentUrl(dogegenStatus?.agent_url || '');
+    setTestResult(null);
   }, [dogegenStatus]);
 
   const running = dogegenStatus?.running;
@@ -71,6 +75,28 @@ export function DogegenCard({ dogegenStatus, session, onSaveConfig, onStart, onS
     }
   }
 
+  async function handleTestAgentUrl() {
+    const url = agentUrl.trim();
+    if (!url) {
+      setTestResult({ ok: false, message: 'Enter an Agent URL first' });
+      return;
+    }
+    setTesting(true);
+    setTestResult(null);
+    try {
+      const status = await api.testDogegenAgent(url);
+      setTestResult(
+        status.agent_reachable
+          ? { ok: true, message: 'Agent reachable' }
+          : { ok: false, message: status.last_error || 'Agent unreachable' }
+      );
+    } catch (e) {
+      setTestResult({ ok: false, message: e.message });
+    } finally {
+      setTesting(false);
+    }
+  }
+
   return (
     <div>
       <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
@@ -115,10 +141,18 @@ export function DogegenCard({ dogegenStatus, session, onSaveConfig, onStart, onS
             <input
               type="text"
               value={agentUrl}
-              onChange={e => setAgentUrl(e.target.value)}
+              onChange={e => { setAgentUrl(e.target.value); setTestResult(null); }}
               placeholder="http://<windows-pc>:7071"
             />
+            <Button small onClick={handleTestAgentUrl} disabled={testing}>
+              {testing ? <span className="spinner" /> : 'Test'}
+            </Button>
           </div>
+          {testResult && (
+            <div className={`text-sm mt-2 ${testResult.ok ? 'green' : 'red'}`}>
+              {testResult.message}
+            </div>
+          )}
           <div className="text-sm muted" style={{ marginTop: 10 }}>
             {isRemote
               ? 'Dogegen executable path (on the agent host — set in agent.json, not here)'

--- a/frontend/src/components/DogegenCard.jsx
+++ b/frontend/src/components/DogegenCard.jsx
@@ -6,6 +6,7 @@ export function DogegenCard({ dogegenStatus, session, onSaveConfig, onStart, onS
   const [resolveHost, setResolveHost] = useState(dogegenStatus?.resolve_host || '');
   const [windowPct, setWindowPct] = useState(dogegenStatus?.window_pct || 10);
   const [maxcll, setMaxcll] = useState(dogegenStatus?.maxcll || 1000);
+  const [agentUrl, setAgentUrl] = useState(dogegenStatus?.agent_url || '');
   const [showSettings, setShowSettings] = useState(false);
   const [busy, setBusy] = useState(false);
   const [msg, setMsg] = useState('');
@@ -16,10 +17,13 @@ export function DogegenCard({ dogegenStatus, session, onSaveConfig, onStart, onS
     setResolveHost(dogegenStatus?.resolve_host || '');
     setWindowPct(dogegenStatus?.window_pct || 10);
     setMaxcll(dogegenStatus?.maxcll || 1000);
+    setAgentUrl(dogegenStatus?.agent_url || '');
   }, [dogegenStatus]);
 
   const running = dogegenStatus?.running;
   const configured = dogegenStatus?.configured;
+  const isRemote = Boolean(dogegenStatus?.agent_url);
+  const agentUnreachable = isRemote && dogegenStatus?.agent_reachable === false;
 
   async function handleSave() {
     setBusy(true);
@@ -30,6 +34,7 @@ export function DogegenCard({ dogegenStatus, session, onSaveConfig, onStart, onS
         resolve_host: resolveHost,
         window_pct: Number(windowPct),
         maxcll: Number(maxcll),
+        agent_url: agentUrl,
       });
       setMsg('Dogegen settings saved');
       setShowSettings(false);
@@ -72,17 +77,23 @@ export function DogegenCard({ dogegenStatus, session, onSaveConfig, onStart, onS
         <span
           style={{
             width: 8, height: 8, borderRadius: '50%',
-            background: running ? 'var(--green)' : 'var(--ink2)',
-            boxShadow: running ? '0 0 6px var(--green)' : 'none',
+            background: agentUnreachable ? 'var(--red)' : running ? 'var(--green)' : 'var(--ink2)',
+            boxShadow: agentUnreachable
+              ? '0 0 6px var(--red)'
+              : running ? '0 0 6px var(--green)' : 'none',
             flexShrink: 0,
           }}
         />
         <span className="text-sm muted">
-          {running
-            ? <span className="green">Dogegen running</span>
-            : configured
-              ? 'Dogegen ready to launch'
-              : 'Dogegen path not configured'}
+          {agentUnreachable
+            ? <span className="red">Dogegen agent unreachable</span>
+            : running
+              ? <span className="green">Dogegen running{isRemote ? ' (remote agent)' : ''}</span>
+              : configured
+                ? `Dogegen ready to launch${isRemote ? ' via remote agent' : ''}`
+                : isRemote
+                  ? 'Dogegen path not configured on agent'
+                  : 'Dogegen path not configured'}
         </span>
         <button
           className="btn btn-sm"
@@ -99,13 +110,27 @@ export function DogegenCard({ dogegenStatus, session, onSaveConfig, onStart, onS
 
       {showSettings && (
         <div className="bridge-settings">
-          <div className="text-sm muted">Dogegen executable path</div>
+          <div className="text-sm muted">Agent URL (optional — for a remote Dogegen Companion Agent)</div>
+          <div className="bridge-url-row">
+            <input
+              type="text"
+              value={agentUrl}
+              onChange={e => setAgentUrl(e.target.value)}
+              placeholder="http://<windows-pc>:7071"
+            />
+          </div>
+          <div className="text-sm muted" style={{ marginTop: 10 }}>
+            {isRemote
+              ? 'Dogegen executable path (on the agent host — set in agent.json, not here)'
+              : 'Dogegen executable path'}
+          </div>
           <div className="bridge-url-row">
             <input
               type="text"
               value={path}
               onChange={e => setPath(e.target.value)}
               placeholder="C:\Program Files\Dogegen\Dogegen.exe"
+              disabled={isRemote}
             />
           </div>
           <div className="text-sm muted" style={{ marginTop: 10 }}>Resolve host (optional)</div>
@@ -115,6 +140,7 @@ export function DogegenCard({ dogegenStatus, session, onSaveConfig, onStart, onS
               value={resolveHost}
               onChange={e => setResolveHost(e.target.value)}
               placeholder="127.0.0.1"
+              disabled={isRemote}
             />
           </div>
           <div className="bridge-url-row" style={{ marginTop: 10 }}>
@@ -125,6 +151,7 @@ export function DogegenCard({ dogegenStatus, session, onSaveConfig, onStart, onS
               value={windowPct}
               onChange={e => setWindowPct(Number(e.target.value))}
               style={{ width: 120 }}
+              disabled={isRemote}
             />
             <span className="text-sm muted">Window %</span>
             <input
@@ -133,6 +160,7 @@ export function DogegenCard({ dogegenStatus, session, onSaveConfig, onStart, onS
               value={maxcll}
               onChange={e => setMaxcll(Number(e.target.value))}
               style={{ width: 140, marginLeft: 8 }}
+              disabled={isRemote}
             />
             <span className="text-sm muted">MaxCLL</span>
             <Button small onClick={handleSave} disabled={busy}>Save</Button>

--- a/frontend/src/components/DogegenCard.test.jsx
+++ b/frontend/src/components/DogegenCard.test.jsx
@@ -1,7 +1,14 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { DogegenCard } from './DogegenCard';
+import { api } from '../api/client';
+
+vi.mock('../api/client', () => ({
+  api: {
+    testDogegenAgent: vi.fn(),
+  },
+}));
 
 function renderCard(props = {}) {
   return render(
@@ -16,6 +23,10 @@ function renderCard(props = {}) {
 }
 
 describe('DogegenCard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('shows local unconfigured message when no status and no agent url', () => {
     renderCard({ dogegenStatus: { running: false, configured: false } });
     expect(screen.getByText('Dogegen path not configured')).toBeInTheDocument();
@@ -91,5 +102,66 @@ describe('DogegenCard', () => {
     await userEvent.click(screen.getByText('Settings'));
     expect(screen.getByPlaceholderText('C:\\Program Files\\Dogegen\\Dogegen.exe')).toBeDisabled();
     expect(screen.getByPlaceholderText('127.0.0.1')).toBeDisabled();
+  });
+
+  describe('Test connection button', () => {
+    it('shows a prompt instead of calling the API when the field is empty', async () => {
+      renderCard({ dogegenStatus: { running: false, configured: false } });
+      await userEvent.click(screen.getByText('Settings'));
+      await userEvent.click(screen.getByText('Test'));
+
+      expect(await screen.findByText('Enter an Agent URL first')).toBeInTheDocument();
+      expect(api.testDogegenAgent).not.toHaveBeenCalled();
+    });
+
+    it('tests the typed URL without requiring Save first, and shows reachable in green', async () => {
+      api.testDogegenAgent.mockResolvedValue({ agent_reachable: true });
+      renderCard({ dogegenStatus: { running: false, configured: false } });
+
+      await userEvent.click(screen.getByText('Settings'));
+      await userEvent.type(
+        screen.getByPlaceholderText('http://<windows-pc>:7071'),
+        'http://192.168.1.50:7071'
+      );
+      await userEvent.click(screen.getByText('Test'));
+
+      expect(api.testDogegenAgent).toHaveBeenCalledWith('http://192.168.1.50:7071');
+      const result = await screen.findByText('Agent reachable');
+      expect(result).toHaveClass('green');
+    });
+
+    it('shows the agent error message in red when unreachable', async () => {
+      api.testDogegenAgent.mockResolvedValue({
+        agent_reachable: false,
+        last_error: 'Cannot reach Dogegen Companion Agent — is it running on the Windows PC?',
+      });
+      renderCard({ dogegenStatus: { running: false, configured: false } });
+
+      await userEvent.click(screen.getByText('Settings'));
+      await userEvent.type(
+        screen.getByPlaceholderText('http://<windows-pc>:7071'),
+        'http://192.168.1.99:7071'
+      );
+      await userEvent.click(screen.getByText('Test'));
+
+      const result = await screen.findByText(
+        'Cannot reach Dogegen Companion Agent — is it running on the Windows PC?'
+      );
+      expect(result).toHaveClass('red');
+    });
+
+    it('clears a stale test result once the URL is edited again', async () => {
+      api.testDogegenAgent.mockResolvedValue({ agent_reachable: true });
+      renderCard({ dogegenStatus: { running: false, configured: false } });
+
+      await userEvent.click(screen.getByText('Settings'));
+      const input = screen.getByPlaceholderText('http://<windows-pc>:7071');
+      await userEvent.type(input, 'http://192.168.1.50:7071');
+      await userEvent.click(screen.getByText('Test'));
+      await screen.findByText('Agent reachable');
+
+      await userEvent.type(input, '1');
+      expect(screen.queryByText('Agent reachable')).not.toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/components/DogegenCard.test.jsx
+++ b/frontend/src/components/DogegenCard.test.jsx
@@ -1,0 +1,95 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import { DogegenCard } from './DogegenCard';
+
+function renderCard(props = {}) {
+  return render(
+    <DogegenCard
+      dogegenStatus={props.dogegenStatus}
+      session={props.session || { mode: 'HDR10' }}
+      onSaveConfig={props.onSaveConfig || vi.fn()}
+      onStart={props.onStart || vi.fn()}
+      onStop={props.onStop || vi.fn()}
+    />
+  );
+}
+
+describe('DogegenCard', () => {
+  it('shows local unconfigured message when no status and no agent url', () => {
+    renderCard({ dogegenStatus: { running: false, configured: false } });
+    expect(screen.getByText('Dogegen path not configured')).toBeInTheDocument();
+  });
+
+  it('shows local running message without remote suffix', () => {
+    renderCard({ dogegenStatus: { running: true, configured: true } });
+    expect(screen.getByText('Dogegen running')).toBeInTheDocument();
+  });
+
+  it('shows remote-agent running message when agent_url is set', () => {
+    renderCard({
+      dogegenStatus: {
+        running: true,
+        configured: true,
+        agent_url: 'http://192.168.1.50:7071',
+        agent_reachable: true,
+      },
+    });
+    expect(screen.getByText('Dogegen running (remote agent)')).toBeInTheDocument();
+  });
+
+  it('shows remote ready message when configured but not running', () => {
+    renderCard({
+      dogegenStatus: {
+        running: false,
+        configured: true,
+        agent_url: 'http://192.168.1.50:7071',
+        agent_reachable: true,
+      },
+    });
+    expect(screen.getByText('Dogegen ready to launch via remote agent')).toBeInTheDocument();
+  });
+
+  it('shows "agent unreachable" when agent_reachable is false', () => {
+    renderCard({
+      dogegenStatus: {
+        running: false,
+        configured: false,
+        agent_url: 'http://192.168.1.50:7071',
+        agent_reachable: false,
+        last_error: 'Cannot reach Dogegen Companion Agent — is it running on the Windows PC?',
+      },
+    });
+    expect(screen.getByText('Dogegen agent unreachable')).toBeInTheDocument();
+  });
+
+  it('Save includes agent_url alongside the existing config fields', async () => {
+    const onSaveConfig = vi.fn().mockResolvedValue({ running: false, configured: false });
+    renderCard({ dogegenStatus: { running: false, configured: false }, onSaveConfig });
+
+    await userEvent.click(screen.getByText('Settings'));
+    await userEvent.type(
+      screen.getByPlaceholderText('http://<windows-pc>:7071'),
+      'http://192.168.1.50:7071'
+    );
+    await userEvent.click(screen.getByText('Save'));
+
+    expect(onSaveConfig).toHaveBeenCalledWith(
+      expect.objectContaining({ agent_url: 'http://192.168.1.50:7071' })
+    );
+  });
+
+  it('disables local-only fields (path, resolve host, window %, maxcll) when an agent url is configured', async () => {
+    renderCard({
+      dogegenStatus: {
+        running: false,
+        configured: true,
+        agent_url: 'http://192.168.1.50:7071',
+        agent_reachable: true,
+      },
+    });
+    await userEvent.click(screen.getByText('Settings'));
+    expect(screen.getByPlaceholderText('C:\\Program Files\\Dogegen\\Dogegen.exe')).toBeDisabled();
+    expect(screen.getByPlaceholderText('127.0.0.1')).toBeDisabled();
+  });
+});

--- a/server.py
+++ b/server.py
@@ -355,9 +355,28 @@ class _ZroBridgeState:
             self._url = url
 
 
+class _DogegenAgentState:
+    """URL of a remote Dogegen Companion Agent (#584), mirroring
+    _ZroBridgeState. Empty = today's local-Popen behavior, unchanged."""
+
+    def __init__(self, url: str) -> None:
+        self._lock = threading.Lock()
+        self._url = url
+
+    def get(self) -> str:
+        with self._lock:
+            return self._url
+
+    def set(self, url: str) -> None:
+        with self._lock:
+            self._url = url
+
+
 _watched_session = _WatchedSessionState()
 _dogegen_state = _DogegenState()
 _zro_bridge = _ZroBridgeState(os.getenv("ZRO_BRIDGE_URL", "http://localhost:7070").rstrip("/"))
+_dogegen_agent = _DogegenAgentState(os.getenv("DOGEGEN_AGENT_URL", "").strip().rstrip("/"))
+_DOGEGEN_AGENT_TIMEOUT = 5.0
 _DOGEGEN_READY_DELAY_SECONDS = 2.0
 _DOGEGEN_DEFAULT_WINDOW_PCT = 10
 _DOGEGEN_DEFAULT_MAXCLL = 1000
@@ -414,6 +433,7 @@ _AUTOCAL_DEFAULTS: Dict[str, Any] = {
 _prefs: Dict[str, Any] = {
     "dogegen": {},
     "bridge_url": "",
+    "dogegen_agent_url": "",
     "watch_folder": "",
     "llm": {"endpoint": "", "model": ""},
     "session_defaults": {
@@ -442,7 +462,7 @@ def _load_prefs() -> None:
     except Exception:
         logger.warning("Failed to parse .prefs.json; using defaults", exc_info=True)
         return
-    for key in ("dogegen", "bridge_url", "watch_folder", "llm", "session_defaults", "argyll"):
+    for key in ("dogegen", "bridge_url", "dogegen_agent_url", "watch_folder", "llm", "session_defaults", "argyll"):
         if key in saved:
             _prefs[key] = saved[key]
     if "autocal" in saved:
@@ -454,12 +474,15 @@ def _load_prefs() -> None:
             _dogegen_config[field] = _prefs["dogegen"][field]
     if _prefs.get("bridge_url"):
         _zro_bridge.set(_prefs["bridge_url"])
+    if _prefs.get("dogegen_agent_url"):
+        _dogegen_agent.set(_prefs["dogegen_agent_url"])
 
 
 def _save_prefs() -> None:
     """Snapshot current globals into _prefs and write atomically."""
     _prefs["dogegen"] = dict(_dogegen_config)
     _prefs["bridge_url"] = _zro_bridge.get()
+    _prefs["dogegen_agent_url"] = _dogegen_agent.get()
     try:
         tmp = _PREFS_PATH.with_suffix(".tmp")
         tmp.write_text(json.dumps(_prefs, indent=2), encoding="utf-8")
@@ -517,6 +540,7 @@ class DogegenConfigReq(BaseModel):
     resolve_host: Optional[str] = None
     window_pct: Optional[int] = None
     maxcll: Optional[int] = None
+    agent_url: Optional[str] = None
 
 
 class PrefsReq(BaseModel):
@@ -702,7 +726,54 @@ def _external_dogegen_pid() -> Optional[int]:
     return None
 
 
+def _dogegen_agent_error_message(exc: Exception) -> str:
+    if isinstance(exc, httpx.ConnectError):
+        return "Cannot reach Dogegen Companion Agent — is it running on the Windows PC?"
+    if isinstance(exc, httpx.TimeoutException):
+        return "Dogegen Companion Agent timed out — check the Windows PC and network."
+    if isinstance(exc, httpx.HTTPStatusError):
+        return exc.response.text or str(exc)
+    return str(exc)
+
+
+def _dogegen_agent_unreachable_payload(url: str, error: str) -> Dict[str, Any]:
+    return {
+        "configured": False,
+        "path": None,
+        "running": False,
+        "pid": None,
+        "managed": False,
+        "ready": False,
+        "ready_in_ms": 0,
+        "resolve_host": "",
+        "window_pct": _DOGEGEN_DEFAULT_WINDOW_PCT,
+        "maxcll": _DOGEGEN_DEFAULT_MAXCLL,
+        "last_error": error,
+        "launch_cmd": [],
+        "agent_url": url,
+        "agent_reachable": False,
+    }
+
+
+def _dogegen_status_payload_via_agent(url: str) -> Dict[str, Any]:
+    """Proxy GET {url}/status — readiness/pid/etc. come from the agent's own
+    payload, not local _dogegen_state (#585b)."""
+    try:
+        resp = httpx.get(f"{url}/status", timeout=_DOGEGEN_AGENT_TIMEOUT)
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception as exc:
+        return _dogegen_agent_unreachable_payload(url, _dogegen_agent_error_message(exc))
+    data["agent_url"] = url
+    data["agent_reachable"] = True
+    return data
+
+
 def _dogegen_status_payload() -> Dict[str, Any]:
+    agent_url = _dogegen_agent.get()
+    if agent_url:
+        return _dogegen_status_payload_via_agent(agent_url)
+
     path = _find_dogegen_executable()
     managed_running = _managed_dogegen_is_running()
     external_pid = None if managed_running else _external_dogegen_pid()
@@ -734,6 +805,7 @@ def _dogegen_status_payload() -> Dict[str, Any]:
         "maxcll": int(_dogegen_config.get("maxcll") or _DOGEGEN_DEFAULT_MAXCLL),
         "last_error": _dogegen_state.get_last_error(),
         "launch_cmd": _dogegen_state.get_launch_cmd(),
+        "agent_url": "",
     }
 
 
@@ -757,7 +829,43 @@ def _dogegen_command_for_session(session: Dict[str, Any], exe_path: str) -> List
     return [exe_path]
 
 
+def _dogegen_agent_request_error(url: str, exc: Exception) -> HTTPException:
+    if isinstance(exc, httpx.HTTPStatusError):
+        return HTTPException(exc.response.status_code, _dogegen_agent_error_message(exc))
+    return HTTPException(502, _dogegen_agent_error_message(exc))
+
+
+def _start_dogegen_via_agent(url: str, session: Dict[str, Any]) -> Dict[str, Any]:
+    try:
+        resp = httpx.post(
+            f"{url}/start", json={"mode": session.get("mode")}, timeout=_DOGEGEN_AGENT_TIMEOUT
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception as exc:
+        raise _dogegen_agent_request_error(url, exc) from exc
+    data["agent_url"] = url
+    data["agent_reachable"] = True
+    return data
+
+
+def _stop_dogegen_via_agent(url: str) -> Dict[str, Any]:
+    try:
+        resp = httpx.post(f"{url}/stop", timeout=_DOGEGEN_AGENT_TIMEOUT)
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception as exc:
+        raise _dogegen_agent_request_error(url, exc) from exc
+    data["agent_url"] = url
+    data["agent_reachable"] = True
+    return data
+
+
 def _start_dogegen_for_session(session: Dict[str, Any]) -> Dict[str, Any]:
+    agent_url = _dogegen_agent.get()
+    if agent_url:
+        return _start_dogegen_via_agent(agent_url, session)
+
     with _dogegen_state._lock:
         if _managed_dogegen_is_running() or _external_dogegen_pid() is not None:
             return {"ok": True, "already_running": True, **_dogegen_status_payload()}
@@ -783,6 +891,10 @@ def _start_dogegen_for_session(session: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def _stop_dogegen() -> Dict[str, Any]:
+    agent_url = _dogegen_agent.get()
+    if agent_url:
+        return _stop_dogegen_via_agent(agent_url)
+
     with _dogegen_state._lock:
         if not _managed_dogegen_is_running():
             return {"ok": True, "already_stopped": True, **_dogegen_status_payload()}
@@ -1246,6 +1358,8 @@ def dogegen_config(req: DogegenConfigReq):
         if req.maxcll <= 0:
             raise HTTPException(400, "maxcll must be greater than 0")
         _dogegen_config["maxcll"] = int(req.maxcll)
+    if req.agent_url is not None:
+        _dogegen_agent.set(req.agent_url.strip().rstrip("/"))
     _save_prefs()
     return {"ok": True, **_dogegen_status_payload()}
 

--- a/server.py
+++ b/server.py
@@ -783,8 +783,15 @@ def _dogegen_status_payload_via_agent(url: str) -> Dict[str, Any]:
     return data
 
 
-def _dogegen_status_payload() -> Dict[str, Any]:
-    agent_url = _dogegen_agent.get()
+def _dogegen_status_payload(url_override: Optional[str] = None) -> Dict[str, Any]:
+    """url_override lets a caller test a candidate agent URL (e.g. the
+    frontend's "Test connection" button) without first persisting it via
+    /api/dogegen/config — mirrors the ZRO Bridge's ?url= passthrough (#555)."""
+    agent_url = (
+        url_override.strip()
+        if (url_override is not None and url_override.strip())
+        else _dogegen_agent.get()
+    )
     if agent_url:
         return _dogegen_status_payload_via_agent(agent_url)
 
@@ -1354,8 +1361,8 @@ def set_code_scale(sid: str, req: CodeScaleReq):
 
 
 @app.get("/api/dogegen/status")
-def dogegen_status():
-    return _dogegen_status_payload()
+def dogegen_status(url: Optional[str] = Query(None)):
+    return _dogegen_status_payload(url)
 
 
 @app.post("/api/dogegen/config")

--- a/server.py
+++ b/server.py
@@ -726,6 +726,20 @@ def _external_dogegen_pid() -> Optional[int]:
     return None
 
 
+# ── Dogegen Companion Agent proxy (#585b) ───────────────────────────────────
+#
+# Contract with tools/dogegen-agent/agent.py (see tools/dogegen-agent/README.md):
+#   GET  {agent_url}/status         -> payload shape-compatible with
+#                                      _dogegen_status_payload() below (running,
+#                                      managed, ready, ready_in_ms, pid, path,
+#                                      configured, last_error, launch_cmd,
+#                                      resolve_host, window_pct, maxcll).
+#   POST {agent_url}/start {"mode"} -> {"ok", "already_running", **status}
+#   POST {agent_url}/stop           -> {"ok", "already_stopped", **status}
+# The agent owns all Popen/tasklist/pgrep logic; this backend only forwards
+# session.mode and reads the agent's response back, adding agent_url /
+# agent_reachable so the frontend can distinguish local vs. remote state.
+
 def _dogegen_agent_error_message(exc: Exception) -> str:
     if isinstance(exc, httpx.ConnectError):
         return "Cannot reach Dogegen Companion Agent — is it running on the Windows PC?"
@@ -1359,7 +1373,14 @@ def dogegen_config(req: DogegenConfigReq):
             raise HTTPException(400, "maxcll must be greater than 0")
         _dogegen_config["maxcll"] = int(req.maxcll)
     if req.agent_url is not None:
-        _dogegen_agent.set(req.agent_url.strip().rstrip("/"))
+        agent_url = req.agent_url.strip().rstrip("/")
+        if agent_url:
+            parsed = urlparse(agent_url)
+            if parsed.scheme not in ("http", "https") or not parsed.netloc:
+                raise HTTPException(
+                    400, "agent_url must be a valid http(s) URL, e.g. http://192.168.1.50:7071"
+                )
+        _dogegen_agent.set(agent_url)
     _save_prefs()
     return {"ok": True, **_dogegen_status_payload()}
 

--- a/tests/test_dogegen_agent_dispatch.py
+++ b/tests/test_dogegen_agent_dispatch.py
@@ -1,0 +1,314 @@
+"""
+Tests for the Dogegen Companion Agent proxy dispatch in server.py (#585b/e).
+
+When DOGEGEN_AGENT_URL / the agent_url config field is set, _dogegen_status_payload,
+_start_dogegen_for_session, and _stop_dogegen must short-circuit the entire local
+Popen/tasklist/pgrep path and proxy to the agent over HTTP instead. These tests mock
+httpx so no real agent needs to be running, and assert the local subprocess path is
+never touched while an agent URL is configured.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import server as srv
+
+client = TestClient(srv.app)
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+def _mock_httpx_get(json_data, status_code=200):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = json_data
+    resp.raise_for_status = MagicMock()
+    if status_code >= 400:
+        from httpx import HTTPStatusError
+        resp.raise_for_status.side_effect = HTTPStatusError(
+            "error", request=MagicMock(), response=MagicMock(text="agent error")
+        )
+    return resp
+
+
+def _mock_httpx_post(json_data, status_code=200):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = json_data
+    resp.raise_for_status = MagicMock()
+    if status_code >= 400:
+        from httpx import HTTPStatusError
+        resp.raise_for_status.side_effect = HTTPStatusError(
+            "error", request=MagicMock(), response=MagicMock(text="agent error")
+        )
+    return resp
+
+
+@pytest.fixture(autouse=True)
+def _reset_state():
+    srv._dogegen_agent.set("")
+    srv._dogegen_state.proc = None
+    srv._dogegen_state.started_at = None
+    srv._dogegen_state.launch_cmd = []
+    srv._dogegen_state.last_error = None
+    srv._dogegen_config = {"path": "", "resolve_host": "", "window_pct": 10, "maxcll": 1000}
+    yield
+    srv._dogegen_agent.set("")
+
+
+@pytest.fixture
+def session_id():
+    resp = client.post("/api/session", json={"tv_key": "u8g"})
+    assert resp.status_code == 200
+    return resp.json()["id"]
+
+
+# ── GET /api/dogegen/status via agent ──────────────────────────────────────────
+
+class TestDogegenStatusViaAgent:
+    def test_proxies_agent_payload(self):
+        srv._dogegen_agent.set("http://192.168.1.50:7071")
+        agent_resp = {
+            "configured": True,
+            "path": "C:\\Dogegen\\Dogegen.exe",
+            "running": True,
+            "pid": 4321,
+            "managed": True,
+            "ready": True,
+            "ready_in_ms": 0,
+            "resolve_host": "127.0.0.1",
+            "window_pct": 10,
+            "maxcll": 1000,
+            "last_error": None,
+            "launch_cmd": ["C:\\Dogegen\\Dogegen.exe"],
+        }
+        with patch("httpx.get", return_value=_mock_httpx_get(agent_resp)):
+            r = client.get("/api/dogegen/status")
+        assert r.status_code == 200
+        d = r.json()
+        assert d["running"] is True
+        assert d["pid"] == 4321
+        assert d["agent_url"] == "http://192.168.1.50:7071"
+        assert d["agent_reachable"] is True
+
+    def test_proxies_to_correct_url(self):
+        srv._dogegen_agent.set("http://10.0.0.5:7071")
+        captured = {}
+
+        def mock_get(url, **kwargs):
+            captured["url"] = url
+            return _mock_httpx_get({"running": False, "configured": False})
+
+        with patch("httpx.get", side_effect=mock_get):
+            client.get("/api/dogegen/status")
+        assert captured["url"] == "http://10.0.0.5:7071/status"
+
+    def test_agent_connect_error_returns_unreachable_payload(self):
+        srv._dogegen_agent.set("http://192.168.1.50:7071")
+        import httpx
+        with patch("httpx.get", side_effect=httpx.ConnectError("refused")):
+            r = client.get("/api/dogegen/status")
+        assert r.status_code == 200
+        d = r.json()
+        assert d["running"] is False
+        assert d["agent_reachable"] is False
+        assert "Cannot reach" in d["last_error"]
+
+    def test_agent_timeout_returns_unreachable_payload(self):
+        srv._dogegen_agent.set("http://192.168.1.50:7071")
+        import httpx
+        with patch("httpx.get", side_effect=httpx.ReadTimeout("timed out")):
+            r = client.get("/api/dogegen/status")
+        assert r.status_code == 200
+        d = r.json()
+        assert d["agent_reachable"] is False
+        assert "timed out" in d["last_error"].lower()
+
+    def test_does_not_touch_local_process_discovery(self, monkeypatch):
+        """Short-circuit contract (#585b): _find_dogegen_executable /
+        _external_dogegen_pid must not run at all when an agent is configured."""
+        srv._dogegen_agent.set("http://192.168.1.50:7071")
+
+        def boom():
+            raise AssertionError("local dogegen discovery must not run in agent mode")
+
+        monkeypatch.setattr(srv, "_find_dogegen_executable", boom)
+        monkeypatch.setattr(srv, "_external_dogegen_pid", boom)
+
+        with patch("httpx.get", return_value=_mock_httpx_get({"running": False, "configured": False})):
+            r = client.get("/api/dogegen/status")
+        assert r.status_code == 200
+
+    def test_empty_agent_url_uses_local_path(self):
+        srv._dogegen_agent.set("")
+        r = client.get("/api/dogegen/status")
+        assert r.status_code == 200
+        d = r.json()
+        assert d["agent_url"] == ""
+
+
+# ── POST /api/dogegen/config — agent_url field ─────────────────────────────────
+
+class TestDogegenConfigAgentUrl:
+    def test_sets_and_persists_agent_url(self, tmp_path):
+        # Once agent_url is set, the endpoint's own response computes status via
+        # the (now-configured) agent, so the agent HTTP call must be mocked too.
+        with patch("server._PREFS_PATH", tmp_path / ".prefs.json"), \
+             patch("httpx.get", return_value=_mock_httpx_get({"running": False, "configured": False})):
+            r = client.post("/api/dogegen/config", json={"agent_url": "http://192.168.1.50:7071"})
+            assert r.status_code == 200
+            assert srv._dogegen_agent.get() == "http://192.168.1.50:7071"
+
+            saved = srv._prefs.get("dogegen_agent_url")
+            assert saved == "http://192.168.1.50:7071"
+
+    def test_strips_trailing_slash(self):
+        with patch("httpx.get", return_value=_mock_httpx_get({"running": False, "configured": False})):
+            client.post("/api/dogegen/config", json={"agent_url": "http://192.168.1.50:7071/"})
+        assert srv._dogegen_agent.get() == "http://192.168.1.50:7071"
+
+    def test_clearing_agent_url_reverts_to_local(self):
+        srv._dogegen_agent.set("http://192.168.1.50:7071")
+        client.post("/api/dogegen/config", json={"agent_url": ""})
+        assert srv._dogegen_agent.get() == ""
+
+
+# ── POST /api/session/{sid}/dogegen/start via agent ────────────────────────────
+
+class TestDogegenStartViaAgent:
+    def test_proxies_start_with_session_mode(self, session_id):
+        srv._dogegen_agent.set("http://192.168.1.50:7071")
+        client.post(f"/api/session/{session_id}/mode", json={"mode": "HDR10"})
+
+        captured = {}
+
+        def mock_post(url, **kwargs):
+            captured["url"] = url
+            captured["json"] = kwargs.get("json")
+            return _mock_httpx_post({
+                "ok": True, "already_running": False,
+                "running": True, "configured": True, "pid": 999,
+                "managed": True, "ready": False, "ready_in_ms": 2000,
+                "resolve_host": "", "window_pct": 10, "maxcll": 1000,
+                "last_error": None, "launch_cmd": ["Dogegen.exe"],
+            })
+
+        with patch("httpx.post", side_effect=mock_post):
+            r = client.post(f"/api/session/{session_id}/dogegen/start")
+
+        assert r.status_code == 200
+        d = r.json()
+        assert d["ok"] is True
+        assert d["running"] is True
+        assert d["agent_url"] == "http://192.168.1.50:7071"
+        assert captured["url"] == "http://192.168.1.50:7071/start"
+        assert captured["json"] == {"mode": "HDR10"}
+
+    def test_agent_unreachable_raises_502(self, session_id):
+        srv._dogegen_agent.set("http://192.168.1.50:7071")
+        import httpx
+        with patch("httpx.post", side_effect=httpx.ConnectError("refused")):
+            r = client.post(f"/api/session/{session_id}/dogegen/start")
+        assert r.status_code == 502
+        assert "Cannot reach" in r.json()["detail"]
+
+    def test_agent_timeout_raises_502(self, session_id):
+        srv._dogegen_agent.set("http://192.168.1.50:7071")
+        import httpx
+        with patch("httpx.post", side_effect=httpx.ConnectTimeout("timed out")):
+            r = client.post(f"/api/session/{session_id}/dogegen/start")
+        assert r.status_code == 502
+        assert "timed out" in r.json()["detail"].lower()
+
+    def test_does_not_launch_local_subprocess(self, session_id, monkeypatch):
+        srv._dogegen_agent.set("http://192.168.1.50:7071")
+
+        def boom(*a, **kw):
+            raise AssertionError("local subprocess.Popen must not run in agent mode")
+
+        monkeypatch.setattr(srv.subprocess, "Popen", boom)
+        monkeypatch.setattr(srv, "_find_dogegen_executable", boom)
+
+        with patch("httpx.post", return_value=_mock_httpx_post({"ok": True, "already_running": False})):
+            r = client.post(f"/api/session/{session_id}/dogegen/start")
+        assert r.status_code == 200
+
+
+# ── POST /api/dogegen/stop via agent ────────────────────────────────────────────
+
+class TestDogegenStopViaAgent:
+    def test_proxies_stop(self):
+        srv._dogegen_agent.set("http://192.168.1.50:7071")
+        captured = {}
+
+        def mock_post(url, **kwargs):
+            captured["url"] = url
+            return _mock_httpx_post({
+                "ok": True, "already_stopped": False,
+                "running": False, "configured": True, "pid": None,
+                "managed": False, "ready": False, "ready_in_ms": 0,
+                "resolve_host": "", "window_pct": 10, "maxcll": 1000,
+                "last_error": None, "launch_cmd": [],
+            })
+
+        with patch("httpx.post", side_effect=mock_post):
+            r = client.post("/api/dogegen/stop")
+
+        assert r.status_code == 200
+        d = r.json()
+        assert d["ok"] is True
+        assert d["running"] is False
+        assert captured["url"] == "http://192.168.1.50:7071/stop"
+
+    def test_agent_unreachable_raises_502(self):
+        srv._dogegen_agent.set("http://192.168.1.50:7071")
+        import httpx
+        with patch("httpx.post", side_effect=httpx.ConnectError("refused")):
+            r = client.post("/api/dogegen/stop")
+        assert r.status_code == 502
+        assert "Cannot reach" in r.json()["detail"]
+
+    def test_does_not_touch_local_state(self, monkeypatch):
+        srv._dogegen_agent.set("http://192.168.1.50:7071")
+
+        def boom():
+            raise AssertionError("local _managed_dogegen_is_running must not run in agent mode")
+
+        monkeypatch.setattr(srv, "_managed_dogegen_is_running", boom)
+
+        with patch("httpx.post", return_value=_mock_httpx_post({"ok": True, "already_stopped": True})):
+            r = client.post("/api/dogegen/stop")
+        assert r.status_code == 200
+
+
+# ── _DogegenAgentState + prefs round-trip ──────────────────────────────────────
+
+class TestDogegenAgentState:
+    def test_get_set(self):
+        state = srv._DogegenAgentState("http://initial:7071")
+        assert state.get() == "http://initial:7071"
+        state.set("http://updated:7071")
+        assert state.get() == "http://updated:7071"
+
+    def test_load_prefs_restores_agent_url(self, tmp_path):
+        prefs_path = tmp_path / ".prefs.json"
+        prefs_path.write_text('{"dogegen_agent_url": "http://saved-host:7071"}')
+        srv._dogegen_agent.set("")
+        with patch("server._PREFS_PATH", prefs_path):
+            srv._load_prefs()
+        assert srv._dogegen_agent.get() == "http://saved-host:7071"
+
+    def test_save_prefs_writes_agent_url(self, tmp_path):
+        prefs_path = tmp_path / ".prefs.json"
+        srv._dogegen_agent.set("http://save-me:7071")
+        with patch("server._PREFS_PATH", prefs_path):
+            srv._save_prefs()
+        import json
+        data = json.loads(prefs_path.read_text())
+        assert data["dogegen_agent_url"] == "http://save-me:7071"

--- a/tests/test_dogegen_agent_dispatch.py
+++ b/tests/test_dogegen_agent_dispatch.py
@@ -178,6 +178,25 @@ class TestDogegenConfigAgentUrl:
         client.post("/api/dogegen/config", json={"agent_url": ""})
         assert srv._dogegen_agent.get() == ""
 
+    @pytest.mark.parametrize("bad_url", [
+        "not-a-url",
+        "192.168.1.50:7071",
+        "ftp://192.168.1.50:7071",
+        "http://",
+    ])
+    def test_rejects_malformed_agent_url(self, bad_url):
+        srv._dogegen_agent.set("")
+        r = client.post("/api/dogegen/config", json={"agent_url": bad_url})
+        assert r.status_code == 400
+        assert "valid http" in r.json()["detail"]
+        assert srv._dogegen_agent.get() == ""
+
+    def test_accepts_https_agent_url(self):
+        with patch("httpx.get", return_value=_mock_httpx_get({"running": False, "configured": False})):
+            r = client.post("/api/dogegen/config", json={"agent_url": "https://agent.example.com:7071"})
+        assert r.status_code == 200
+        assert srv._dogegen_agent.get() == "https://agent.example.com:7071"
+
 
 # ── POST /api/session/{sid}/dogegen/start via agent ────────────────────────────
 

--- a/tests/test_dogegen_agent_dispatch.py
+++ b/tests/test_dogegen_agent_dispatch.py
@@ -153,6 +153,58 @@ class TestDogegenStatusViaAgent:
         assert d["agent_url"] == ""
 
 
+# ── GET /api/dogegen/status?url= — "Test connection" passthrough (mirrors #555) ─
+
+class TestDogegenStatusUrlOverride:
+    def test_candidate_url_overrides_stored_and_is_not_persisted(self):
+        srv._dogegen_agent.set("")
+        captured = {}
+
+        def mock_get(url, **kwargs):
+            captured["url"] = url
+            return _mock_httpx_get({"running": False, "configured": False})
+
+        with patch("httpx.get", side_effect=mock_get):
+            r = client.get("/api/dogegen/status?url=http://candidate-host:7071")
+        assert r.status_code == 200
+        d = r.json()
+        assert d["agent_url"] == "http://candidate-host:7071"
+        assert d["agent_reachable"] is True
+        assert captured["url"] == "http://candidate-host:7071/status"
+        # The candidate must not be saved — stored config is untouched.
+        assert srv._dogegen_agent.get() == ""
+
+    def test_candidate_url_reports_unreachable_without_raising(self):
+        srv._dogegen_agent.set("")
+        import httpx
+        with patch("httpx.get", side_effect=httpx.ConnectError("refused")):
+            r = client.get("/api/dogegen/status?url=http://192.168.1.99:7071")
+        assert r.status_code == 200
+        d = r.json()
+        assert d["agent_reachable"] is False
+        assert "Cannot reach" in d["last_error"]
+
+    def test_empty_query_url_falls_back_to_stored(self):
+        srv._dogegen_agent.set("http://stored-host:7071")
+        captured = {}
+
+        def mock_get(url, **kwargs):
+            captured["url"] = url
+            return _mock_httpx_get({"running": False, "configured": False})
+
+        with patch("httpx.get", side_effect=mock_get):
+            r = client.get("/api/dogegen/status?url=")
+        assert r.status_code == 200
+        assert captured["url"] == "http://stored-host:7071/status"
+
+    def test_no_query_url_falls_back_to_local_when_unconfigured(self, monkeypatch):
+        srv._dogegen_agent.set("")
+        monkeypatch.setattr(srv, "_find_dogegen_executable", lambda: None)
+        r = client.get("/api/dogegen/status")
+        assert r.status_code == 200
+        assert r.json()["agent_url"] == ""
+
+
 # ── POST /api/dogegen/config — agent_url field ─────────────────────────────────
 
 class TestDogegenConfigAgentUrl:

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -27,9 +27,11 @@ def _reset_globals():
         "window_pct": 10,
         "maxcll": 1000,
     }
+    server_module._dogegen_agent.set("")
     server_module._prefs = {
         "dogegen": {},
         "bridge_url": "",
+        "dogegen_agent_url": "",
         "watch_folder": "",
         "llm": {"endpoint": "", "model": ""},
         "session_defaults": {

--- a/unraid-template.xml
+++ b/unraid-template.xml
@@ -23,7 +23,8 @@
 
 **Optional:**
 - Set OPENROUTER_API_KEY in the Extra Parameters field for cloud LLM routing
-- Set LITELLM_ENDPOINT to configure the AI Assistant endpoint</Overview>
+- Set LITELLM_ENDPOINT to configure the AI Assistant endpoint
+- For Dogegen HDR10 pattern generation, set "Dogegen Agent URL" to a Dogegen Companion Agent (tools/dogegen-agent) running on a separate Windows PC — Unraid is a Linux host and cannot run Dogegen.exe itself</Overview>
   <Category>MediaTools: Other</Category>
   <WebUI>http://[IP]:[PORT:8000]</WebUI>
   <TemplateURL>https://raw.githubusercontent.com/jweber93/tv-calibration/main/unraid-template.xml</TemplateURL>
@@ -36,7 +37,6 @@
 -v /mnt/user/appdata/tv-calibration/.sessions:/app/.sessions \
 -v /mnt/user/appdata/tv-calibration/.calibration-history:/app/.calibration-history \
 -v /mnt/user/appdata/tv-calibration/.prefs.json:/app/.prefs.json \
--v DOGEGEN_PATH:/app/tools/dogegen \
 -v ZRO_DROPS:/data/zro-drops
   </ExtraParams>
   <Config>
@@ -55,7 +55,7 @@
     <Config Name="Prefs file" Target="/app/.prefs.json" Default="" Mode="rw" Description="User preferences file. Maps to /mnt/user/appdata/tv-calibration/.prefs.json" Display="always" Required="false">
       <Value>/mnt/user/appdata/tv-calibration/.prefs.json</Value>
     </Config>
-    <Config Name="Dogegen path" Target="/app/tools/dogegen" Default="" Mode="rw" Description="Optional: mount path to Dogegen executable for HDR pattern generation" Display="optional" Required="false">
+    <Config Name="Dogegen Agent URL" Target="DOGEGEN_AGENT_URL" Default="" Mode="" Description="Optional: URL of a Dogegen Companion Agent (tools/dogegen-agent) running on a separate Windows PC, e.g. http://192.168.1.50:7071. Unraid is a Linux host, so Dogegen.exe cannot be bind-mounted or run in this container — it must run on a Windows PC and be controlled over the network. Leave empty if you aren't using Dogegen." Type="Variable" Display="always" Required="false">
       <Value></Value>
     </Config>
   </Config>


### PR DESCRIPTION
## 📺 Overview

Follow-up to #584 (Dogegen Companion Agent). Wires the backend to that agent over HTTP so a backend running in Docker on a split-host setup (e.g. Unraid) can control Dogegen on a separate Windows PC, instead of always assuming Dogegen is a local child process.

Closes #585, #592, #593, #594, #595, #596

### What does this PR do?
* **Type of change:** [x] New feature
* **Component(s) affected:** Backend (`server.py`), frontend (`DogegenCard.jsx`), docs (`README.md`, `unraid-template.xml`)

---

## 🛠️ Technical Context & Implementation

* **The Problem:** `/api/dogegen/status`, `/api/session/{sid}/dogegen/start`, `/api/dogegen/stop`, and `/api/dogegen/config` went straight through `subprocess.Popen` / `tasklist` / `pgrep`, with no remote path — a backend running in Docker on Unraid had no way to control Dogegen on a separate Windows machine.
* **The Solution:** Add a configurable Companion Agent URL and proxy Dogegen control over HTTP to it when set, with a matching frontend field and docs; local behavior is unchanged when unset.
  - **(a)** Added `DOGEGEN_AGENT_URL` env var + `.prefs.json` field + a `_DogegenAgentState` mirroring `_ZroBridgeState`, plus an `agent_url` field on `/api/dogegen/config`.
  - **(b)** When the agent URL is set, `_dogegen_status_payload`, `_start_dogegen_for_session`, and `_stop_dogegen` short-circuit the entire local path and proxy to the agent's `GET /status` / `POST /start` / `POST /stop` — `_find_dogegen_executable` / `_external_dogegen_pid` never run locally in that mode. The status endpoint always degrades gracefully (200, `agent_reachable: false`, human-readable `last_error`); start/stop raise a clean 502 when the agent is unreachable or times out. Empty URL = today's local-Popen behavior, byte-for-byte unchanged.
  - **(c)** `DogegenCard.jsx` gets an optional "Agent URL" field, disables the now-agent-owned path/resolve-host/window%/maxcll fields when remote, and its status pill distinguishes "local" vs "remote agent" vs "agent unreachable" (mirroring the ZRO Bridge status indicator).
  - **(d)** README documents the same-host vs. split-host topology; `unraid-template.xml` drops the misleading `/app/tools/dogegen → path on host` mapping (a Linux/Unraid host can never exec a Windows `.exe`) in favor of a `DOGEGEN_AGENT_URL` template field.
  - **(e)** New `tests/test_dogegen_agent_dispatch.py` mocks the agent HTTP calls (success, connect-refused, timeout) and asserts the local subprocess/discovery path never runs while an agent is configured.
* **Impact on existing workflows/APIs:** None for same-host installs — `DOGEGEN_AGENT_URL` defaults empty, and all existing same-host tests pass unmodified.

### Mathematical / Data Integrity Checks (If Applicable)
Not applicable — no color math or LUT calculations in this change.

---

## 🧪 Testing & Validation

### Environment Details
* **OS / Target Display:** Linux backend container + Linux-hosted Companion Agent (stand-in for the Windows PC) for verification; no physical TV/meter involved.
* **Hardware/Mock Used:** None — Dogegen itself was never installed; verification exercises the HTTP control plane only.

### Verification Steps
1. `python -m pytest tests/` — 1509 passed, 2 pre-existing skips, 0 failures.
2. `npx vitest run` (frontend) — 126 passed, including 7 new `DogegenCard.test.jsx` cases.
3. Live, real-process verification (not mocks): ran the actual `tools/dogegen-agent/agent.py` and the actual backend (`DOGEGEN_AGENT_URL` set) as separate OS processes and drove them with `curl` — confirmed proxied status/start/stop, graceful 200 degradation with `agent_reachable: false` when pointed at a closed port, and clean 502s from start/stop in that state. Then drove the real Vite dev server in headless Chromium (Playwright) end-to-end: Agent URL field populates from live status, local-only fields disable in remote mode, and the status pill/error text flip between green "running (remote agent)" and red "agent unreachable" live as the configured URL changes, recovering once pointed back at the working agent.

### Firmware / TV Settings
Not applicable — this PR only changes the transport between the backend and Dogegen's process-control layer.

---

## 📸 Visual Evidence (UI / Plot Changes)
<details>
<summary><b>Click to expand Visuals</b></summary>

### Before
`DogegenCard` only supported a local executable path, with no way to point at a remote agent.

### After
- Settings panel gains an "Agent URL" field; local-only fields (path/resolve host/window %/MaxCLL) grey out with a "set in agent.json, not here" hint once an agent URL is configured.
- Status pill reads "Dogegen running (remote agent)" (green) when the agent is reachable, and "Dogegen agent unreachable" (red) with the agent's error message when it isn't — verified live against a real Companion Agent process, including recovery after the URL is fixed.

</details>

---

## 🧼 Checklist
* [x] Code adheres to project style guidelines (formatting, typing, linting) — `ruff check` and `eslint` both clean.
* [x] Unit tests added/updated and passing.
* [x] Documentation (README, inline docstrings) updated to reflect changes.
* [x] No credentials, local absolute paths, or hardware-specific hardcoding leaked.
