### PR TITLE
Fix #606: forward session white point to LLM background analysis

### DIFF
--- a/server.py
+++ b/server.py
@@ -21,7 +21,7 @@ import threading
 from contextlib import asynccontextmanager, suppress as context_suppress
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional, Tuple
 from urllib.parse import urlparse
 
 import httpx
@@ -1105,6 +1105,7 @@ def _run_llm_background(
     tv_key: str = "",
     session_step_history: Optional[List[Dict[str, Any]]] = None,
     tv_settings: Optional[TVSettings] = None,
+    white_point: Optional[Tuple[float, float]] = None,
 ) -> None:
     _parsed_ep = urlparse(llm_cfg.endpoint)
     _safe_endpoint = f"{_parsed_ep.scheme}://{_parsed_ep.hostname or ''}{_parsed_ep.path}"
@@ -1128,7 +1129,7 @@ def _run_llm_background(
         },
     )
     try:
-        summary = _calcore_analyze(patches, cfg)
+        summary = _calcore_analyze(patches, cfg, white_point)
 
         # Build history block for this TV so the LLM has prior-session context.
         history_block: Optional[str] = None
@@ -1248,6 +1249,8 @@ def _maybe_trigger_llm(sid: str, session: Dict[str, Any]) -> None:
 
     patches = [_measurement_to_patch(m) for m in all_measurements]
     cfg = _session_to_analysis_config(session)
+    target = session.get("target")
+    white_point = target.white_point_xy if target else None
     llm_cfg = LLMConfig.from_dict(llm_cfg_dict, default_timeout=30.0)
     has_key = bool(llm_cfg_dict.get("api_key"))
     logger.info(
@@ -1274,6 +1277,7 @@ def _maybe_trigger_llm(sid: str, session: Dict[str, Any]) -> None:
             "tv_key": session.get("tv_key", ""),
             "session_step_history": session.get("llm_step_history", []),
             "tv_settings": tv_settings,
+            "white_point": white_point,
         },
         daemon=True,
     ).start()
@@ -1571,12 +1575,15 @@ def llm_run(sid: str):
 
     patches = [_measurement_to_patch(m) for m in all_measurements]
     cfg = _session_to_analysis_config(session)
+    target = session.get("target")
+    white_point = target.white_point_xy if target else None
     llm_cfg = LLMConfig.from_dict(llm_cfg_dict, default_timeout=30.0)
     phase_str = session.get("step", "baseline")
 
     t = threading.Thread(
         target=_run_llm_background,
         args=(sid, patches, cfg, phase_str, llm_cfg),
+        kwargs={"white_point": white_point},
         daemon=True,
     )
     t.start()

--- a/tests/test_maybe_trigger_llm_white_point.py
+++ b/tests/test_maybe_trigger_llm_white_point.py
@@ -1,0 +1,105 @@
+"""Regression test for #606.
+
+`_maybe_trigger_llm` must forward the session's target white point through to
+`_run_llm_background` -> `analyze()`, mirroring every other `_calcore_analyze`
+call site (`/gamut/diagnosis`, `/gamut/advise`, `/suggested-patches`,
+`/next-settings`). Before the fix, the LLM background path always analyzed
+against the D65 default regardless of the session's actual target, so a
+non-D65 target would silently produce a different Summary (and therefore a
+different adjustment plan) than every diagnostic endpoint in the same
+session.
+"""
+
+import unittest
+from unittest.mock import patch
+
+from calcore.colour import D65_xy
+from calcore.models import CalibrationTarget, CalMode, Measurement
+
+import server
+
+# D50 white point (x=0.3457, y=0.3585) — same fixture used in test_white_point.py
+D50_xy = (0.3457, 0.3585)
+
+
+class _SyncThread:
+    """Stand-in for threading.Thread that runs its target synchronously.
+
+    Lets the test observe the Summary handed to `_call_llm` without racing a
+    real background thread.
+    """
+
+    def __init__(self, target=None, args=(), kwargs=None, daemon=None):
+        self._target = target
+        self._args = args
+        self._kwargs = kwargs or {}
+
+    def start(self):
+        self._target(*self._args, **self._kwargs)
+
+
+def _wb_measurement(pct: int, meas_xyz=(50.0, 50.0, 50.0)) -> Measurement:
+    v = round(pct / 100 * 255)
+    return Measurement(
+        X=meas_xyz[0], Y=meas_xyz[1], Z=meas_xyz[2],
+        label=f"{pct}%", stimulus_rgb=(v, v, v),
+    )
+
+
+def _session(white_point_xy):
+    return {
+        "id": "test-sid",
+        "step": "baseline",
+        "llm_config": {"endpoint": "http://localhost:1234", "model": "test-model"},
+        "target": CalibrationTarget(mode=CalMode.SDR, white_point_xy=white_point_xy),
+        "wb_measurements": [_wb_measurement(50)],
+    }
+
+
+class TestMaybeTriggerLlmWhitePoint(unittest.TestCase):
+    """The LLM background analysis must honor the session's target white point."""
+
+    def _trigger_and_capture_summary(self, session):
+        captured = []
+
+        def fake_call_llm(summary, *args, **kwargs):
+            captured.append(summary)
+            return ""
+
+        with patch.object(server, "threading") as mock_threading:
+            mock_threading.Thread.side_effect = _SyncThread
+            with patch.object(server, "_call_llm", side_effect=fake_call_llm):
+                server._maybe_trigger_llm("test-sid", session)
+
+        self.assertEqual(len(captured), 1, "expected exactly one LLM call")
+        return captured[0]
+
+    def test_d50_target_produces_different_summary_than_d65(self):
+        summary_d50 = self._trigger_and_capture_summary(_session(D50_xy))
+        summary_d65 = self._trigger_and_capture_summary(_session(D65_xy))
+
+        de_d50 = summary_d50.grayscale_rows[0]["dE2000"]
+        de_d65 = summary_d65.grayscale_rows[0]["dE2000"]
+        self.assertNotAlmostEqual(de_d50, de_d65, places=3)
+
+    def test_d65_target_matches_default_analysis(self):
+        """Sanity check: a D65 session target should match the D65 default."""
+        from calcore.analysis import analyze
+        from calcore.models import AnalysisConfig, Patch
+
+        summary_via_trigger = self._trigger_and_capture_summary(_session(D65_xy))
+
+        patch_obj = Patch(
+            label="50%", r_target=128, g_target=128, b_target=128,
+            meas_xyz=(50.0, 50.0, 50.0), kind="grayscale",
+        )
+        cfg = server._session_to_analysis_config(_session(D65_xy))
+        summary_direct = analyze([patch_obj], cfg)
+
+        de_trigger = summary_via_trigger.grayscale_rows[0]["dE2000"]
+        de_direct = summary_direct.grayscale_rows[0]["dE2000"]
+        self.assertAlmostEqual(de_trigger, de_direct, places=6)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 📺 Overview

