### PR TITLE
Fix color-patch targets to scale by measured peak, not fixed 100 nits

### DIFF
--- a/calcore/targets.py
+++ b/calcore/targets.py
@@ -60,4 +60,13 @@ def target_xyz_for_patch(
         return xyY_to_xyz(white_point_xy[0], white_point_xy[1], target_y)
 
     matrix = detect_matrix(cfg.target_space)
-    return rgb_to_xyz(target_rgb, matrix)
+    xyz_at_100 = rgb_to_xyz(target_rgb, matrix)
+    # rgb_to_xyz() is normalized colorimetry (white -> Y=100). Color-patch
+    # targets must be compared against absolute measured XYZ (nits), so scale
+    # into the same relative colorimetry the grayscale branch above uses:
+    # target luminance relative to the display's measured peak, not a fixed
+    # 100-nit reference. Otherwise every display whose peak isn't exactly
+    # 100 nits reports false color dE (see issue #603).
+    peak = measured_peak_y if measured_peak_y and measured_peak_y > 0 else 100.0
+    scale = peak / 100.0
+    return (xyz_at_100[0] * scale, xyz_at_100[1] * scale, xyz_at_100[2] * scale)

--- a/tests/test_calcore/test_calcore.py
+++ b/tests/test_calcore/test_calcore.py
@@ -153,6 +153,48 @@ class AnalyzeTests(unittest.TestCase):
         self.assertIsNone(summary.grayscale_rows[1]["gamma"])
         self.assertIsNone(summary.gamma_midtones)
 
+    def test_analyze_color_de_is_zero_for_perfect_display_at_any_peak(self):
+        # Issue #603: color-patch targets were compared on a fixed 100-nit
+        # scale while grayscale targets scaled by the measured peak. A
+        # perfectly calibrated display at any peak other than 100 nits
+        # reported large, false color dE. Reproduce a flawless BT.709 SDR
+        # display at several peaks and confirm color dE stays ~0.
+        from calcore.spaces import BT709_RGB_TO_XYZ
+
+        gamma = 2.2
+
+        def ideal_xyz(r, g, b, peak, code_max=255):
+            lin = [(c / code_max) ** gamma for c in (r, g, b)]
+            return tuple(
+                sum(BT709_RGB_TO_XYZ[row][i] * lin[i] for i in range(3)) * peak
+                for row in range(3)
+            )
+
+        for peak in (100.0, 120.0, 300.0, 1000.0):
+            with self.subTest(peak=peak):
+                grays = (0, 64, 128, 191, 255)
+                patches = [
+                    Patch(f"{c},{c},{c}", c, c, c, ideal_xyz(c, c, c, peak), kind="grayscale")
+                    for c in grays
+                ]
+                patches += [
+                    Patch("255,0,0", 255, 0, 0, ideal_xyz(255, 0, 0, peak), kind="color"),
+                    Patch("0,255,0", 0, 255, 0, ideal_xyz(0, 255, 0, peak), kind="color"),
+                    Patch("0,0,255", 0, 0, 255, ideal_xyz(0, 0, 255, peak), kind="color"),
+                ]
+
+                summary = analyze(
+                    patches,
+                    AnalysisConfig(
+                        mode="sdr", eotf="gamma22", target_space="bt709", code_max=255
+                    ),
+                )
+
+                self.assertLess(summary.grayscale_avg_de or 999.0, 0.5)
+                self.assertLess(summary.color_100_avg_de or 999.0, 0.5)
+                for row in summary.color_rows:
+                    self.assertLess(row["dE2000"], 0.5)
+
 
 class DeterminePhaseTests(unittest.TestCase):
     def make_summary(self, **overrides):


### PR DESCRIPTION
## 📺 Overview

Closes #603

### What does this PR do?
* **Type of change:** [x] Bug fix
* **Component(s) affected:** `calcore` analysis/target pipeline (color-patch ΔE computation)

---

## 🛠️ Technical Context & Implementation

* **The Problem:** `analyze()` compared **absolute measured XYZ (nits)** against color-patch targets computed in **normalized colorimetry** (`rgb_to_xyz()` always scales white to Y=100), while grayscale targets were correctly scaled by the measured display peak (`measured_peak_y_effective`). Any display whose peak wasn't exactly 100 nits reported large, false color ΔE even when perfectly calibrated. Since `color_100_*`/`color_75_*` metrics feed `determine_phase()` (CMS unlock/verify gating), the LLM adjustment prompts, and `assess_convergence()`, the pipeline could never converge on colors for non-100-nit displays.
* **The Solution:** `target_xyz_for_patch()` (`calcore/targets.py`) now scales the color-patch target XYZ by `measured_peak_y_effective / 100.0` before returning it, putting it in the same relative colorimetry as the grayscale branch and matching the calibrator-side `target_nits_for_colour()` convention. This is the single place the fixed-100 vs. absolute-nits mismatch is resolved.
* **Impact on existing workflows/APIs:** None for the common case — sessions measured at peak ≈100 nits (the existing test fixtures) are unaffected since the scale factor is 1.0. Sessions on displays with any other peak luminance now get correct color ΔE instead of falsely-inflated values.

### Mathematical / Data Integrity Checks (If Applicable)
* [x] Matrix transformations or LUT calculations have been validated (reproduced the issue's exact repro script; color ΔE now ~0 for a perfectly calibrated display at peaks 100/120/300/1000 nits).
* [x] Floating-point precision or data truncation risks have been addressed (no new precision issues; straightforward linear scale).

---

## 🧪 Testing & Validation

### Verification Steps
1. Added `test_analyze_color_de_is_zero_for_perfect_display_at_any_peak` to `tests/test_calcore/test_calcore.py`, covering peaks 100/120/300/1000 nits as requested in the issue.
2. Ran the issue's exact repro script directly — before the fix: `dE2000 ≈ [25.06, 25.04, 20.86]`; after the fix: `dE2000 ≈ [0.0, 0.0, 0.0]`.
3. Ran the full test suite (`python -m pytest tests/`): 1526 passed, no regressions.
4. Ran `ruff check` on the changed files: clean.

---

## 🧼 Checklist
* [x] Code adheres to project style guidelines (formatting, typing, linting).
* [x] Unit tests added/updated and passing.
* [ ] Documentation (README, inline docstrings) updated to reflect changes. *(not needed — internal calculation fix, no public API/behavioral doc changes)*
* [x] No credentials, local absolute paths, or hardware-specific hardcoding leaked.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MTrwqxcoKzdqBXoEkkzs96)_