### PR TITLE
Fix Round-1 damping bypass when adjustment 'from' is null

### DIFF
--- a/calcore/llm.py
+++ b/calcore/llm.py
@@ -1536,6 +1536,14 @@ def _apply_round1_damping(
     Only the first round is damped here (there is no prior residual to trend
     against yet). Later rounds rely on the prior-rounds history fed back into
     the prompt, which already tells the model what did and didn't work.
+
+    A numeric ``to`` with a null ``from`` has no baseline to damp against —
+    the schema permits ``"from": null`` for cases where the model doesn't know
+    the current value. Passing such an adjustment through as-is on round 1
+    would apply the full, undamped absolute value and bypass the clamp
+    entirely (#579), so it is dropped rather than auto-applied undamped.
+    Non-numeric targets (e.g. an enum/preset like "Movie") aren't a damping
+    concern at all and pass through unchanged.
     """
     if rounds_used != 0:
         return adjustments
@@ -1544,7 +1552,17 @@ def _apply_round1_damping(
     for adj in adjustments:
         from_val = _safe_float(adj.get("from"))
         to_val = _safe_float(adj.get("to"))
-        if from_val is None or to_val is None or from_val == to_val:
+        if to_val is None:
+            damped.append(adj)
+            continue
+        if from_val is None:
+            logger.warning(
+                "_apply_round1_damping: dropping round-1 adjustment for %s/%s "
+                "— numeric 'to' with null 'from' has no baseline to damp against",
+                adj.get("menu"), adj.get("setting"),
+            )
+            continue
+        if from_val == to_val:
             damped.append(adj)
             continue
         new_to = from_val + _ROUND1_DAMPING_FACTOR * (to_val - from_val)

--- a/tests/test_adaptive_loop.py
+++ b/tests/test_adaptive_loop.py
@@ -1085,6 +1085,35 @@ class TestPredictNextSettings:
         assert result is not None
         assert result.adjustments[0]["to"] == "Movie"
 
+    def test_round1_drops_numeric_absolute_adjustment_with_null_from(self):
+        # #579: a compliant model can emit "from": null with a numeric "to" on
+        # round 1. Passing that through undamped would bypass the ~0.55 clamp
+        # entirely, so it must be dropped rather than auto-applied as-is.
+        llm = _llm_mock()
+        plan = {
+            "adjustments": [
+                {
+                    "menu": "White Balance",
+                    "setting": "R Gain",
+                    "from": None,
+                    "to": -20,
+                    "scope": "global",
+                    "reason": "Full correction, no known current value.",
+                }
+            ],
+            "next_step": "rerun_grayscale",
+            "confidence": 0.9,
+        }
+        p, mock_urlopen = _patch_urlopen(plan)
+        try:
+            result = predict_next_settings(
+                _summary(avg_de=5.0, max_de=7.0), _cfg_mock(), "post_grayscale", llm
+            )
+        finally:
+            p.stop()
+        assert result is not None
+        assert result.adjustments == []
+
     def test_round2_deltas_are_not_damped_by_the_deterministic_clamp(self):
         # rounds_used == 1 (one prior round already recorded): the clamp only
         # backstops Round 1, so a full delta here should pass through as-is —


### PR DESCRIPTION
## 📺 Overview

Closes #579

### What does this PR do?
* **Type of change:** [x] Bug fix
* **Component(s) affected:** `calcore/llm.py` — Round-1 deterministic damping (`_apply_round1_damping`)

---

## 🛠️ Technical Context & Implementation

* **The Problem:** `_apply_round1_damping` enforces the "conservative Round-1 correction factor (~0.55)" invariant deterministically, but only when both `from` and `to` are present and numeric. The prompt schema explicitly permits `"from": null`, so a compliant model could emit a numeric absolute `to` with `from: null` on round 1 and the clamp would be skipped entirely — the full, undamped value passed straight through to `_generate_*_steps` in `calibrator/osd.py`, which renders it directly as the OSD target value with no re-damping downstream. This confirms the defect described in the issue.
* **The Solution:** When an adjustment's `to` is numeric but `from` is `None` on round 1, there is no baseline to damp against, so the adjustment is now dropped (with a warning logged) instead of being auto-applied undamped. Non-numeric targets (e.g. an enum/preset like `"Movie"`) are left untouched, since they were never a damping concern in the first place.
* **Impact on existing workflows/APIs:** No change to `NextSettingsPrediction`'s shape. Only round-1 adjustments that were an undamped-bypass case (numeric `to`, null `from`) are now excluded from the result instead of silently passing through unclamped.

### Mathematical / Data Integrity Checks (If Applicable)
* [x] Floating-point precision or data truncation risks have been addressed (no change to existing rounding logic for the damped-value path).

---

## 🧪 Testing & Validation

### Verification Steps
1. `python -m pytest tests/ -q --no-cov` — full suite passes.
2. Added `test_round1_drops_numeric_absolute_adjustment_with_null_from` in `tests/test_adaptive_loop.py`, asserting a round-1 numeric adjustment with `from: null` is dropped rather than passed through as an undamped absolute set.
3. Confirmed the existing `test_round1_damping_skips_adjustments_without_numeric_from` (non-numeric `to`, e.g. a preset name) is unaffected.

---

## 🧼 Checklist
* [x] Code adheres to project style guidelines (formatting, typing, linting).
* [x] Unit tests added/updated and passing.
* [ ] Documentation (README, inline docstrings) updated to reflect changes. (docstring on `_apply_round1_damping` updated in place)
* [x] No credentials, local absolute paths, or hardware-specific hardcoding leaked.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Sn4pG3VbpNwGK551QXH6Y)_