### PR TITLE
ArgyllCMS: refresh-timing/integration options for flicker-prone panels

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,6 +491,8 @@ Modern wide-gamut panels (QD-OLED, WOLED, QD-LCD) need a per-panel spectral corr
 
 To identify the right settings for a given TV: start with everything unset and take a few readings at a fixed patch to check for noise or drift. If readings are noisy or drift over repeated measurements of the same patch, try `argyll_refresh_mode: "refresh"` first (most likely culprit on PWM-dimmed panels); if the panel's PWM/refresh frequency is known, add `argyll_refresh_rate_hz`; if readings are still noisy at low light levels, try `argyll_integration_mode: "averaging"` if your meter supports it. These flags are verified against the installed ArgyllCMS version's `spotread -?` output — if a flag is rejected by your version, `spotread` fails loudly with a clear `spotread_error` rather than silently misreading.
 
+> **Requires ArgyllCMS v3.x+** for `spotread`'s `-Y` sub-flags. Older Argyll releases don't support them and will reject any of these three settings with a `spotread_error` — leave them unset if you're on an older version.
+
 **Graceful "ArgyllCMS not found" handling** — if `spotread` isn't on PATH/at the configured path, or no meter is detected, `GET /api/zro/bridge/status` still returns `200` with `spotread_found: false` (or a `no_meter` error type from a triggered read) and a human-readable message instead of a crash, so the UI can show a clear "install ArgyllCMS" / "check the meter connection" prompt rather than a generic failure.
 
 ### Dogegen Integration

--- a/README.md
+++ b/README.md
@@ -452,28 +452,44 @@ Copy `tools/zro-bridge/bridge.example.json` to `bridge.json` and set:
   "argyll_spotread_path": "spotread",
   "argyll_port": null,
   "argyll_timeout_s": 20.0,
-  "argyll_correction": null
+  "argyll_correction": null,
+  "argyll_refresh_mode": null,
+  "argyll_refresh_rate_hz": null,
+  "argyll_integration_mode": null
 }
 ```
 
 - `argyll_spotread_path` — leave as `"spotread"` to resolve via PATH, or set a full path if it isn't on PATH.
 - `argyll_port` — the serial/USB port `spotread -c` should use. Leave `null` to auto-detect (most USB meters); set it explicitly if you have multiple meters attached.
 - `argyll_correction` — path to a CCMX/CCSS meter-correction file (see below).
+- `argyll_refresh_mode`, `argyll_refresh_rate_hz`, `argyll_integration_mode` — refresh-timing tuning for flicker-prone panels (see below). All default to `null`, which reproduces the original `spotread -e -O` read exactly.
 
 **4. Meter discovery and selection**
 
 With `backend: "argyll"` and the Bridge running, the app can list and persist which detected instrument to use:
 
 ```
