### PR TITLE
fix: don't count colour rows in grayscale groups as unknown_rows (#607)

### DIFF
--- a/calibrator/zro_import.py
+++ b/calibrator/zro_import.py
@@ -561,8 +561,10 @@ def _process_grayscale_group(
     gray_rows: List[_Row] = []
     for row in group:
         patch_type = _classify(row.r, row.g, row.b)
-        if patch_type not in {"grayscale", "black", "white"}:
+        if patch_type == "unknown":
             result.unknown_rows += 1
+            continue
+        if patch_type not in {"grayscale", "black", "white"}:
             continue
         gray_rows.append(row)
 

--- a/calibrator/zro_import.py
+++ b/calibrator/zro_import.py
@@ -565,6 +565,7 @@ def _process_grayscale_group(
             result.unknown_rows += 1
             continue
         if patch_type not in {"grayscale", "black", "white"}:
+            # Colour types (red, green, etc.) are handled by _extract_colour_rows()
             continue
         gray_rows.append(row)
 

--- a/tests/test_zro_import.py
+++ b/tests/test_zro_import.py
@@ -614,6 +614,12 @@ class TestMixedGroupColourExtraction:
         r = parse_zro_csv(_MIXED_GROUP_CSV)
         assert len(r.pre_measurements) == 11
 
+    def test_colour_rows_in_mixed_group_not_counted_as_unknown(self):
+        """Colour rows in a grayscale-dominated group are imported by
+        _extract_colour_rows and must NOT be double-counted as unknown."""
+        r = parse_zro_csv(_MIXED_GROUP_CSV)
+        assert r.unknown_rows == 0
+
 
 class TestImportZroEndpoint:
 


### PR DESCRIPTION
## 📺 Overview

When a ZRO export group is classified as `grayscale` but contains colour (CMS) rows, those colour rows were correctly imported by `_extract_colour_rows()` but also incorrectly counted as `unknown_rows` by `_process_grayscale_group()`. The operator sees a false "N rows could not be classified" warning even though every row was successfully imported.

Closes #607

### What does this PR do?
* **Type of change:** [x] Bug fix | [ ] New feature | [ ] Refactoring | [ ] CI/CD or Tooling
* **Component(s) affected:** ZRO import parser (`calibrator/zro_import.py`)

---

## 🛠️ Technical Context & Implementation

* **The Problem:** `_process_grayscale_group()` increments `unknown_rows` for any row where `_classify()` returns a type not in `{grayscale, black, white}`. This includes colour types (red, green, blue, etc.) that `_extract_colour_rows()` — called immediately after — handles correctly. Result: colour rows are double-handled (imported + falsely flagged as unknown).
* **The Solution:** Only count a row as unknown when `_classify()` actually returns `"unknown"`. Colour-type rows are now skipped silently in the grayscale group processor, since `_extract_colour_rows` owns them.
* **Impact on existing workflows/APIs:** None — this only affects the `unknown_rows` counter. All measurements are imported identically. The import summary will now correctly report `0` unknown rows for mixed groups.

### Mathematical / Data Integrity Checks (If Applicable)
* [ ] Matrix transformations or LUT calculations have been validated.
* [ ] Floating-point precision or data truncation risks have been addressed.

---

## 🧪 Testing & Validation

### Environment Details
* **OS / Target Display:** macOS (CI)
* **Hardware/Mock Used:** Unit tests only — no hardware required

### Verification Steps
1. `pytest tests/test_zro_import.py -v -m "not hardware"` — all 107 tests pass
2. New regression test `test_colour_rows_in_mixed_group_not_counted_as_unknown` asserts `unknown_rows == 0` for the mixed-group fixture
3. `python -m compileall calibrator/zro_import.py` — passes

### Firmware / TV Settings
* [ ] Verified against target display firmware version — N/A
* [ ] Local Dimming set to Medium during test runs — N/A
* [ ] Correct white point mode used (Warm1 for HDR, Warm2 for SDR) — N/A

---

## 📸 Visual Evidence (UI / Plot Changes)
<!-- No UI changes — backend import fix only -->

---

## 🧼 Checklist
* [x] Code adheres to project style guidelines (formatting, typing, linting).
* [x] Unit tests added/updated and passing.
* [ ] Documentation (README, inline docstrings) updated to reflect changes. — N/A (diagnostic counter fix, no user-facing docs)
* [x] No credentials, local absolute paths, or hardware-specific hardcoding leaked.