### PR TITLE
Fix #604: linearize color-patch targets with the session EOTF

### DIFF
--- a/calcore/targets.py
+++ b/calcore/targets.py
@@ -22,20 +22,34 @@ def _linear_fraction_of_peak(
     Shares the session EOTF dispatch (PQ / BT.1886 / gamma) so grayscale and
     color-patch targets linearize signal the same way before either is
     turned into an XYZ target (see issue #604 — color patches previously
-    skipped this step entirely).
+    skipped this step entirely). The return value is always a fraction in
+    [0, 1] where 1.0 represents *peak*; multiply by an absolute peak (nits)
+    to get an absolute target luminance, or feed several channels' fractions
+    directly into rgb_to_xyz() for a color-patch target.
+
+    Per-EOTF calling convention:
+    - PQ: pq_target_nits() returns absolute ST.2084 nits for signal *n*,
+      clipped at *peak*; dividing by *peak* expresses that as the same
+      0..1 fraction the other branches return.
+    - BT.1886: bt1886_eotf(v, lw, lb, gamma) expects white/black levels
+      (lw/lb) in the same units. Passing lw=1.0 and lb=black_frac (the
+      display's measured black normalized to *peak* = 1.0) returns the
+      fractional curve directly — algebraically identical to calling
+      bt1886_eotf(n, peak, measured_black_y, gamma) and then dividing by
+      peak, just without the extra division.
+    - gamma: n**gamma is already a 0..1 fraction of peak (n=1 -> 1.0), no
+      rescaling needed.
     """
-    if cfg.mode.lower() == "hdr" or cfg.eotf.lower() == "pq":
+    eotf = (cfg.eotf or "gamma22").lower()
+    mode = (cfg.mode or "sdr").lower()
+    if mode == "hdr" or eotf == "pq":
         return pq_target_nits(n, peak) / peak
-    elif cfg.eotf.lower() == "bt1886":
-        gamma = 2.2 if cfg.mode.lower() == "sdr" else 2.4
+    elif eotf == "bt1886":
+        gamma = 2.2 if mode == "sdr" else 2.4
         black_frac = measured_black_y / peak if peak > 0 else 0.0
         return bt1886_eotf(n, 1.0, black_frac, gamma=gamma)
     else:
-        gamma = (
-            2.2
-            if cfg.eotf.lower() in ("gamma22", "2.2", "gamma")
-            else float(cfg.eotf)
-        )
+        gamma = 2.2 if eotf in ("gamma22", "2.2", "gamma") else float(eotf)
         return gamma_eotf(n, gamma=gamma)
 
 

--- a/calcore/targets.py
+++ b/calcore/targets.py
@@ -11,6 +11,34 @@ from .spaces import detect_matrix, rgb_to_xyz
 logger = logging.getLogger(__name__)
 
 
+def _linear_fraction_of_peak(
+    n: float,
+    cfg: AnalysisConfig,
+    peak: float,
+    measured_black_y: float,
+) -> float:
+    """Linearize a normalized code value *n* into a 0..1 fraction of peak luminance.
+
+    Shares the session EOTF dispatch (PQ / BT.1886 / gamma) so grayscale and
+    color-patch targets linearize signal the same way before either is
+    turned into an XYZ target (see issue #604 — color patches previously
+    skipped this step entirely).
+    """
+    if cfg.mode.lower() == "hdr" or cfg.eotf.lower() == "pq":
+        return pq_target_nits(n, peak) / peak
+    elif cfg.eotf.lower() == "bt1886":
+        gamma = 2.2 if cfg.mode.lower() == "sdr" else 2.4
+        black_frac = measured_black_y / peak if peak > 0 else 0.0
+        return bt1886_eotf(n, 1.0, black_frac, gamma=gamma)
+    else:
+        gamma = (
+            2.2
+            if cfg.eotf.lower() in ("gamma22", "2.2", "gamma")
+            else float(cfg.eotf)
+        )
+        return gamma_eotf(n, gamma=gamma)
+
+
 def target_xyz_for_patch(
     patch: Patch,
     code_max: int,
@@ -38,35 +66,30 @@ def target_xyz_for_patch(
         _normalize_code(patch.g_target, cfg.signal_range) / code_max,
         _normalize_code(patch.b_target, cfg.signal_range) / code_max,
     )
+    peak = measured_peak_y if measured_peak_y and measured_peak_y > 0 else 100.0
 
     if patch.is_grayscale:
-        n = _normalize_code(patch.r_target, cfg.signal_range) / code_max
-        if cfg.mode.lower() == "hdr" or cfg.eotf.lower() == "pq":
-            # PQ (ST.2084) is an absolute EOTF: the signal encodes nits
-            # directly, not a fraction of peak. Clip at the display's
-            # measured peak (its tone-map knee).
-            target_y = pq_target_nits(n, measured_peak_y)
-        elif cfg.eotf.lower() == "bt1886":
-            # Use target's gamma: 2.2 for SDR (per SDR_TARGET in models.py), 2.4 for others
-            gamma = 2.2 if cfg.mode.lower() == "sdr" else 2.4
-            target_y = bt1886_eotf(n, measured_peak_y, measured_black_y, gamma=gamma)
-        else:
-            gamma = (
-                2.2
-                if cfg.eotf.lower() in ("gamma22", "2.2", "gamma")
-                else float(cfg.eotf)
-            )
-            target_y = gamma_eotf(n, gamma=gamma) * measured_peak_y
+        n = target_rgb[0]
+        target_y = _linear_fraction_of_peak(n, cfg, peak, measured_black_y) * peak
         return xyY_to_xyz(white_point_xy[0], white_point_xy[1], target_y)
 
+    # Color-patch targets must be linearized with the same session EOTF as
+    # grayscale before matrixing to XYZ: signal RGB is gamma/PQ/BT.1886-encoded,
+    # not linear light, so feeding it straight into rgb_to_xyz() (a linear-light
+    # matrix) understates the EOTF's compression at non-100% signal levels
+    # (see issue #604).
+    linear_rgb = (
+        _linear_fraction_of_peak(target_rgb[0], cfg, peak, measured_black_y),
+        _linear_fraction_of_peak(target_rgb[1], cfg, peak, measured_black_y),
+        _linear_fraction_of_peak(target_rgb[2], cfg, peak, measured_black_y),
+    )
     matrix = detect_matrix(cfg.target_space)
-    xyz_at_100 = rgb_to_xyz(target_rgb, matrix)
+    xyz_at_100 = rgb_to_xyz(linear_rgb, matrix)
     # rgb_to_xyz() is normalized colorimetry (white -> Y=100). Color-patch
     # targets must be compared against absolute measured XYZ (nits), so scale
     # into the same relative colorimetry the grayscale branch above uses:
     # target luminance relative to the display's measured peak, not a fixed
     # 100-nit reference. Otherwise every display whose peak isn't exactly
     # 100 nits reports false color dE (see issue #603).
-    peak = measured_peak_y if measured_peak_y and measured_peak_y > 0 else 100.0
     scale = peak / 100.0
     return (xyz_at_100[0] * scale, xyz_at_100[1] * scale, xyz_at_100[2] * scale)

--- a/tests/test_calcore/test_calcore.py
+++ b/tests/test_calcore/test_calcore.py
@@ -265,6 +265,74 @@ class AnalyzeTests(unittest.TestCase):
                 self.assertIsNotNone(summary.color_75_avg_de)
                 self.assertLess(summary.color_75_avg_de, 0.5)
 
+    def test_target_xyz_for_patch_falls_back_to_100_peak_when_measured_peak_missing(self):
+        # PR #612 review: measured_peak_y can be None or 0.0 (e.g. no
+        # grayscale patches measured yet). Confirm target_xyz_for_patch
+        # doesn't raise (no ZeroDivisionError from the color EOTF-linearize
+        # path) and falls back to the same 100.0 peak used elsewhere.
+        patch = Patch("191,0,0", 191, 0, 0, (0.0, 0.0, 0.0), kind="color")
+        cfg = AnalysisConfig(mode="sdr", eotf="gamma22", target_space="bt709", code_max=255)
+        xyz_explicit_100 = target_xyz_for_patch(patch, 255, cfg, 100.0, 0.0)
+
+        for missing_peak in (None, 0.0):
+            with self.subTest(measured_peak_y=missing_peak):
+                xyz_missing = target_xyz_for_patch(patch, 255, cfg, missing_peak, 0.0)
+                for i in range(3):
+                    self.assertAlmostEqual(xyz_missing[i], xyz_explicit_100[i], places=6)
+
+    def test_linear_fraction_of_peak_guards_against_none_mode_and_eotf(self):
+        # PR #612 review: cfg.mode / cfg.eotf must not be assumed non-None —
+        # _linear_fraction_of_peak() calls .lower() on both, which would
+        # raise AttributeError on a malformed config without a guard.
+        patch = Patch("128,128,128", 128, 128, 128, (0.0, 0.0, 0.0), kind="grayscale")
+        cfg = AnalysisConfig(target_space="bt709", code_max=255)
+        cfg.mode = None
+        cfg.eotf = None
+
+        xyz = target_xyz_for_patch(patch, 255, cfg, 100.0, 0.0)
+        self.assertIsInstance(xyz, tuple)
+
+    def test_color_75_fix_unlocks_cms_to_verify_phase_gate(self):
+        # PR #612 review: prove the fix's real-world effect, not just that
+        # dE is small in isolation. Before #604 was fixed, a perfectly
+        # calibrated display's 75% color patches reported dE ~6.67, which
+        # failed determine_phase()'s color_ok <= 3.0 gate (calcore/phase.py)
+        # and stuck a flawless display in the "cms" phase forever.
+        from calcore.eotf import gamma_eotf
+        from calcore.spaces import BT709_RGB_TO_XYZ
+
+        code_max = 255
+        peak = 100.0
+        gamma = 2.2
+
+        def lin(n):
+            return gamma_eotf(n, gamma=gamma)
+
+        def ideal_xyz(r, g, b):
+            # BT709_RGB_TO_XYZ is normalized so (1,1,1) maps to the D65
+            # white point at Y=100; reusing it for r==g==b grayscale patches
+            # gives the same XYZ target_xyz_for_patch derives via xyY_to_xyz.
+            lin_rgb = [lin(c / code_max) for c in (r, g, b)]
+            return tuple(
+                peak * sum(BT709_RGB_TO_XYZ[row][i] * lin_rgb[i] for i in range(3))
+                for row in range(3)
+            )
+
+        def gray_patch(code):
+            return Patch(str(code), code, code, code, ideal_xyz(code, code, code), kind="grayscale")
+
+        def color_patch(label, r, g, b):
+            return Patch(label, r, g, b, ideal_xyz(r, g, b), kind="color")
+
+        patches = [gray_patch(0), gray_patch(code_max), color_patch("191,0,0", 191, 0, 0)]
+
+        summary = analyze(
+            patches,
+            AnalysisConfig(mode="sdr", eotf="gamma22", target_space="bt709", code_max=code_max),
+        )
+
+        self.assertEqual(determine_phase(summary, "cms"), "verify")
+
 
 class DeterminePhaseTests(unittest.TestCase):
     def make_summary(self, **overrides):

--- a/tests/test_calcore/test_calcore.py
+++ b/tests/test_calcore/test_calcore.py
@@ -237,11 +237,11 @@ class AnalyzeTests(unittest.TestCase):
                         return bt1886_eotf(n, 1.0, black_y / peak, gamma=2.2)
                     return pq_target_nits(n, peak) / peak
 
-                def gray_patch(code):
+                def gray_patch(code, peak=peak):
                     y = lin_frac(code / code_max) * peak
                     return Patch(str(code), code, code, code, (0.0, y, 0.0), kind="grayscale")
 
-                def color_patch(label, r, g, b):
+                def color_patch(label, r, g, b, matrix=matrix, peak=peak):
                     lin = [lin_frac(c / code_max) for c in (r, g, b)]
                     return Patch(label, r, g, b, ideal_xyz(matrix, lin, peak), kind="color")
 

--- a/tests/test_calcore/test_calcore.py
+++ b/tests/test_calcore/test_calcore.py
@@ -85,7 +85,9 @@ class AnalyzeTests(unittest.TestCase):
                 768,
                 0,
                 0,
-                (30.92856, 15.947926, 1.4498115),
+                # EOTF-linearized target for a 75%-signal (768/1023) red patch
+                # under gamma 2.2 (issue #604) — not the raw-signal XYZ.
+                (21.947105836855492, 11.316476646700588, 1.0287706526265932),
                 kind="color",
             ),
             Patch(
@@ -93,7 +95,7 @@ class AnalyzeTests(unittest.TestCase):
                 0,
                 768,
                 0,
-                (26.8188255, 53.637651, 8.9396085),
+                (19.030350229884174, 38.06070045976835, 6.343450076628058),
                 kind="color",
             ),
         ]
@@ -105,7 +107,10 @@ class AnalyzeTests(unittest.TestCase):
 
         self.assertEqual(summary.meta["patch_count"], 5)
         self.assertLess(summary.grayscale_avg_de or 999.0, 0.5)
-        self.assertLess(summary.color_75_avg_de or 999.0, 1.0)
+        # Note: "x or 999.0" would misfire here since a perfectly EOTF-linearized
+        # target/measurement pair legitimately yields dE == 0.0 (falsy).
+        self.assertIsNotNone(summary.color_75_avg_de)
+        self.assertLess(summary.color_75_avg_de, 1.0)
         self.assertLess(abs((summary.gamma_midtones or 0.0) - 2.2), 0.1)
         self.assertEqual(summary.grayscale_over_3, 0)
 
@@ -194,6 +199,71 @@ class AnalyzeTests(unittest.TestCase):
                 self.assertLess(summary.color_100_avg_de or 999.0, 0.5)
                 for row in summary.color_rows:
                     self.assertLess(row["dE2000"], 0.5)
+
+    def test_analyze_75pct_color_de_is_zero_for_perfect_display(self):
+        # Issue #604: target_xyz_for_patch() fed gamma/PQ/BT.1886-encoded
+        # signal RGB straight into the linear-light RGB->XYZ matrix for color
+        # patches, only applying the session EOTF for grayscale. A 100%
+        # patch is unaffected (signal == linear at the top of the range),
+        # but a 75% patch's target luminance was badly inflated. Reproduce a
+        # flawless display's 75% R/G/B patches (measured XYZ computed from
+        # the *linearized* signal, independently of target_xyz_for_patch)
+        # for each supported EOTF and confirm color_75_avg_de stays ~0.
+        from calcore.eotf import bt1886_eotf, gamma_eotf, pq_target_nits
+        from calcore.spaces import BT2020_RGB_TO_XYZ, BT709_RGB_TO_XYZ
+
+        code_max = 255
+
+        def ideal_xyz(matrix, lin_fracs, peak):
+            return tuple(
+                peak * sum(matrix[row][i] * lin_fracs[i] for i in range(3))
+                for row in range(3)
+            )
+
+        cases = [
+            # (eotf, mode, target_space, matrix, peak, black_y)
+            ("gamma22", "sdr", "bt709", BT709_RGB_TO_XYZ, 100.0, 0.0),
+            ("bt1886", "sdr", "bt709", BT709_RGB_TO_XYZ, 100.0, 0.05),
+            ("pq", "hdr", "bt2020", BT2020_RGB_TO_XYZ, 1000.0, 0.0),
+        ]
+
+        for eotf, mode, target_space, matrix, peak, black_y in cases:
+            with self.subTest(eotf=eotf):
+
+                def lin_frac(n, eotf=eotf, peak=peak, black_y=black_y):
+                    if eotf == "gamma22":
+                        return gamma_eotf(n, gamma=2.2)
+                    if eotf == "bt1886":
+                        return bt1886_eotf(n, 1.0, black_y / peak, gamma=2.2)
+                    return pq_target_nits(n, peak) / peak
+
+                def gray_patch(code):
+                    y = lin_frac(code / code_max) * peak
+                    return Patch(str(code), code, code, code, (0.0, y, 0.0), kind="grayscale")
+
+                def color_patch(label, r, g, b):
+                    lin = [lin_frac(c / code_max) for c in (r, g, b)]
+                    return Patch(label, r, g, b, ideal_xyz(matrix, lin, peak), kind="color")
+
+                patches = [gray_patch(0), gray_patch(code_max)]
+                patches += [
+                    color_patch("191,0,0", 191, 0, 0),
+                    color_patch("0,191,0", 0, 191, 0),
+                    color_patch("0,0,191", 0, 0, 191),
+                ]
+
+                summary = analyze(
+                    patches,
+                    AnalysisConfig(
+                        mode=mode, eotf=eotf, target_space=target_space, code_max=code_max
+                    ),
+                )
+
+                # A perfect display's linearized 75% patches legitimately give
+                # dE == 0.0 (falsy), so check for None explicitly rather than
+                # using the "x or 999.0" pattern.
+                self.assertIsNotNone(summary.color_75_avg_de)
+                self.assertLess(summary.color_75_avg_de, 0.5)
 
 
 class DeterminePhaseTests(unittest.TestCase):


### PR DESCRIPTION
## 📺 Overview

Closes #604

### What does this PR do?
* **Type of change:** [x] Bug fix | [ ] New feature | [ ] Refactoring | [ ] CI/CD or Tooling
* **Component(s) affected:** calcore (color-patch target computation / analysis pipeline)

---

## 🛠️ Technical Context & Implementation

* **The Problem:** `target_xyz_for_patch()` fed gamma/PQ/BT.1886-encoded signal RGB straight into the linear-light RGB→XYZ matrix for color patches, while grayscale targets correctly ran the same signal through the session EOTF first. A 100% patch was unaffected (signal == linear at the top of the range), but any non-100% color patch — most notably the "75%" saturation bucket that gates CMS→verify phase progression — got a badly inflated target luminance (ΔE ~6.7 on a perfectly calibrated display, per the issue repro).
* **The Solution:** Factored the EOTF dispatch (PQ / BT.1886 / gamma) that grayscale targets already used into a shared helper, `_linear_fraction_of_peak()`. Color-patch channels are now linearized with it before being matrixed to XYZ, then the existing #603 peak-scaling is applied on top. The grayscale branch was refactored to call the same helper (verified mathematically equivalent to the prior grayscale-only code) so both patch kinds share one EOTF dispatch, per the issue's suggested fix.
* **Impact on existing workflows/APIs:** No signature changes. Only the numeric value of color-patch targets changes (grayscale targets are unaffected). This corrects `color_75_avg_de` / `color_100_avg_de` reporting and the CMS→verify phase gate in `calcore/phase.py`, which reads those values directly.

### Mathematical / Data Integrity Checks (If Applicable)
* [x] Matrix transformations or LUT calculations have been validated.
* [x] Floating-point precision or data truncation risks have been addressed.

---

## 🧪 Testing & Validation

### Verification Steps
1. `python -m pytest tests/` — full suite passes (382 tests, 82.6% coverage).
2. Ran the issue's repro script directly against the fixed code: 75% red patch `(191,0,0)` on a perfect 100-nit BT.709 display now reports `dE2000 = 0.0` (previously `6.67`).
3. Updated the "near-target" fixture in `tests/test_calcore/test_calcore.py` (previously encoded the buggy non-linearized target as the measurement) to physically-correct EOTF-linearized values.
4. Added `test_analyze_75pct_color_de_is_zero_for_perfect_display`, covering 75% R/G/B patches for all three supported EOTFs (gamma22, bt1886, pq), asserting `color_75_avg_de < 0.5` on a perfect display.

---

## 🧼 Checklist
* [x] Code adheres to project style guidelines (formatting, typing, linting).
* [x] Unit tests added/updated and passing.
* [ ] Documentation (README, inline docstrings) updated to reflect changes. — not applicable, no public API/behavioral surface beyond the bug fix itself.
* [x] No credentials, local absolute paths, or hardware-specific hardcoding leaked.