-GET  /api/zro/bridge/instruments   → { instruments: [{index, name}, ...], selected_port, correction_path }
-POST /api/zro/bridge/instrument    { port, instrument_name?, correction_path? }
+GET  /api/zro/bridge/instruments   → { instruments: [{index, name}, ...], selected_port, correction_path,
+                                        refresh_mode, refresh_rate_hz, integration_mode }
+POST /api/zro/bridge/instrument    { port, instrument_name?, correction_path?,
+                                      refresh_mode?, refresh_rate_hz?, integration_mode? }
 ```
 
-The selection (and correction path) is saved to the app's `.prefs.json` (`argyll.port` / `argyll.instrument_name` / `argyll.correction_path`) so it survives app restarts, and is pushed to the Bridge immediately if it's reachable; if the Bridge is offline the choice still saves and is re-applied the next time the app reconnects.
+The selection (correction path and refresh-timing settings included) is saved to the app's `.prefs.json` under `argyll.*` (`argyll.port` / `argyll.instrument_name` / `argyll.correction_path` / `argyll.refresh_mode` / `argyll.refresh_rate_hz` / `argyll.integration_mode`) so it survives app restarts, and is pushed to the Bridge immediately if it's reachable; if the Bridge is offline the choice still saves and is re-applied the next time the app reconnects. In the app itself, these controls live in the Argyll meter card on the Prepare page's instrument panel, alongside the meter/port picker and correction-file field.
 
 **5. CCMX/CCSS meter correction**
 
 Modern wide-gamut panels (QD-OLED, WOLED, QD-LCD) need a per-panel spectral correction for **colorimeters** (i1Display and similar) to read accurately — spectrophotometers (i1Pro) do not need one. Acquire a `.ccmx`/`.ccss` file for your meter/panel combination and set its path via `argyll_correction` in `bridge.json` or `correction_path` in the `POST /api/zro/bridge/instrument` call above. If a colorimeter takes a reading with no correction configured, `spotread`'s output is checked for a missing-correction warning and it's surfaced back through the reading result (`warning` field) rather than failing silently.
+
+**6. Refresh-timing tuning for flicker-prone panels**
+
+`spotread`'s default adaptive-integration read timing assumes a steady-state light source. Some panels don't hold still: PWM-dimmed backlights, some VA/edge-lit LCDs, and other displays with periodic brightness modulation can beat against that timing and bias or add noise to a reading. Three opt-in settings tune `spotread`'s `-Y` refresh-timing flags for exactly this — all default to unset, which is byte-for-byte the original `-e -O` command:
+
+- **`argyll_refresh_mode`** (`"refresh"` / `"non_refresh"` / unset) — passes `-Y r` or `-Y n`, forcing spotread's refresh vs. non-refresh measurement mode instead of relying on the instrument's own display-type default. Use `"refresh"` for panels with periodic backlight modulation (PWM dimming, CRT-like behavior); use `"non_refresh"` for steady-state panels (most modern LCD/OLED without PWM dimming).
+- **`argyll_refresh_rate_hz`** (number or unset) — passes `-Y R:<rate>`, overriding spotread's auto-measured refresh-rate calibration with a known value. Useful when auto-detection is unreliable; set it to the panel's PWM dimming frequency if you know it (check the TV's service menu or manufacturer documentation — this varies by model and is not always the panel's native refresh rate).
+- **`argyll_integration_mode`** (`"non_adaptive"` / `"averaging"` / unset) — passes `-Y A` (fixed, non-adaptive integration time — faster, but can be less accurate at low light levels) or `-Y a` (the instrument's averaging mode, where the connected meter supports it).
+
+To identify the right settings for a given TV: start with everything unset and take a few readings at a fixed patch to check for noise or drift. If readings are noisy or drift over repeated measurements of the same patch, try `argyll_refresh_mode: "refresh"` first (most likely culprit on PWM-dimmed panels); if the panel's PWM/refresh frequency is known, add `argyll_refresh_rate_hz`; if readings are still noisy at low light levels, try `argyll_integration_mode: "averaging"` if your meter supports it. These flags are verified against the installed ArgyllCMS version's `spotread -?` output — if a flag is rejected by your version, `spotread` fails loudly with a clear `spotread_error` rather than silently misreading.
 
 **Graceful "ArgyllCMS not found" handling** — if `spotread` isn't on PATH/at the configured path, or no meter is detected, `GET /api/zro/bridge/status` still returns `200` with `spotread_found: false` (or a `no_meter` error type from a triggered read) and a human-readable message instead of a crash, so the UI can show a clear "install ArgyllCMS" / "check the meter connection" prompt rather than a generic failure.
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -50,7 +50,7 @@ import { AppShell }     from './components/AppShell';
 
 export default function App() {
   const sess = useSession();
-  const { session, profiles, watchStatus, watchDefaultPath, bridgeStatus, bridgeUrl, dogegenStatus, adbStatus, loading,
+  const { session, profiles, watchStatus, watchDefaultPath, bridgeStatus, bridgeUrl, dogegenStatus, adbStatus, argyllPrefs, loading,
           llmInsight, llmStreaming, llmError, dismissLlmInsight, saveTvSettings, getSuggestedPatches, runSuggestedPatches, getPredictedSettings } = sess;
   const [showStartOver, setShowStartOver] = useState(false);
   const [showComparison, setShowComparison] = useState(false);
@@ -161,6 +161,7 @@ export default function App() {
         bridgeUrl={bridgeUrl}
         dogegenStatus={dogegenStatus}
         adbStatus={adbStatus}
+        argyllPrefs={argyllPrefs}
         onMeasure={sess.triggerMeasure}
         onSaveBridgeUrl={sess.saveBridgeUrl}
         onStartWatch={sess.startWatch}
@@ -169,6 +170,8 @@ export default function App() {
         onSaveDogegenConfig={sess.saveDogegenConfig}
         onStartDogegen={sess.startDogegen}
         onStopDogegen={sess.stopDogegen}
+        onScanArgyllInstruments={sess.scanArgyllInstruments}
+        onSaveArgyllInstrument={sess.saveArgyllInstrument}
       >
         {showComparison ? (
           <ComparisonPage profiles={profiles} />

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -94,6 +94,10 @@ export const api = {
   saveBridgeUrl:   (url)      => api.post('/api/bridge/url', { url }),
   triggerMeasure:  (url)      => api.post('/api/bridge/measure', { url }),
 
+  // ArgyllCMS instrument (backend="argyll" only)
+  getArgyllInstruments: ()    => api.get('/api/zro/bridge/instruments'),
+  saveArgyllInstrument: (body) => api.post('/api/zro/bridge/instrument', body),
+
   // Dogegen
   getDogegenStatus: ()        => api.get('/api/dogegen/status'),
   testDogegenAgent: (url)     => api.get(`/api/dogegen/status?url=${encodeURIComponent(url)}`),

--- a/frontend/src/components/AppShell.jsx
+++ b/frontend/src/components/AppShell.jsx
@@ -6,10 +6,12 @@ export function AppShell({
   watchStatus, watchDefaultPath,
   bridgeStatus, bridgeUrl,
   dogegenStatus, adbStatus,
+  argyllPrefs,
   onMeasure, onSaveBridgeUrl,
   onStartWatch, onStopWatch,
   onUpload,
   onSaveDogegenConfig, onStartDogegen, onStopDogegen,
+  onScanArgyllInstruments, onSaveArgyllInstrument,
 }) {
   const showInstrument = session != null;
 
@@ -31,6 +33,7 @@ export function AppShell({
             bridgeUrl={bridgeUrl}
             dogegenStatus={dogegenStatus}
             adbStatus={adbStatus}
+            argyllPrefs={argyllPrefs}
             onMeasure={onMeasure}
             onSaveBridgeUrl={onSaveBridgeUrl}
             onStartWatch={onStartWatch}
@@ -39,6 +42,8 @@ export function AppShell({
             onSaveDogegenConfig={onSaveDogegenConfig}
             onStartDogegen={onStartDogegen}
             onStopDogegen={onStopDogegen}
+            onScanArgyllInstruments={onScanArgyllInstruments}
+            onSaveArgyllInstrument={onSaveArgyllInstrument}
           />
         </aside>
       )}

--- a/frontend/src/components/ArgyllCard.jsx
+++ b/frontend/src/components/ArgyllCard.jsx
@@ -130,11 +130,13 @@ export function ArgyllCard({ argyllPrefs, onScanInstruments, onSaveInstrument })
           <div className="bridge-url-row">
             <input
               type="number"
-              min={0}
+              min={0.1}
+              max={500}
               step="any"
               value={refreshRateHz}
               onChange={e => setRefreshRateHz(e.target.value)}
               placeholder="e.g. 120"
+              title="Panel refresh/PWM frequency in Hz (typical: 30-240)"
               style={{ width: 120 }}
             />
           </div>

--- a/frontend/src/components/ArgyllCard.jsx
+++ b/frontend/src/components/ArgyllCard.jsx
@@ -1,0 +1,159 @@
+import { useEffect, useState } from 'react';
+import { Button } from './Button';
+
+const REFRESH_MODE_OPTIONS = [
+  { value: '', label: 'Auto (instrument default)' },
+  { value: 'refresh', label: 'Refresh display (PWM backlight, CRT-like)' },
+  { value: 'non_refresh', label: 'Non-refresh display (steady-state LCD/OLED)' },
+];
+
+const INTEGRATION_MODE_OPTIONS = [
+  { value: '', label: 'Adaptive (spotread default)' },
+  { value: 'non_adaptive', label: 'Non-adaptive (fixed integration time)' },
+  { value: 'averaging', label: 'Averaging (where the instrument supports it)' },
+];
+
+export function ArgyllCard({ argyllPrefs, onScanInstruments, onSaveInstrument }) {
+  const [port, setPort] = useState(argyllPrefs?.port || '');
+  const [correctionPath, setCorrectionPath] = useState(argyllPrefs?.correction_path || '');
+  const [refreshMode, setRefreshMode] = useState(argyllPrefs?.refresh_mode || '');
+  const [refreshRateHz, setRefreshRateHz] = useState(argyllPrefs?.refresh_rate_hz ?? '');
+  const [integrationMode, setIntegrationMode] = useState(argyllPrefs?.integration_mode || '');
+  const [instruments, setInstruments] = useState([]);
+  const [showSettings, setShowSettings] = useState(false);
+  const [scanning, setScanning] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [msg, setMsg] = useState('');
+
+  useEffect(() => {
+    setPort(argyllPrefs?.port || '');
+    setCorrectionPath(argyllPrefs?.correction_path || '');
+    setRefreshMode(argyllPrefs?.refresh_mode || '');
+    setRefreshRateHz(argyllPrefs?.refresh_rate_hz ?? '');
+    setIntegrationMode(argyllPrefs?.integration_mode || '');
+  }, [argyllPrefs]);
+
+  async function handleScan() {
+    setScanning(true);
+    setMsg('');
+    try {
+      const result = await onScanInstruments();
+      setInstruments(result?.instruments || []);
+      if (!result?.instruments?.length) {
+        setMsg('No instruments detected — check the USB connection.');
+      }
+    } catch (e) {
+      setMsg(`Error: ${e.message}`);
+    } finally {
+      setScanning(false);
+    }
+  }
+
+  async function handleSave() {
+    setBusy(true);
+    setMsg('');
+    try {
+      await onSaveInstrument({
+        port: port || null,
+        instrument_name: instruments.find(i => String(i.index) === String(port))?.name || argyllPrefs?.instrument_name || null,
+        correction_path: correctionPath || null,
+        refresh_mode: refreshMode || null,
+        refresh_rate_hz: refreshRateHz === '' ? null : Number(refreshRateHz),
+        integration_mode: integrationMode || null,
+      });
+      setMsg('Instrument settings saved');
+    } catch (e) {
+      setMsg(`Error: ${e.message}`);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
+        <span className="text-sm muted">
+          {argyllPrefs?.instrument_name || argyllPrefs?.port
+            ? `Meter: ${argyllPrefs?.instrument_name || `port ${argyllPrefs.port}`}`
+            : 'No meter selected'}
+        </span>
+        <button
+          className="btn btn-sm"
+          style={{ marginLeft: 'auto' }}
+          onClick={() => setShowSettings(s => !s)}
+        >
+          {showSettings ? 'Hide' : 'Settings'}
+        </button>
+      </div>
+
+      {showSettings && (
+        <div className="bridge-settings">
+          <div className="text-sm muted" style={{ marginBottom: 6 }}>Meter / port</div>
+          <div className="bridge-url-row">
+            <select value={port} onChange={e => setPort(e.target.value)}>
+              <option value="">Auto-detect (spotread default)</option>
+              {instruments.map(i => (
+                <option key={i.index} value={i.index}>{i.name}</option>
+              ))}
+            </select>
+            <Button small onClick={handleScan} disabled={scanning}>
+              {scanning ? <span className="spinner" /> : 'Scan'}
+            </Button>
+          </div>
+
+          <div className="text-sm muted" style={{ marginTop: 10 }}>
+            CCMX/CCSS correction file (colorimeters on wide-gamut panels)
+          </div>
+          <div className="bridge-url-row">
+            <input
+              type="text"
+              value={correctionPath}
+              onChange={e => setCorrectionPath(e.target.value)}
+              placeholder="C:\path\to\correction.ccmx"
+            />
+          </div>
+
+          <div className="text-sm muted" style={{ marginTop: 10 }}>
+            Display refresh mode (flicker-prone / PWM-backlit panels)
+          </div>
+          <div className="bridge-url-row">
+            <select value={refreshMode} onChange={e => setRefreshMode(e.target.value)}>
+              {REFRESH_MODE_OPTIONS.map(o => (
+                <option key={o.value} value={o.value}>{o.label}</option>
+              ))}
+            </select>
+          </div>
+
+          <div className="text-sm muted" style={{ marginTop: 10 }}>
+            Refresh rate override (Hz) — leave blank to auto-detect
+          </div>
+          <div className="bridge-url-row">
+            <input
+              type="number"
+              min={0}
+              step="any"
+              value={refreshRateHz}
+              onChange={e => setRefreshRateHz(e.target.value)}
+              placeholder="e.g. 120"
+              style={{ width: 120 }}
+            />
+          </div>
+
+          <div className="text-sm muted" style={{ marginTop: 10 }}>
+            Integration time / averaging override
+          </div>
+          <div className="bridge-url-row" style={{ marginTop: 4 }}>
+            <select value={integrationMode} onChange={e => setIntegrationMode(e.target.value)}>
+              {INTEGRATION_MODE_OPTIONS.map(o => (
+                <option key={o.value} value={o.value}>{o.label}</option>
+              ))}
+            </select>
+            <Button small onClick={handleSave} disabled={busy}>Save</Button>
+          </div>
+        </div>
+      )}
+
+      {msg && <div className="text-sm muted mt-2">{msg}</div>}
+    </div>
+  );
+}

--- a/frontend/src/components/ArgyllCard.test.jsx
+++ b/frontend/src/components/ArgyllCard.test.jsx
@@ -1,0 +1,94 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ArgyllCard } from './ArgyllCard';
+
+function renderCard(props = {}) {
+  return render(
+    <ArgyllCard
+      argyllPrefs={props.argyllPrefs}
+      onScanInstruments={props.onScanInstruments || vi.fn().mockResolvedValue({ instruments: [] })}
+      onSaveInstrument={props.onSaveInstrument || vi.fn().mockResolvedValue({})}
+    />
+  );
+}
+
+describe('ArgyllCard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows "No meter selected" when there are no saved prefs', () => {
+    renderCard();
+    expect(screen.getByText('No meter selected')).toBeInTheDocument();
+  });
+
+  it('shows the saved instrument name when prefs are set', () => {
+    renderCard({ argyllPrefs: { port: '1', instrument_name: 'Klein K10-A on COM3' } });
+    expect(screen.getByText('Meter: Klein K10-A on COM3')).toBeInTheDocument();
+  });
+
+  it('Scan populates the port dropdown from onScanInstruments', async () => {
+    const onScanInstruments = vi.fn().mockResolvedValue({
+      instruments: [{ index: 1, name: 'X-Rite i1 Display Pro, USB' }],
+    });
+    renderCard({ onScanInstruments });
+
+    await userEvent.click(screen.getByText('Settings'));
+    await userEvent.click(screen.getByText('Scan'));
+
+    expect(onScanInstruments).toHaveBeenCalled();
+    expect(await screen.findByText('X-Rite i1 Display Pro, USB')).toBeInTheDocument();
+  });
+
+  it('Save defaults refresh mode / rate / integration mode to null when left unset', async () => {
+    const onSaveInstrument = vi.fn().mockResolvedValue({});
+    renderCard({ onSaveInstrument });
+
+    await userEvent.click(screen.getByText('Settings'));
+    await userEvent.click(screen.getByText('Save'));
+
+    expect(onSaveInstrument).toHaveBeenCalledWith(
+      expect.objectContaining({
+        refresh_mode: null,
+        refresh_rate_hz: null,
+        integration_mode: null,
+      })
+    );
+  });
+
+  it('Save includes the chosen refresh mode, refresh rate, and integration mode', async () => {
+    const onSaveInstrument = vi.fn().mockResolvedValue({});
+    renderCard({ onSaveInstrument });
+
+    await userEvent.click(screen.getByText('Settings'));
+    await userEvent.selectOptions(
+      screen.getByText('Auto (instrument default)').closest('select'),
+      'refresh'
+    );
+    await userEvent.type(screen.getByPlaceholderText('e.g. 120'), '120');
+    await userEvent.selectOptions(
+      screen.getByText('Adaptive (spotread default)').closest('select'),
+      'non_adaptive'
+    );
+    await userEvent.click(screen.getByText('Save'));
+
+    expect(onSaveInstrument).toHaveBeenCalledWith(
+      expect.objectContaining({
+        refresh_mode: 'refresh',
+        refresh_rate_hz: 120,
+        integration_mode: 'non_adaptive',
+      })
+    );
+  });
+
+  it('shows an error message when saving fails', async () => {
+    const onSaveInstrument = vi.fn().mockRejectedValue(new Error('bridge unreachable'));
+    renderCard({ onSaveInstrument });
+
+    await userEvent.click(screen.getByText('Settings'));
+    await userEvent.click(screen.getByText('Save'));
+
+    expect(await screen.findByText('Error: bridge unreachable')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/InstrumentPanel.jsx
+++ b/frontend/src/components/InstrumentPanel.jsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect } from 'react';
 import { fmtDateTime, measurementTimeSummary } from '../utils/fmt';
 import { Button } from './Button';
 import { DogegenCard } from './DogegenCard';
+import { ArgyllCard } from './ArgyllCard';
 
 function StatusDot({ ok }) {
   return (
@@ -18,10 +19,12 @@ export function InstrumentPanel({
   watchStatus, watchDefaultPath,
   bridgeStatus, bridgeUrl,
   dogegenStatus, adbStatus,
+  argyllPrefs,
   onMeasure, onSaveBridgeUrl,
   onStartWatch, onStopWatch,
   onUpload,
   onSaveDogegenConfig, onStartDogegen, onStopDogegen,
+  onScanArgyllInstruments, onSaveArgyllInstrument,
 }) {
   const [measureBusy, setMeasureBusy] = useState(false);
   const [measureMsg, setMeasureMsg] = useState('');
@@ -146,6 +149,17 @@ export function InstrumentPanel({
               onSaveConfig={onSaveDogegenConfig}
               onStart={onStartDogegen}
               onStop={onStopDogegen}
+            />
+          </div>
+        )}
+
+        {/* ArgyllCMS direct-meter backend */}
+        {bridgeStatus?.backend === 'argyll' && (
+          <div style={{ marginTop: 10 }}>
+            <ArgyllCard
+              argyllPrefs={argyllPrefs}
+              onScanInstruments={onScanArgyllInstruments}
+              onSaveInstrument={onSaveArgyllInstrument}
             />
           </div>
         )}

--- a/frontend/src/hooks/useSession.js
+++ b/frontend/src/hooks/useSession.js
@@ -33,6 +33,7 @@ export function useSession() {
   const [watchDefaultPath, setWatchDefaultPath] = useState('');
   const [bridgeStatus, setBridgeStatus] = useState(null);
   const [dogegenStatus, setDogegenStatus] = useState(null);
+  const [argyllPrefs, setArgyllPrefs] = useState(null);
   const [adbStatus, setAdbStatus] = useState(null);
   const [loading, setLoading] = useState(true);
 
@@ -173,6 +174,7 @@ export function useSession() {
         setBridgeUrl(url);
         api.saveBridgeUrl(url).catch(() => { /* best-effort sync */ });
         setWatchDefaultPath(prefs?.watch_folder || '');
+        setArgyllPrefs(prefs?.argyll || null);
       })
       .catch(() => { /* load failure is non-fatal */ })
       .finally(() => setLoading(false));
@@ -400,6 +402,16 @@ export function useSession() {
     return status;
   }
 
+  async function scanArgyllInstruments() {
+    return api.getArgyllInstruments();
+  }
+
+  async function saveArgyllInstrument(config) {
+    const result = await api.saveArgyllInstrument(config);
+    setArgyllPrefs(result?.argyll || null);
+    return result;
+  }
+
   async function adbDeploy() {
     const result = await api.adbDeploy();
     await refreshAdbStatus();
@@ -463,10 +475,12 @@ export function useSession() {
 
   return {
     session, profiles, watchStatus, watchDefaultPath, bridgeUrl, bridgeStatus, dogegenStatus, adbStatus, loading,
+    argyllPrefs,
     createSession, deleteSession, nextStep, prevStep, jumpToStep, confirmMode, confirmPrepared, setGammaWorkflow, setSignalRange, setGrayscaleRamp, setCodeScale, setPatternGenerator, setLightspaceTier,
     uploadCsv, startWatch, stopWatch,
     saveBridgeUrl, triggerMeasure, refreshBridgeStatus,
     saveDogegenConfig, startDogegen, stopDogegen, refreshDogegenStatus,
+    scanArgyllInstruments, saveArgyllInstrument,
     adbDeploy, adbApply, adbReset, adbSetPicture, adbGetPicture, refreshAdbStatus,
     configureLlm, getLlmStatus, saveTvSettings,
     llmInsight, llmStreaming, llmError, dismissLlmInsight,

--- a/server.py
+++ b/server.py
@@ -21,7 +21,7 @@ import threading
 from contextlib import asynccontextmanager, suppress as context_suppress
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Literal, Optional
 from urllib.parse import urlparse
 
 import httpx
@@ -447,8 +447,18 @@ _prefs: Dict[str, Any] = {
     # scan, kept alongside so the UI can show a selection without re-scanning.
     # correction_path (issue #535) is the CCMX/CCSS meter-correction file
     # passed through to spotread -X; colorimeters need one on wide-gamut
-    # panels, spectrophotometers (i1Pro) don't.
-    "argyll": {"port": "", "instrument_name": "", "correction_path": ""},
+    # panels, spectrophotometers (i1Pro) don't. refresh_mode/refresh_rate_hz/
+    # integration_mode (issue #600) tune spotread -Y for flicker-prone panels
+    # (PWM-dimmed backlights, some VA/edge-lit LCDs) — all empty by default,
+    # which reproduces the original -e -O read exactly.
+    "argyll": {
+        "port": "",
+        "instrument_name": "",
+        "correction_path": "",
+        "refresh_mode": "",
+        "refresh_rate_hz": None,
+        "integration_mode": "",
+    },
 }
 
 
@@ -616,6 +626,9 @@ class ZroBridgeInstrumentBody(BaseModel):
     port: Optional[str] = None
     instrument_name: Optional[str] = None
     correction_path: Optional[str] = None
+    refresh_mode: Optional[Literal["refresh", "non_refresh"]] = None
+    refresh_rate_hz: Optional[float] = None
+    integration_mode: Optional[Literal["non_adaptive", "averaging"]] = None
 
 
 class ZroBridgeMeasureBody(BaseModel):
@@ -2619,15 +2632,19 @@ def zro_bridge_instruments():
 @app.post("/api/zro/bridge/instrument")
 def zro_bridge_select_instrument(body: ZroBridgeInstrumentBody):
     """
-    Persist the selected ArgyllCMS meter and CCMX/CCSS correction path
-    across app sessions (#531, #535) and push them to the bridge so they
-    take effect immediately. If the bridge is unreachable the selection
-    still saves — it applies next time the app reconnects and re-pushes it.
+    Persist the selected ArgyllCMS meter, CCMX/CCSS correction path, and
+    flicker/refresh-timing tuning across app sessions (#531, #535, #600) and
+    push them to the bridge so they take effect immediately. If the bridge is
+    unreachable the selection still saves — it applies next time the app
+    reconnects and re-pushes it.
     """
     _prefs["argyll"] = {
         "port": body.port or "",
         "instrument_name": body.instrument_name or "",
         "correction_path": body.correction_path or "",
+        "refresh_mode": body.refresh_mode or "",
+        "refresh_rate_hz": body.refresh_rate_hz,
+        "integration_mode": body.integration_mode or "",
     }
     _save_prefs()
 
@@ -2637,7 +2654,13 @@ def zro_bridge_select_instrument(body: ZroBridgeInstrumentBody):
         try:
             resp = httpx.post(
                 f"{url}/config/argyll-port",
-                json={"port": body.port, "correction_path": body.correction_path},
+                json={
+                    "port": body.port,
+                    "correction_path": body.correction_path,
+                    "refresh_mode": body.refresh_mode,
+                    "refresh_rate_hz": body.refresh_rate_hz,
+                    "integration_mode": body.integration_mode,
+                },
                 timeout=_ZRO_BRIDGE_TIMEOUT,
             )
             resp.raise_for_status()

--- a/tests/test_argyll_backend.py
+++ b/tests/test_argyll_backend.py
@@ -694,6 +694,25 @@ class TestBridgeInstrumentEndpoints:
         resp = asyncio.run(_run())
         assert resp.status_code == 400
 
+    def test_partial_refresh_settings_updates_persist_unmodified_fields(self):
+        """Setting refresh_mode in one request, then refresh_rate_hz in a
+        separate request that omits refresh_mode, must not clobber the
+        value set by the first request (same omit-a-key-to-leave-it-alone
+        contract as correction_path)."""
+        bridge._config["backend"] = "argyll"
+
+        async def _run():
+            transport = httpx.ASGITransport(app=bridge.app)
+            async with httpx.AsyncClient(transport=transport, base_url="http://bridge.test") as client:
+                await client.post("/config/argyll-port", json={"port": "1", "refresh_mode": "refresh"})
+                return await client.post("/config/argyll-port", json={"port": "1", "refresh_rate_hz": 120})
+
+        resp = asyncio.run(_run())
+
+        assert resp.status_code == 200
+        assert bridge._config["argyll_refresh_mode"] == "refresh"
+        assert bridge._config["argyll_refresh_rate_hz"] == 120
+
     def test_instruments_reports_refresh_timing_fields(self):
         bridge._config["backend"] = "argyll"
         bridge._config["argyll_refresh_mode"] = "non_refresh"

--- a/tests/test_argyll_backend.py
+++ b/tests/test_argyll_backend.py
@@ -159,6 +159,126 @@ class TestReadXyzParsing:
         assert "warning" not in result
 
 
+# ── read_xyz: refresh-timing / integration tuning (issue #600) ─────────────────
+
+class TestReadXyzRefreshTiming:
+    def test_default_unset_command_is_byte_identical_to_e_O(self):
+        """No refresh_mode/refresh_rate_hz/integration_mode passed — no -Y flags
+        of any kind, reproducing today's command exactly."""
+        stdout = "Result is XYZ: 1.0 2.0 3.0\n"
+        with patch("shutil.which", return_value="/usr/bin/spotread"), \
+             patch("subprocess.run", return_value=_mock_proc(stdout=stdout)) as mock_run:
+            argyll_backend.read_xyz()
+
+        cmd = mock_run.call_args.args[0]
+        assert cmd == ["/usr/bin/spotread", "-e", "-O"]
+
+    def test_refresh_mode_refresh_passes_Y_r(self):
+        stdout = "Result is XYZ: 1.0 2.0 3.0\n"
+        with patch("shutil.which", return_value="/usr/bin/spotread"), \
+             patch("subprocess.run", return_value=_mock_proc(stdout=stdout)) as mock_run:
+            argyll_backend.read_xyz(refresh_mode="refresh")
+
+        cmd = mock_run.call_args.args[0]
+        assert cmd == ["/usr/bin/spotread", "-e", "-O", "-Y", "r"]
+
+    def test_refresh_mode_non_refresh_passes_Y_n(self):
+        stdout = "Result is XYZ: 1.0 2.0 3.0\n"
+        with patch("shutil.which", return_value="/usr/bin/spotread"), \
+             patch("subprocess.run", return_value=_mock_proc(stdout=stdout)) as mock_run:
+            argyll_backend.read_xyz(refresh_mode="non_refresh")
+
+        cmd = mock_run.call_args.args[0]
+        assert cmd == ["/usr/bin/spotread", "-e", "-O", "-Y", "n"]
+
+    def test_refresh_rate_hz_passes_Y_R_rate(self):
+        stdout = "Result is XYZ: 1.0 2.0 3.0\n"
+        with patch("shutil.which", return_value="/usr/bin/spotread"), \
+             patch("subprocess.run", return_value=_mock_proc(stdout=stdout)) as mock_run:
+            argyll_backend.read_xyz(refresh_rate_hz=119.88)
+
+        cmd = mock_run.call_args.args[0]
+        assert cmd == ["/usr/bin/spotread", "-e", "-O", "-Y", "R:119.88"]
+
+    def test_integration_mode_non_adaptive_passes_Y_A(self):
+        stdout = "Result is XYZ: 1.0 2.0 3.0\n"
+        with patch("shutil.which", return_value="/usr/bin/spotread"), \
+             patch("subprocess.run", return_value=_mock_proc(stdout=stdout)) as mock_run:
+            argyll_backend.read_xyz(integration_mode="non_adaptive")
+
+        cmd = mock_run.call_args.args[0]
+        assert cmd == ["/usr/bin/spotread", "-e", "-O", "-Y", "A"]
+
+    def test_integration_mode_averaging_passes_Y_a(self):
+        stdout = "Result is XYZ: 1.0 2.0 3.0\n"
+        with patch("shutil.which", return_value="/usr/bin/spotread"), \
+             patch("subprocess.run", return_value=_mock_proc(stdout=stdout)) as mock_run:
+            argyll_backend.read_xyz(integration_mode="averaging")
+
+        cmd = mock_run.call_args.args[0]
+        assert cmd == ["/usr/bin/spotread", "-e", "-O", "-Y", "a"]
+
+    def test_all_options_combine_before_port_in_documented_order(self):
+        """-X, then the -Y sub-flags in refresh_mode/refresh_rate_hz/
+        integration_mode order, then the trailing port — matching the
+        existing correction_path -> -X ordering convention."""
+        stdout = "Result is XYZ: 1.0 2.0 3.0\n"
+        with patch("shutil.which", return_value="/usr/bin/spotread"), \
+             patch("subprocess.run", return_value=_mock_proc(stdout=stdout)) as mock_run:
+            argyll_backend.read_xyz(
+                port="/dev/ttyUSB0",
+                correction_path="/some/correction.ccmx",
+                refresh_mode="refresh",
+                refresh_rate_hz=120,
+                integration_mode="averaging",
+            )
+
+        cmd = mock_run.call_args.args[0]
+        assert cmd == [
+            "/usr/bin/spotread", "-e", "-O",
+            "-X", "/some/correction.ccmx",
+            "-Y", "r",
+            "-Y", "R:120",
+            "-Y", "a",
+            "/dev/ttyUSB0",
+        ]
+
+    def test_read_xyz_async_forwards_refresh_timing_params(self):
+        stdout = "Result is XYZ: 1.0 2.0 3.0\n"
+        with patch("shutil.which", return_value="/usr/bin/spotread"), \
+             patch("subprocess.run", return_value=_mock_proc(stdout=stdout)) as mock_run:
+            asyncio.run(argyll_backend.read_xyz_async(
+                refresh_mode="non_refresh",
+                refresh_rate_hz=60,
+                integration_mode="non_adaptive",
+            ))
+
+        cmd = mock_run.call_args.args[0]
+        assert cmd == [
+            "/usr/bin/spotread", "-e", "-O",
+            "-Y", "n",
+            "-Y", "R:60",
+            "-Y", "A",
+        ]
+
+    def test_rejected_flag_fails_loudly_as_spotread_error(self):
+        """If the installed Argyll version rejects a -Y flag, spotread's
+        non-zero exit surfaces as a clear spotread_error, not a silent
+        misread."""
+        with patch("shutil.which", return_value="/usr/bin/spotread"), \
+             patch(
+                 "subprocess.run",
+                 return_value=_mock_proc(
+                     stderr="spotread: Unknown option 'q'\n", returncode=1
+                 ),
+             ):
+            result = argyll_backend.read_xyz(refresh_mode="refresh")
+
+        assert result["ok"] is False
+        assert result["error_type"] == "spotread_error"
+        assert "raw" in result
+
+
 # ── read_xyz: HDR absolute-nit verification (issue #534) ───────────────────────
 
 class TestAbsoluteNits:
@@ -515,6 +635,107 @@ class TestBridgeInstrumentEndpoints:
 
         assert resp.status_code == 200
         assert captured_cmds[-1][-1] == "2"
+
+    def test_set_argyll_refresh_timing_updates_runtime_config(self):
+        bridge._config["backend"] = "argyll"
+
+        async def _run():
+            transport = httpx.ASGITransport(app=bridge.app)
+            async with httpx.AsyncClient(transport=transport, base_url="http://bridge.test") as client:
+                return await client.post(
+                    "/config/argyll-port",
+                    json={
+                        "port": "2",
+                        "refresh_mode": "refresh",
+                        "refresh_rate_hz": 119.88,
+                        "integration_mode": "averaging",
+                    },
+                )
+
+        resp = asyncio.run(_run())
+
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "ok": True,
+            "argyll_port": "2",
+            "refresh_mode": "refresh",
+            "refresh_rate_hz": 119.88,
+            "integration_mode": "averaging",
+        }
+        assert bridge._config["argyll_refresh_mode"] == "refresh"
+        assert bridge._config["argyll_refresh_rate_hz"] == 119.88
+        assert bridge._config["argyll_integration_mode"] == "averaging"
+
+    def test_set_argyll_refresh_mode_rejects_invalid_value(self):
+        bridge._config["backend"] = "argyll"
+
+        async def _run():
+            transport = httpx.ASGITransport(app=bridge.app)
+            async with httpx.AsyncClient(transport=transport, base_url="http://bridge.test") as client:
+                return await client.post(
+                    "/config/argyll-port",
+                    json={"port": "2", "refresh_mode": "bogus"},
+                )
+
+        resp = asyncio.run(_run())
+        assert resp.status_code == 400
+
+    def test_set_argyll_integration_mode_rejects_invalid_value(self):
+        bridge._config["backend"] = "argyll"
+
+        async def _run():
+            transport = httpx.ASGITransport(app=bridge.app)
+            async with httpx.AsyncClient(transport=transport, base_url="http://bridge.test") as client:
+                return await client.post(
+                    "/config/argyll-port",
+                    json={"port": "2", "integration_mode": "bogus"},
+                )
+
+        resp = asyncio.run(_run())
+        assert resp.status_code == 400
+
+    def test_instruments_reports_refresh_timing_fields(self):
+        bridge._config["backend"] = "argyll"
+        bridge._config["argyll_refresh_mode"] = "non_refresh"
+        bridge._config["argyll_refresh_rate_hz"] = 60.0
+        bridge._config["argyll_integration_mode"] = "non_adaptive"
+
+        async def _run():
+            transport = httpx.ASGITransport(app=bridge.app)
+            async with httpx.AsyncClient(transport=transport, base_url="http://bridge.test") as client:
+                return await client.get("/instruments")
+
+        with patch("shutil.which", return_value="/usr/bin/spotread"), \
+             patch("subprocess.run", return_value=_mock_proc(stdout=_SPOTREAD_HELP_TWO_INSTRUMENTS, returncode=1)):
+            resp = asyncio.run(_run())
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["refresh_mode"] == "non_refresh"
+        assert data["refresh_rate_hz"] == 60.0
+        assert data["integration_mode"] == "non_adaptive"
+
+    def test_set_argyll_refresh_timing_takes_effect_on_next_measure(self):
+        bridge._config["backend"] = "argyll"
+
+        captured_cmds = []
+
+        def recording_run(cmd, **kwargs):
+            captured_cmds.append(cmd)
+            return _mock_proc(stdout="Result is XYZ: 1.0 2.0 3.0\n")
+
+        async def _run():
+            transport = httpx.ASGITransport(app=bridge.app)
+            async with httpx.AsyncClient(transport=transport, base_url="http://bridge.test") as client:
+                await client.post("/config/argyll-port", json={"port": None, "refresh_mode": "refresh"})
+                return await client.post("/measure")
+
+        with patch("shutil.which", return_value="/usr/bin/spotread"), \
+             patch("subprocess.run", side_effect=recording_run):
+            resp = asyncio.run(_run())
+
+        assert resp.status_code == 200
+        assert captured_cmds[-1] == ["/usr/bin/spotread", "-e", "-O", "-Y", "r"]
 
     def test_config_write_concurrent_with_in_flight_measure_does_not_race(self):
         """

--- a/tests/test_zro_bridge.py
+++ b/tests/test_zro_bridge.py
@@ -151,7 +151,10 @@ class TestZroBridgeInstruments:
 
     def test_select_persists_and_pushes_to_bridge(self):
         srv._zro_bridge.set("http://192.168.1.50:7070")
-        srv._prefs["argyll"] = {"port": "", "instrument_name": "", "correction_path": ""}
+        srv._prefs["argyll"] = {
+            "port": "", "instrument_name": "", "correction_path": "",
+            "refresh_mode": "", "refresh_rate_hz": None, "integration_mode": "",
+        }
         captured = {}
 
         def mock_post(url, **kwargs):
@@ -177,14 +180,66 @@ class TestZroBridgeInstruments:
             "port": "2",
             "instrument_name": "X-Rite i1 Display Pro, USB",
             "correction_path": "/etc/argyll/i1d3.ccss",
+            "refresh_mode": "",
+            "refresh_rate_hz": None,
+            "integration_mode": "",
         }
         assert srv._prefs["argyll"] == {
             "port": "2",
             "instrument_name": "X-Rite i1 Display Pro, USB",
             "correction_path": "/etc/argyll/i1d3.ccss",
+            "refresh_mode": "",
+            "refresh_rate_hz": None,
+            "integration_mode": "",
         }
         assert captured["url"] == "http://192.168.1.50:7070/config/argyll-port"
-        assert captured["json"] == {"port": "2", "correction_path": "/etc/argyll/i1d3.ccss"}
+        assert captured["json"] == {
+            "port": "2",
+            "correction_path": "/etc/argyll/i1d3.ccss",
+            "refresh_mode": None,
+            "refresh_rate_hz": None,
+            "integration_mode": None,
+        }
+
+    def test_select_persists_and_pushes_refresh_timing_fields(self):
+        srv._zro_bridge.set("http://192.168.1.50:7070")
+        captured = {}
+
+        def mock_post(url, **kwargs):
+            captured["url"] = url
+            captured["json"] = kwargs.get("json")
+            return _mock_httpx_post({"ok": True, "argyll_port": "2"})
+
+        with patch("httpx.post", side_effect=mock_post):
+            r = client.post(
+                "/api/zro/bridge/instrument",
+                json={
+                    "port": "2",
+                    "refresh_mode": "refresh",
+                    "refresh_rate_hz": 119.88,
+                    "integration_mode": "averaging",
+                },
+            )
+
+        assert r.status_code == 200
+        d = r.json()
+        assert d["argyll"]["refresh_mode"] == "refresh"
+        assert d["argyll"]["refresh_rate_hz"] == 119.88
+        assert d["argyll"]["integration_mode"] == "averaging"
+        assert captured["json"] == {
+            "port": "2",
+            "correction_path": None,
+            "refresh_mode": "refresh",
+            "refresh_rate_hz": 119.88,
+            "integration_mode": "averaging",
+        }
+
+    def test_select_rejects_invalid_refresh_mode(self):
+        r = client.post(
+            "/api/zro/bridge/instrument",
+            json={"port": "2", "refresh_mode": "bogus"},
+        )
+        assert r.status_code == 422
 
     def test_select_persists_even_if_bridge_unreachable(self):
         srv._zro_bridge.set("http://192.168.1.50:7070")
@@ -204,7 +259,14 @@ class TestZroBridgeInstruments:
         assert r.status_code == 200
         d = r.json()
         assert d["pushed_to_bridge"] is False
-        assert srv._prefs["argyll"] == {"port": "3", "instrument_name": "Meter", "correction_path": ""}
+        assert srv._prefs["argyll"] == {
+            "port": "3",
+            "instrument_name": "Meter",
+            "correction_path": "",
+            "refresh_mode": "",
+            "refresh_rate_hz": None,
+            "integration_mode": "",
+        }
 
 
 # ── POST /api/zro/trigger ──────────────────────────────────────────────────────

--- a/tools/zro-bridge/backends/argyll_backend.py
+++ b/tools/zro-bridge/backends/argyll_backend.py
@@ -16,6 +16,15 @@ need and must be preserved end to end (see ``read_xyz``'s docstring).
 
 Meter discovery/selection (issue #531) is a separate follow-up. CCMX/CCSS
 spectral correction is supported via the ``correction_path`` parameter.
+
+For flicker-prone panels (PWM-dimmed backlights, some VA/edge-lit LCDs, and
+other non-constant-refresh displays), spotread's adaptive-integration default
+can beat against the panel's refresh behavior and bias or add noise to a
+reading. ``refresh_mode``, ``refresh_rate_hz``, and ``integration_mode`` map
+onto spotread's ``-Y`` sub-flags (verified against ``spotread`` v3.x's
+``-?`` usage text and https://www.argyllcms.com/doc/spotread.html) to tune
+that behavior; all three are opt-in and default to ``None``, which reproduces
+today's ``-e -O`` command byte-for-byte.
 """
 
 import logging
@@ -43,6 +52,16 @@ class XyzReadOk(TypedDict):
 
 
 ErrorType = Literal["not_found", "no_meter", "timeout", "parse_error", "spotread_error"]
+
+# spotread -Y r|n — force refresh or non-refresh display measurement mode,
+# overriding the -y display-type default. Relevant for flicker-prone panels:
+# "refresh" is for CRT-like/PWM-backlit displays with periodic brightness
+# modulation, "non_refresh" is for steady-state panels (most modern LCD/OLED).
+RefreshMode = Literal["refresh", "non_refresh"]
+
+# spotread -Y A|a — non-adaptive (fixed) integration time vs. an instrument's
+# averaging mode, where supported by the connected meter.
+IntegrationMode = Literal["non_adaptive", "averaging"]
 
 
 class XyzReadError(TypedDict):
@@ -165,6 +184,9 @@ def read_xyz(
     spotread_path: str = "spotread",
     timeout: float = _DEFAULT_TIMEOUT_S,
     correction_path: Optional[str] = None,
+    refresh_mode: Optional[RefreshMode] = None,
+    refresh_rate_hz: Optional[float] = None,
+    integration_mode: Optional[IntegrationMode] = None,
 ) -> XyzReadResult:
     """
     Take one single-shot emissive reading via ``spotread -e -O`` and return XYZ.
@@ -191,6 +213,26 @@ def read_xyz(
     correction file — if it cannot find one, a ``warning`` field is added to
     the result dict.
 
+    ``refresh_mode``, ``refresh_rate_hz``, and ``integration_mode`` tune
+    spotread's read timing for flicker-prone panels (PWM-dimmed backlights,
+    some VA/edge-lit LCDs) so XYZ readings aren't corrupted by beat-frequency
+    or sampling artifacts against the panel's refresh behavior:
+
+    - ``refresh_mode="refresh"`` passes ``-Y r``, forcing refresh-display
+      measurement mode (periodic brightness modulation, e.g. PWM backlights).
+      ``refresh_mode="non_refresh"`` passes ``-Y n`` for steady-state panels.
+      Leave unset to use the instrument's ``-y`` display-type default.
+    - ``refresh_rate_hz`` passes ``-Y R:<rate>``, overriding spotread's
+      auto-measured refresh rate calibration with a known value (e.g. the
+      panel's PWM dimming frequency) when auto-detection is unreliable.
+    - ``integration_mode="non_adaptive"`` passes ``-Y A`` (fixed integration
+      time, faster but potentially less accurate on low light levels).
+      ``integration_mode="averaging"`` passes ``-Y a`` (instrument averaging
+      mode, where the connected meter supports it).
+
+    All three are opt-in; leaving them unset reproduces today's ``-e -O``
+    command exactly, with no ``-Y`` flags added.
+
     Returns on success::
 
         {"ok": True, "method": "argyll", "X": .., "Y": .., "Z": .., "x": .., "y": ..,
@@ -216,6 +258,12 @@ def read_xyz(
     cmd = [resolved, "-e", "-O"]
     if correction_path:
         cmd.extend(["-X", correction_path])
+    if refresh_mode:
+        cmd.extend(["-Y", "r" if refresh_mode == "refresh" else "n"])
+    if refresh_rate_hz:
+        cmd.extend(["-Y", f"R:{refresh_rate_hz}"])
+    if integration_mode:
+        cmd.extend(["-Y", "A" if integration_mode == "non_adaptive" else "a"])
     if port:
         cmd.append(port)
 
@@ -305,6 +353,9 @@ async def read_xyz_async(
     spotread_path: str = "spotread",
     timeout: float = _DEFAULT_TIMEOUT_S,
     correction_path: Optional[str] = None,
+    refresh_mode: Optional[RefreshMode] = None,
+    refresh_rate_hz: Optional[float] = None,
+    integration_mode: Optional[IntegrationMode] = None,
 ) -> XyzReadResult:
     """
     Async wrapper around ``read_xyz()``.
@@ -320,6 +371,9 @@ async def read_xyz_async(
         spotread_path=spotread_path,
         timeout=timeout,
         correction_path=correction_path,
+        refresh_mode=refresh_mode,
+        refresh_rate_hz=refresh_rate_hz,
+        integration_mode=integration_mode,
     )
 
 

--- a/tools/zro-bridge/bridge.example.json
+++ b/tools/zro-bridge/bridge.example.json
@@ -22,6 +22,8 @@
   "argyll_port": null,
   "argyll_timeout_s": 20.0,
   "argyll_correction": null,
+
+  "_comment_refresh_timing": "argyll_refresh_mode / argyll_refresh_rate_hz / argyll_integration_mode need ArgyllCMS v3.x+ (spotread -Y support); older versions reject them with spotread_error.",
   "argyll_refresh_mode": null,
   "argyll_refresh_rate_hz": null,
   "argyll_integration_mode": null

--- a/tools/zro-bridge/bridge.example.json
+++ b/tools/zro-bridge/bridge.example.json
@@ -21,5 +21,8 @@
   "argyll_spotread_path": "spotread",
   "argyll_port": null,
   "argyll_timeout_s": 20.0,
-  "argyll_correction": null
+  "argyll_correction": null,
+  "argyll_refresh_mode": null,
+  "argyll_refresh_rate_hz": null,
+  "argyll_integration_mode": null
 }

--- a/tools/zro-bridge/bridge.py
+++ b/tools/zro-bridge/bridge.py
@@ -86,6 +86,19 @@ DEFAULT_CONFIG = {
     # Colorimeters (i1Display, etc.) need one on wide-gamut panels for
     # accuracy; spectrophotometers (i1Pro) do not. Leave null to skip -X.
     "argyll_correction": None,
+    # Refresh-timing tuning for flicker-prone panels (PWM-dimmed backlights,
+    # some VA/edge-lit LCDs) — all optional, unset reproduces today's
+    # `-e -O` command exactly. See README's ArgyllCMS section.
+    # "refresh" (-Y r) or "non_refresh" (-Y n); leave null to use the
+    # instrument's own display-type default.
+    "argyll_refresh_mode": None,
+    # Override spotread's auto-measured refresh rate (Hz), e.g. the panel's
+    # PWM dimming frequency, via -Y R:<rate>. Leave null to auto-detect.
+    "argyll_refresh_rate_hz": None,
+    # "non_adaptive" (-Y A, fixed integration time) or "averaging" (-Y a,
+    # instrument averaging mode where supported). Leave null for spotread's
+    # adaptive default.
+    "argyll_integration_mode": None,
 }
 
 _config: dict = dict(DEFAULT_CONFIG)
@@ -166,15 +179,17 @@ async def list_instruments():
 
     Returns {"ok": True, "instruments": [{"index": int, "name": str}, ...],
              "selected_port": <current argyll_port, or null>,
-             "correction_path": <current argyll_correction, or null>}.
+             "correction_path": <current argyll_correction, or null>,
+             "refresh_mode": <current argyll_refresh_mode, or null>,
+             "refresh_rate_hz": <current argyll_refresh_rate_hz, or null>,
+             "integration_mode": <current argyll_integration_mode, or null>}.
     An empty instruments list means spotread ran but nothing is connected —
     that's a valid result, not an error.
 
-    ``selected_port`` and ``correction_path`` reflect whichever values are
-    currently in effect for reads: bridge.json's static ``argyll_port`` /
-    ``argyll_correction`` until/unless a client has since called
-    ``POST /config/argyll-port``, which overrides them in memory for the
-    rest of this bridge process's life.
+    These reflect whichever values are currently in effect for reads:
+    bridge.json's static ``argyll_*`` settings until/unless a client has
+    since called ``POST /config/argyll-port``, which overrides them in
+    memory for the rest of this bridge process's life.
     """
     backend = _config.get("backend", "pyautogui")
     if backend != "argyll":
@@ -191,6 +206,9 @@ async def list_instruments():
         **result,
         "selected_port": _config.get("argyll_port"),
         "correction_path": _config.get("argyll_correction"),
+        "refresh_mode": _config.get("argyll_refresh_mode"),
+        "refresh_rate_hz": _config.get("argyll_refresh_rate_hz"),
+        "integration_mode": _config.get("argyll_integration_mode"),
     }
 
 
@@ -198,12 +216,16 @@ async def list_instruments():
 def set_argyll_port(body: dict):
     """
     Select which detected instrument/port argyll reads use, and optionally
-    its CCMX/CCSS correction file path, for the rest of this bridge
-    process's lifetime (in-memory only — edit argyll_port / argyll_correction
-    in bridge.json if you want the choice to survive a bridge restart too).
+    its CCMX/CCSS correction file path and refresh-timing tuning, for the
+    rest of this bridge process's lifetime (in-memory only — edit the
+    corresponding argyll_* keys in bridge.json if you want the choice to
+    survive a bridge restart too).
 
-    Body: {"port": <str|null>, "correction_path"?: <str|null>}. The
-    ``correction_path`` key is optional — omit it to change the port only.
+    Body: {"port": <str|null>, "correction_path"?: <str|null>,
+           "refresh_mode"?: "refresh"|"non_refresh"|null,
+           "refresh_rate_hz"?: <number|null>,
+           "integration_mode"?: "non_adaptive"|"averaging"|null}.
+    All keys besides ``port`` are optional — omit a key to leave it unchanged.
     """
     port = body.get("port") or None
     _config["argyll_port"] = port
@@ -214,6 +236,25 @@ def set_argyll_port(body: dict):
         _config["argyll_correction"] = correction_path
         logger.info("Argyll correction path set to %r (runtime only)", correction_path)
         response["argyll_correction"] = correction_path
+    if "refresh_mode" in body:
+        refresh_mode = body.get("refresh_mode") or None
+        if refresh_mode not in (None, "refresh", "non_refresh"):
+            raise HTTPException(400, "refresh_mode must be 'refresh', 'non_refresh', or null.")
+        _config["argyll_refresh_mode"] = refresh_mode
+        logger.info("Argyll refresh mode set to %r (runtime only)", refresh_mode)
+        response["refresh_mode"] = refresh_mode
+    if "refresh_rate_hz" in body:
+        refresh_rate_hz = body.get("refresh_rate_hz") or None
+        _config["argyll_refresh_rate_hz"] = refresh_rate_hz
+        logger.info("Argyll refresh rate set to %r (runtime only)", refresh_rate_hz)
+        response["refresh_rate_hz"] = refresh_rate_hz
+    if "integration_mode" in body:
+        integration_mode = body.get("integration_mode") or None
+        if integration_mode not in (None, "non_adaptive", "averaging"):
+            raise HTTPException(400, "integration_mode must be 'non_adaptive', 'averaging', or null.")
+        _config["argyll_integration_mode"] = integration_mode
+        logger.info("Argyll integration mode set to %r (runtime only)", integration_mode)
+        response["integration_mode"] = integration_mode
     return response
 
 
@@ -262,6 +303,9 @@ async def trigger_measure():
             spotread_path=_config.get("argyll_spotread_path", "spotread"),
             timeout=_config.get("argyll_timeout_s", 20.0),
             correction_path=_config.get("argyll_correction"),
+            refresh_mode=_config.get("argyll_refresh_mode"),
+            refresh_rate_hz=_config.get("argyll_refresh_rate_hz"),
+            integration_mode=_config.get("argyll_integration_mode"),
         )
         if not result["ok"]:
             raise HTTPException(502, result.get("error", "Measurement failed"))
@@ -325,6 +369,9 @@ async def trigger_measure_sequence(body: dict):
                 spotread_path=_config.get("argyll_spotread_path", "spotread"),
                 timeout=_config.get("argyll_timeout_s", 20.0),
                 correction_path=_config.get("argyll_correction"),
+                refresh_mode=_config.get("argyll_refresh_mode"),
+                refresh_rate_hz=_config.get("argyll_refresh_rate_hz"),
+                integration_mode=_config.get("argyll_integration_mode"),
             )
         else:
             result = {"ok": False, "error": f"Unknown backend: {backend!r}"}


### PR DESCRIPTION
## 📺 Overview

Closes #600

### What does this PR do?
* **Type of change:** [ ] Bug fix | [x] New feature | [ ] Refactoring | [ ] CI/CD or Tooling
* **Component(s) affected:** ArgyllCMS wrapper (`tools/zro-bridge`), backend API (`server.py`), Prepare page instrument panel UI

---

## 🛠️ Technical Context & Implementation

* **The Problem:** `spotread` reads on flicker-prone panels (PWM-dimmed backlights, some VA/edge-lit LCDs) can be noisy or biased because the meter's adaptive-integration timing beats against the panel's refresh behavior. The wrapper always called `spotread -e -O` with no display-type or timing hints.
* **The Solution:** Added three opt-in settings — `argyll_refresh_mode` (`"refresh"`/`"non_refresh"` → `spotread -Y r`/`-Y n`), `argyll_refresh_rate_hz` (→ `-Y R:<rate>`), and `argyll_integration_mode` (`"non_adaptive"`/`"averaging"` → `-Y A`/`-Y a`). Flags verified against ArgyllCMS's `spotread` docs/usage text (`-y`/`-Y` sub-flags), not guessed. Threaded through `read_xyz()`'s command construction (same pattern as the existing `correction_path` → `-X` handling), `bridge.py`'s `/config/argyll-port` and `/instruments` endpoints, `server.py`'s `.prefs.json` `argyll.*` namespace, and a new Argyll meter card on the Prepare page's instrument panel (alongside the existing meter/correction-file controls).
* **Impact on existing workflows/APIs:** None by default — all three settings default to unset/`null`, which reproduces today's `spotread -e -O` command byte-for-byte (covered by a dedicated test). `POST /config/argyll-port` and `POST /api/zro/bridge/instrument` gained new optional body fields; existing callers omitting them are unaffected.

### Mathematical / Data Integrity Checks (If Applicable)
* [x] N/A — no matrix/LUT math touched; this only changes the `spotread` CLI invocation and config plumbing.

---

## 🧪 Testing & Validation

### Environment Details
* **OS / Target Display:** N/A — no physical meter or TV available in this environment
* **Hardware/Mock Used:** Simulated `spotread` output via mocked `subprocess.run` (no real ArgyllCMS installation or meter required)

### Verification Steps
1. `python -m pytest tests/test_argyll_backend.py tests/test_zro_bridge.py -q` — new tests cover each `-Y` flag individually, flag ordering when combined with `-X`/port, the default-unset byte-identical command, and the bridge/server endpoint plumbing (422/400 on invalid values).
2. `python -m pytest tests/ --no-cov` — full suite: 1534 passed, 2 skipped.
3. `npx vitest run` (frontend) — 136 passed, including new `ArgyllCard.test.jsx` coverage of the settings card (scan, save, defaults, error handling).

### Firmware / TV Settings
* [ ] Not verified against real display firmware — no physical meter/TV in this environment; verification is via mocked `spotread` subprocess output only.

---

## 📸 Visual Evidence (UI / Plot Changes)
<details>
<summary><b>Click to expand Visuals</b></summary>

### Before
No frontend UI existed for ArgyllCMS meter/correction selection — those settings were backend-API-only.

### After
Added an "Argyll meter" settings card (`frontend/src/components/ArgyllCard.jsx`) to the Prepare page's instrument panel, shown when `backend: "argyll"` is active. Includes meter/port scan+select, CCMX/CCSS correction path, and the new refresh-mode / refresh-rate / integration-mode controls, all persisted via `.prefs.json` and pushed to the bridge on save.

</details>

---

## 🧼 Checklist
* [x] Code adheres to project style guidelines (formatting, typing, linting).
* [x] Unit tests added/updated and passing.
* [x] Documentation (README, inline docstrings) updated to reflect changes.
* [x] No credentials, local absolute paths, or hardware-specific hardcoding leaked.
