### PR TITLE
Fix #605: remove duplicated validate-and-append block in translate_corrections()

### DIFF
--- a/calibrator/osd.py
+++ b/calibrator/osd.py
@@ -601,17 +601,6 @@ def translate_corrections(
             )
             continue
 
-        has_schema = _has_schema_for_setting(tv_profile, adj)
-        if not has_schema and setting_key.startswith(("white_balance_", "cms.", "gamma", "backlight", "black_level", "contrast")):
-            # Known category but no schema - still generate steps from TV profile paths
-            valid_adjustments.append(adj)
-        elif has_schema:
-            valid_adjustments.append(adj)
-        else:
-            result.skipped_reasons.append(
-                f"Cannot map adjustment '{adj.get('setting', '?')}': no menu path found for this setting on {tv_profile.name}."
-            )
-
     if not valid_adjustments:
         return result
 

--- a/tests/test_osd_translator.py
+++ b/tests/test_osd_translator.py
@@ -402,6 +402,20 @@ class TestTranslateCorrections:
         assert len(result.skipped_reasons) >= 1
         assert "NonExistentControl" in result.skipped_reasons[0]
 
+    def test_one_step_per_adjustment(self):
+        """Regression test for #605: each mappable adjustment must produce
+        exactly one OSD step, not two, and step numbers must be unique."""
+        adjustments = [
+            _llm_adj("Red Gain", "", 0, -3, "x too high"),
+            _llm_adj("Green Gain", "", 0, 2, "y too low"),
+            _llm_adj("Blue Offset", "", 0, -1, "z shadows too cool"),
+        ]
+        result = translate_corrections(adjustments, U8G)
+        assert not result.skipped_reasons
+        assert len(result.steps) == len(adjustments)
+        step_numbers = [step.step_number for step in result.steps]
+        assert step_numbers == sorted(set(step_numbers))
+
     def test_step_to_dict(self):
         step = OSDStep(step_number=1, menu_path="A > B", action="Adjust X", value="5")
         d = step.to_dict()


### PR DESCRIPTION
## 📺 Overview

`translate_corrections()` in `calibrator/osd.py` appended every valid adjustment to `valid_adjustments` twice, producing two identical OSD steps per adjustment. For delta-form instructions, an operator following the on-screen checklist would apply the same correction twice (2x overshoot), fighting the Round-1 damping invariant from #579/#602.

Closes #605

### What does this PR do?
* **Type of change:** [x] Bug fix
* **Component(s) affected:** OSD Command Translator (`calibrator/osd.py`)

---

## 🛠️ Technical Context & Implementation

* **The Problem:** A rebase/merge left two copies of the same `has_schema` check-and-append block back-to-back inside the `for adj in normalised:` loop in `translate_corrections()` (`osd.py:592-613`). The first copy's accept branches fell through into the second, identical copy, so every mappable adjustment was appended twice and rendered as two duplicate `OSDStep`s.
* **The Solution:** Deleted the second, duplicated block. One `has_schema` check, one append, one `continue` on reject.
* **Impact on existing workflows/APIs:** `POST /api/session/{sid}/osd/translate` now returns exactly one OSD step per mappable adjustment instead of two. No API shape changes.

---

## 🧪 Testing & Validation

### Verification Steps
1. Reproduced the bug from the issue: 1 adjustment in → 2 identical steps out (before fix).
2. Applied the fix; same input now yields exactly 1 step.
3. Added `test_one_step_per_adjustment` to `tests/test_osd_translator.py`: N mappable adjustments in → exactly N steps out, with unique `step_number`s.
4. `python -m pytest --no-cov` → `1543 passed, 2 skipped` (full suite, no regressions).

---

## 🧼 Checklist
* [x] Code adheres to project style guidelines (formatting, typing, linting).
* [x] Unit tests added/updated and passing.
* [ ] Documentation (README, inline docstrings) updated to reflect changes. — N/A, internal bug fix.
* [x] No credentials, local absolute paths, or hardware-specific hardcoding leaked.


---
_Generated by [Claude Code](https://claude.ai/code/session_01ESmEZNVJTKEzBR4KVsULRk)_