### PR TITLE
fix(unraid-template): remove nonexistent Samba sidecar, fix broken icon URL

### DIFF
--- a/unraid-template.xml
+++ b/unraid-template.xml
@@ -9,17 +9,16 @@
   <Privileged>false</Privileged>
   <Support>https://github.com/jweber93/tv-calibration/issues</Support>
   <Project>https://github.com/jweber93/tv-calibration</Project>
-  <Overview>Automated TV display calibration server with guided workflow, LLM-powered analysis, and ZRO CSV auto-import via Samba.
+  <Overview>Automated TV display calibration server with guided workflow, LLM-powered analysis, and ZRO CSV auto-import.
 
 **Setup on Unraid:**
 1. Set your ZRO measurement share path in the "ZRO Drops Share" field (e.g. /mnt/user/downloads/zro-drops)
-2. Configure LiteLLM endpoint and model in the AI Assistant section of the app UI
-3. Map your Windows ZRO export share to the Samba container at `\\&lt;UNRAID_IP&gt;\zro-drops`
+2. Expose that same host path as an Unraid SMB share (User Shares → Add Share) so ColourSpace ZRO on Windows can export directly into it — the container itself does not run Samba, it relies on the host's SMB server
+3. Configure LiteLLM endpoint and model in the AI Assistant section of the app UI
 4. Open http://&lt;UNRAID_IP&gt;:8000 in your browser
 
 **Services included:**
 - calcore-server (FastAPI) on port 8000
-- Samba on ports 139/445 exposing zro-drops/ share
 
 **Optional:**
 - Set "OpenRouter API Key" in the template fields for cloud LLM routing
@@ -28,31 +27,25 @@
   <Category>MediaTools: Other</Category>
   <WebUI>http://[IP]:[PORT:8000]</WebUI>
   <TemplateURL>https://raw.githubusercontent.com/jweber93/tv-calibration/main/unraid-template.xml</TemplateURL>
-  <Icon>https://raw.githubusercontent.com/jweber93/tv-calibration/main/frontend/public/logo.svg</Icon>
+  <Icon>https://raw.githubusercontent.com/jweber93/tv-calibration/main/frontend/public/favicon.svg</Icon>
   <ExtraParams>
 --name tv-calibration \
 --restart unless-stopped
   </ExtraParams>
   <Config>
-    <Config Name="App port" Target="8000" Default="8000" Mode="tcp" Display="always" Description="Port for the FastAPI web UI">
+    <Config Name="App port" Target="8000" Default="8000" Mode="tcp" Type="Port" Display="always" Description="Port for the FastAPI web UI">
       <Value>8000</Value>
     </Config>
-    <Config Name="Samba NetBIOS port" Target="139" Default="139" Mode="tcp" Display="always" Description="Samba NetBIOS session port for ZRO CSV auto-import share">
-      <Value>139</Value>
-    </Config>
-    <Config Name="Samba CIFS port" Target="445" Default="445" Mode="tcp" Display="always" Description="Samba CIFS port for ZRO CSV auto-import share">
-      <Value>445</Value>
-    </Config>
-    <Config Name="ZRO Drops Share" Target="/data/zro-drops" Default="/mnt/user/downloads/zro-drops" Mode="rw" Description="Host path for ZRO CSV auto-import. Map your ColourSpace export folder here. The Samba sidecar exposes this as \\\\&lt;UNRAID_IP&gt;\\zro-drops" Display="always" Required="true">
+    <Config Name="ZRO Drops Share" Target="/data/zro-drops" Default="/mnt/user/downloads/zro-drops" Mode="rw" Type="Path" Description="Host path for ZRO CSV auto-import. Map your ColourSpace export folder here, then expose this same host path as an Unraid SMB share so ColourSpace ZRO on Windows can write to it directly." Display="always" Required="true">
       <Value>/mnt/user/downloads/zro-drops</Value>
     </Config>
-    <Config Name="Sessions dir" Target="/app/.sessions" Default="/mnt/user/appdata/tv-calibration/.sessions" Mode="rw" Description="Persisted session storage. Maps to /mnt/user/appdata/tv-calibration/.sessions" Display="always" Required="false">
+    <Config Name="Sessions dir" Target="/app/.sessions" Default="/mnt/user/appdata/tv-calibration/.sessions" Mode="rw" Type="Path" Description="Persisted session storage. Maps to /mnt/user/appdata/tv-calibration/.sessions" Display="always" Required="false">
       <Value>/mnt/user/appdata/tv-calibration/.sessions</Value>
     </Config>