Closes #606

### What does this PR do?
* **Type of change:** [x] Bug fix
* **Component(s) affected:** Backend (`server.py`) — LLM background analysis path

---

## 🛠️ Technical Context & Implementation

* **The Problem:** `_run_llm_background()` called `_calcore_analyze(patches, cfg)` without a white point, so it always defaulted to D65 regardless of the session's actual target. Every other `_calcore_analyze()` call site (`/gamut/diagnosis`, `/gamut/advise`, `/suggested-patches`, `/next-settings`) correctly passes `target.white_point_xy`. `_maybe_trigger_llm()` never extracted the target, so it couldn't forward the white point. This is currently latent (all shipped targets use D65), but it would silently regress #485 the moment a non-D65 target ships — the LLM adjustment plan (the path that drives hardware changes) would analyze against a different white point than every diagnostic endpoint in the same session.
* **The Solution:** `_maybe_trigger_llm()` now reads `session.get("target")` and passes `target.white_point_xy` through to `_run_llm_background()`, which forwards it to `_calcore_analyze(patches, cfg, white_point)` — mirroring the existing pattern at `server.py:2098-2101`. Also fixed the manual `/api/session/{sid}/llm/run` endpoint, which calls `_run_llm_background()` directly and had the same gap.
* **Impact on existing workflows/APIs:** None today — all shipped targets (`SDR_TARGET`/`HDR10_TARGET`/`DV_TARGET`) use the default D65 white point, so behavior is unchanged for current sessions. This only changes behavior once a non-D65 target is configured.

### Mathematical / Data Integrity Checks (If Applicable)
* [x] Floating-point precision or data truncation risks have been addressed (N/A — no new numeric computation, just parameter threading).

---

## 🧪 Testing & Validation

### Verification Steps
1. Added `tests/test_maybe_trigger_llm_white_point.py`, which stubs `_call_llm`, configures a session whose target has a D50 white point, triggers `_maybe_trigger_llm()`, and asserts the `Summary` handed to `_call_llm` differs from the D65 analysis (reusing the fixture pattern from `tests/test_white_point.py`).
2. Ran full test suite: `python -m pytest tests/ --no-cov` — 100% pass.

### Firmware / TV Settings
* N/A — backend logic change only, no hardware interaction.

---

## 🧼 Checklist
* [x] Code adheres to project style guidelines (formatting, typing, linting).
* [x] Unit tests added/updated and passing.
* [ ] Documentation (README, inline docstrings) updated to reflect changes. (N/A — internal bug fix, no user-facing behavior change)
* [x] No credentials, local absolute paths, or hardware-specific hardcoding leaked.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5WxiBJJcQsNSVK41Lyj4x)_