### PR TITLE
Document and wire the full split-host deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,11 @@ Setup:
 1. On the Windows PC, start both companion services:
    - `tools/zro-bridge/start.bat` — copy `bridge.example.json` → `bridge.json` first; set `"backend": "argyll"` if you're using ArgyllCMS instead of ColourSpace.
    - `tools/dogegen-agent/start.bat` — copy `agent.example.json` → `agent.json` first.
-   - Confirm both are reachable: `curl http://<windows-pc-ip>:7070/status` and `curl http://<windows-pc-ip>:7071/status`.
+   - Confirm both are reachable before wiring up the container, so you fail fast if one didn't start:
+     ```bash
+     curl http://<windows-pc-ip>:7070/status && echo "✓ ZRO Bridge"
+     curl http://<windows-pc-ip>:7071/status && echo "✓ Dogegen Agent"
+     ```
 2. On the Docker host, point the container at both before (or after) starting it:
    ```bash
    export ZRO_BRIDGE_URL=http://<windows-pc-ip>:7070
@@ -317,6 +321,13 @@ Setup:
    ```
    Both can also be set later from the app's Bridge/Dogegen cards, or in `.prefs.json`, without restarting the container.
 3. Leave `DOGEGEN_PATH` empty — it's a same-host-only setting and is ignored whenever `DOGEGEN_AGENT_URL` is set.
+
+**Troubleshooting split-host:**
+
+- **"Agent unreachable" / "Cannot reach Dogegen Companion Agent"** — the container could reach the URL at config time but can't now, or never could. Re-run the two `curl` checks above from the Docker host itself (not from your laptop) — same-LAN doesn't guarantee same-subnet/VLAN reachability.
+- **Windows Firewall blocking the ports** — `start.bat` binds `0.0.0.0:7070`/`0.0.0.0:7071`, but a fresh Windows Firewall prompt (or a Domain/Public network profile) can silently block inbound connections from other hosts. Allow inbound TCP 7070 and 7071 for `python.exe` (or add a rule for the ports directly).
+- **`DOGEGEN_PATH` set alongside `DOGEGEN_AGENT_URL`** — harmless but confusing: whenever `DOGEGEN_AGENT_URL` is non-empty the backend proxies to the agent unconditionally and never looks at `DOGEGEN_PATH`, so a stale value won't break anything, but clear it anyway to avoid wondering which path is actually in effect.
+- **Bridge reachable but reads fail** — check the Bridge's own `backend` setting in `bridge.json` (`pyautogui` / `remote_control` / `argyll`) matches what you actually have running (ColourSpace ZRO vs. ArgyllCMS) — a reachable-but-misconfigured Bridge returns a clean error rather than a connection failure, so `curl .../status` succeeding doesn't guarantee a measurement will.
 
 Everything else — the workflow, session state, quality gates, reports — runs from the container exactly as in a same-host install; the only difference is two lightweight Windows services sitting between it and the physical hardware.
 