-    <Config Name="History dir" Target="/app/.calibration-history" Default="/mnt/user/appdata/tv-calibration/.calibration-history" Mode="rw" Description="Persisted calibration history. Maps to /mnt/user/appdata/tv-calibration/.calibration-history" Display="always" Required="false">
+    <Config Name="History dir" Target="/app/.calibration-history" Default="/mnt/user/appdata/tv-calibration/.calibration-history" Mode="rw" Type="Path" Description="Persisted calibration history. Maps to /mnt/user/appdata/tv-calibration/.calibration-history" Display="always" Required="false">
       <Value>/mnt/user/appdata/tv-calibration/.calibration-history</Value>
     </Config>
-    <Config Name="Prefs file" Target="/app/.prefs.json" Default="/mnt/user/appdata/tv-calibration/.prefs.json" Mode="rw" Description="User preferences file. Maps to /mnt/user/appdata/tv-calibration/.prefs.json" Display="always" Required="false">
+    <Config Name="Prefs file" Target="/app/.prefs.json" Default="/mnt/user/appdata/tv-calibration/.prefs.json" Mode="rw" Type="Path" Description="User preferences file. Maps to /mnt/user/appdata/tv-calibration/.prefs.json" Display="always" Required="false">
       <Value>/mnt/user/appdata/tv-calibration/.prefs.json</Value>
     </Config>
     <Config Name="Dogegen Agent URL" Target="DOGEGEN_AGENT_URL" Default="" Mode="" Description="Optional: URL of a Dogegen Companion Agent (tools/dogegen-agent) running on a separate Windows PC, e.g. http://192.168.1.50:7071. Unraid is a Linux host, so Dogegen.exe cannot be bind-mounted or run in this container — it must run on a Windows PC and be controlled over the network. Leave empty if you aren't using Dogegen." Type="Variable" Display="always" Required="false">


### PR DESCRIPTION
## 📺 Overview

Closes #

### What does this PR do?
* **Type of change:** [x] Bug fix | [ ] New feature | [ ] Refactoring | [ ] CI/CD or Tooling
* **Component(s) affected:** unraid-template.xml

---

## 🛠️ Technical Context & Implementation

* **The Problem:** The template mapped ports 139/445 and described a bundled "Samba on ports 139/445 exposing zro-drops/ share" service, but the published image (`Dockerfile`) never installs or runs Samba — only `calcore-server` on port 8000 runs. Mapping those ports did nothing, and the instructions contradicted the README's actual Unraid guidance (expose the ZRO Drops path as a native Unraid SMB share). Separately, `<Icon>` pointed at `frontend/public/logo.svg`, a file that doesn't exist in the repo, so the template icon 404s in Community Applications.
* **The Solution:** Removed the Samba port Config entries and Samba-sidecar references from the Overview; updated setup instructions to match the README (expose the ZRO Drops Share path via Unraid's own SMB server instead); fixed `<Icon>` to point at `frontend/public/favicon.svg`, which actually exists; and added the `Type="Path"`/`Type="Port"` attribute to the path/port Config entries for Community Applications template compliance.
* **Impact on existing workflows/APIs:** None — this is metadata/config-only; no application code changed. Existing installs are unaffected since the Samba ports were never functional to begin with.

### Mathematical / Data Integrity Checks (If Applicable)
N/A — no calibration math touched.

---

## 🧪 Testing & Validation

### Environment Details
* **OS / Target Display:** N/A — Unraid Community Applications template only
* **Hardware/Mock Used:** N/A

### Verification Steps
1. Parsed `unraid-template.xml` with `xml.dom.minidom` to confirm it's still valid XML.
2. Confirmed via `Dockerfile` that the image never installs/runs Samba.
3. Confirmed `frontend/public/favicon.svg` exists and `frontend/public/logo.svg` does not.

### Firmware / TV Settings
N/A

---

## 📸 Visual Evidence (UI / Plot Changes)
N/A — no UI changes.

---

## 🧼 Checklist
* [x] Code adheres to project style guidelines (formatting, typing, linting).
* [x] No credentials, local absolute paths, or hardware-specific hardcoding leaked.
* [ ] Unit tests added/updated and passing. (N/A — no test coverage for a static XML template)
* [ ] Documentation (README, inline docstrings) updated to reflect changes. (N/A — README already describes this behavior; the template was out of sync with it)