--- a/README.md
+++ b/README.md
@@ -301,6 +301,8 @@ This is the topology for running the container on a server/NAS with no hardware 
 | **[ZRO Bridge](tools/zro-bridge/)** (`bridge.py`) — reads the meter, either by triggering ColourSpace ZRO or directly via ArgyllCMS `spotread` (see [ArgyllCMS Direct-Meter Backend](#argyllcms-direct-meter-backend-no-paid-products) if you don't have a ColourSpace license) | `calcore-server` — session state, ΔE/gamma/PQ math, report generation, the web UI |
 | **[Dogegen Companion Agent](tools/dogegen-agent/README.md)** (`agent.py`) — starts/stops Dogegen, reports status | Calls both services over HTTP; never spawns a local process or opens a serial/USB port |
 
+**Where ArgyllCMS sits:** `spotread` is a command-line tool, not a service — it must run on the same physical machine as the USB-connected meter, because that's an OS/USB-driver constraint, not something you can configure around. It never runs in the container. When the Bridge's `bridge.json` has `"backend": "argyll"`, the Bridge itself (running on the Windows PC) shells out to `spotread` as a local subprocess, parses the XYZ reading, and returns it over the same `GET /status` / `POST /measure` HTTP endpoints it always exposes. The container only ever receives JSON over HTTP — it never sees the meter, the serial/USB port, or the `spotread` process itself.
+
 Setup:
 
 1. On the Windows PC, start both companion services:

--- a/README.md
+++ b/README.md
@@ -292,6 +292,34 @@ Dogegen is a Windows GUI application that needs a real desktop, GPU, and HDMI ou
 - **Same-host** (backend and Dogegen on the *same* Windows PC, e.g. via Docker Desktop + WSL2): bind-mount `Dogegen.exe` into the container and set `DOGEGEN_PATH` to that in-container path, exactly as before. The backend launches it directly with `subprocess.Popen`.
 - **Split-host** (backend in Docker on a different machine — e.g. Unraid — while Dogegen stays on the Windows PC): a bind-mounted `.exe` path does nothing, since a Linux container cannot execute a Windows binary and cannot spawn a process on a different physical machine. Instead, run the **[Dogegen Companion Agent](tools/dogegen-agent/README.md)** on the Windows PC (`tools/dogegen-agent/start.bat`) and point the backend at it with `DOGEGEN_AGENT_URL=http://<windows-pc-ip>:7071` (env var, `.prefs.json`, or the Agent URL field on the Dogegen card in the app). The backend then proxies start/stop/status to the agent over HTTP instead of managing a local process. Leave `DOGEGEN_AGENT_URL` empty to keep today's same-host behavior unchanged.
 
+### Full split-host: math + UI in Docker, spectrometer + Dogegen on a Windows PC
+
+This is the topology for running the container on a server/NAS with no hardware attached at all — no USB meter, no GPU, no HDMI output — while a Windows PC next to the TV owns both physical devices. The container never touches either device directly; it only makes outbound HTTP calls to whatever `ZRO_BRIDGE_URL` / `DOGEGEN_AGENT_URL` point at.
+
+| Windows PC (has the meter + GPU/HDMI) | Container (has neither) |
+|---|---|
+| **[ZRO Bridge](tools/zro-bridge/)** (`bridge.py`) — reads the meter, either by triggering ColourSpace ZRO or directly via ArgyllCMS `spotread` (see [ArgyllCMS Direct-Meter Backend](#argyllcms-direct-meter-backend-no-paid-products) if you don't have a ColourSpace license) | `calcore-server` — session state, ΔE/gamma/PQ math, report generation, the web UI |
+| **[Dogegen Companion Agent](tools/dogegen-agent/README.md)** (`agent.py`) — starts/stops Dogegen, reports status | Calls both services over HTTP; never spawns a local process or opens a serial/USB port |
+
+Setup:
+
+1. On the Windows PC, start both companion services:
+   - `tools/zro-bridge/start.bat` — copy `bridge.example.json` → `bridge.json` first; set `"backend": "argyll"` if you're using ArgyllCMS instead of ColourSpace.
+   - `tools/dogegen-agent/start.bat` — copy `agent.example.json` → `agent.json` first.
+   - Confirm both are reachable: `curl http://<windows-pc-ip>:7070/status` and `curl http://<windows-pc-ip>:7071/status`.
+2. On the Docker host, point the container at both before (or after) starting it:
+   ```bash
+   export ZRO_BRIDGE_URL=http://<windows-pc-ip>:7070
+   export DOGEGEN_AGENT_URL=http://<windows-pc-ip>:7071
+   docker compose up -d
+   ```
+   Both can also be set later from the app's Bridge/Dogegen cards, or in `.prefs.json`, without restarting the container.
+3. Leave `DOGEGEN_PATH` empty — it's a same-host-only setting and is ignored whenever `DOGEGEN_AGENT_URL` is set.
+
+Everything else — the workflow, session state, quality gates, reports — runs from the container exactly as in a same-host install; the only difference is two lightweight Windows services sitting between it and the physical hardware.
+
+> **ADB TV auto-apply is not part of this split yet.** ADB commands run from wherever `server.py` runs, so in this topology that's the container — which would need network line-of-sight to the TV's ADB port and the `adb` client installed. Neither is wired up today: the container image doesn't ship `adb`, and there's no companion-agent equivalent for it. Manual OSD entry is unaffected; only the ADB "auto-apply" convenience path is out of scope for now.
+
 ---
 
 ## Unraid
@@ -335,6 +363,8 @@ Expose the `/mnt/user/downloads/zro-drops` directory as an Unraid SMB share (Use
 **Dogegen on Unraid (split-host):**
 
 Since Unraid runs Linux, Dogegen must stay on a separate Windows PC and be controlled over the network — a bind-mounted `.exe` path will not run. Install the **[Dogegen Companion Agent](tools/dogegen-agent/README.md)** on that Windows PC (`tools/dogegen-agent/start.bat`), then set `DOGEGEN_AGENT_URL` on the `tv-calibration` container to `http://<WINDOWS_PC_IP>:7071` — either as an extra parameter (`-e DOGEGEN_AGENT_URL=http://<WINDOWS_PC_IP>:7071`) or via the template's **Dogegen Agent URL** field. The app's Dogegen card also lets you set/change this URL at runtime without restarting the container.
+
+The spectrometer follows the same shape: rather than passing a USB meter through to Unraid, run the **[ZRO Bridge](tools/zro-bridge/)** on that same Windows PC and set `ZRO_BRIDGE_URL` to `http://<WINDOWS_PC_IP>:7070`. See [Full split-host](#full-split-host-math--ui-in-docker-spectrometer--dogegen-on-a-windows-pc) for the combined setup.
 
 **AI assistant on Unraid:**
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,11 @@
 #   # App UI: http://localhost:8000
 #   # LiteLLM endpoint for app config: http://localhost:4000
 #
+# Split-host (spectrometer + Dogegen on a separate Windows PC instead of
+# this Docker host): set ZRO_BRIDGE_URL / DOGEGEN_AGENT_URL below to that
+# PC's tools/zro-bridge and tools/dogegen-agent services. See README.md
+# "Full split-host" section.
+#
 # Unraid: use unraid-template.xml instead of this file.
 
 services:
@@ -26,7 +31,10 @@ services:
       - LITELLM_ENDPOINT=http://litellm:4000
       - LITELLM_MODEL=tvcal-analyst
       - ZRO_BRIDGE_URL=
+      # DOGEGEN_PATH is for same-host installs only (bind-mounted exe) and is
+      # ignored whenever DOGEGEN_AGENT_URL is set — see README.md.
       - DOGEGEN_PATH=
+      - DOGEGEN_AGENT_URL=
       - PYTHONUNBUFFERED=1
     depends_on:
       litellm:

--- a/docs/docker-architecture-roadmap.md
+++ b/docs/docker-architecture-roadmap.md
@@ -1,5 +1,11 @@
 # Docker Architecture Roadmap
 
+**Status: shipped.** #584 and #585 landed as `tools/dogegen-agent/` and the
+`DOGEGEN_AGENT_URL` backend wiring, respectively. This doc is kept as the
+scoping record; for the current user-facing setup see README.md's
+["Full split-host"](../README.md#full-split-host-math--ui-in-docker-spectrometer--dogegen-on-a-windows-pc)
+section.
+
 Scoping for making Docker a first-class deployment target: split the backend
 into a container that can run anywhere on the LAN (Docker Desktop, Unraid) while
 Dogegen — a Windows GUI app that needs a real desktop / GPU / HDMI output —


### PR DESCRIPTION
## 📺 Overview

Follow-up to #597/#598 (Dogegen Companion Agent + backend wiring). After confirming the split-host architecture (Docker container running the backend/frontend, spectrometer + Dogegen staying on a separate Windows PC) is correctly wired end-to-end, this PR closes the remaining doc/config gaps so the deployment story is complete and discoverable in one place.

### What does this PR do?
* **Type of change:** [x] Refactoring/Docs (no code behavior change) | [ ] Bug fix | [ ] New feature | [ ] CI/CD or Tooling
* **Component(s) affected:** `docker-compose.yml`, `README.md`, `docs/docker-architecture-roadmap.md`

---

## 🛠️ Technical Context & Implementation

* **The Problem:** `DOGEGEN_AGENT_URL` was added to `server.py`/`unraid-template.xml` in #598 but never surfaced in `docker-compose.yml`, so Docker Compose users had no first-class way to configure the split-host Dogegen path. Separately, the split-host story for the *spectrometer* (ZRO Bridge) and for *Dogegen* (Companion Agent) were documented in three separate sections with no single end-to-end recipe for "run everything remotely, keep hardware on a Windows PC" — which is the exact scenario these last two features were built for.
* **The Solution:** Wire and document the split-host deployment end to end:
  - `docker-compose.yml`: add `DOGEGEN_AGENT_URL=` alongside the existing `ZRO_BRIDGE_URL`/`DOGEGEN_PATH`, with comments clarifying same-host vs. split-host precedence.
  - `README.md`: new "Full split-host" section under Docker that ties the ZRO Bridge (+ ArgyllCMS direct-meter backend) and Dogegen Companion Agent together into one setup recipe, clarifies exactly where `spotread` runs relative to the meter and the container, and explicitly notes that ADB auto-apply is *not* wired for this topology (no `adb` in the container image, no companion-agent equivalent) — manual OSD entry is unaffected. Added a matching cross-reference from the Unraid section.
  - `docs/docker-architecture-roadmap.md`: marked "Status: shipped" now that #584/#585 have landed, pointing at the new README section, so it reads as a historical scoping record rather than an open TODO.
* **Impact on existing workflows/APIs:** None — `DOGEGEN_AGENT_URL` defaults to empty, matching current behavior byte-for-byte. Docs-only otherwise.

### Mathematical / Data Integrity Checks (If Applicable)
Not applicable — no calculation logic touched.

---

## 🧪 Testing & Validation

* Validated `docker-compose.yml` parses correctly (`docker compose config` / YAML load).
* Read through `server.py`'s Dogegen dispatch (`_dogegen_status_payload`, `_start_dogegen_for_session`, `_stop_dogegen`) to confirm the agent-URL short-circuit added in #598 doesn't touch local `Popen`/`tasklist` logic when configured, so the new compose var is safe to expose as-is.
* No test suite changes needed (docs/config only); no existing tests reference `docker-compose.yml` contents.

### Environment Details
Not applicable — no hardware/firmware touched.

### Firmware / TV Settings
Not applicable.

---

## 📸 Visual Evidence (UI / Plot Changes)
Not applicable — no UI changes.

---

## 🧼 Checklist
* [x] Code adheres to project style guidelines (formatting, typing, linting).
* [x] Unit tests added/updated and passing. — N/A (docs/config-only change, no test-covered behavior changed)
* [x] Documentation (README, inline docstrings) updated to reflect changes.
* [x] No credentials, local absolute paths, or hardware-specific hardcoding leaked.
