### PR TITLE
fix(unraid-template): flatten Config schema so Unraid actually renders fields

### DIFF
--- a/unraid-template.xml
+++ b/unraid-template.xml
@@ -32,33 +32,13 @@
 --name tv-calibration \
 --restart unless-stopped
   </ExtraParams>
-  <Config>
-    <Config Name="App port" Target="8000" Default="8000" Mode="tcp" Type="Port" Display="always" Description="Port for the FastAPI web UI">
-      <Value>8000</Value>
-    </Config>
-    <Config Name="ZRO Drops Share" Target="/data/zro-drops" Default="/mnt/user/downloads/zro-drops" Mode="rw" Type="Path" Description="Host path for ZRO CSV auto-import. Map your ColourSpace export folder here, then expose this same host path as an Unraid SMB share so ColourSpace ZRO on Windows can write to it directly." Display="always" Required="true">
-      <Value>/mnt/user/downloads/zro-drops</Value>
-    </Config>
-    <Config Name="Sessions dir" Target="/app/.sessions" Default="/mnt/user/appdata/tv-calibration/.sessions" Mode="rw" Type="Path" Description="Persisted session storage. Maps to /mnt/user/appdata/tv-calibration/.sessions" Display="always" Required="false">
-      <Value>/mnt/user/appdata/tv-calibration/.sessions</Value>
-    </Config>
-    <Config Name="History dir" Target="/app/.calibration-history" Default="/mnt/user/appdata/tv-calibration/.calibration-history" Mode="rw" Type="Path" Description="Persisted calibration history. Maps to /mnt/user/appdata/tv-calibration/.calibration-history" Display="always" Required="false">
-      <Value>/mnt/user/appdata/tv-calibration/.calibration-history</Value>
-    </Config>
-    <Config Name="Prefs file" Target="/app/.prefs.json" Default="/mnt/user/appdata/tv-calibration/.prefs.json" Mode="rw" Type="Path" Description="User preferences file. Maps to /mnt/user/appdata/tv-calibration/.prefs.json" Display="always" Required="false">
-      <Value>/mnt/user/appdata/tv-calibration/.prefs.json</Value>
-    </Config>
-    <Config Name="Dogegen Agent URL" Target="DOGEGEN_AGENT_URL" Default="" Mode="" Description="Optional: URL of a Dogegen Companion Agent (tools/dogegen-agent) running on a separate Windows PC, e.g. http://192.168.1.50:7071. Unraid is a Linux host, so Dogegen.exe cannot be bind-mounted or run in this container — it must run on a Windows PC and be controlled over the network. Leave empty if you aren't using Dogegen." Type="Variable" Display="always" Required="false">
-      <Value></Value>
-    </Config>
-    <Config Name="LiteLLM Endpoint" Target="LITELLM_ENDPOINT" Default="http://host.docker.internal:4000" Mode="" Description="LiteLLM proxy URL for AI-assisted analysis. Set this if you run a local LiteLLM proxy on Unraid or elsewhere." Type="Variable" Display="always" Required="false">
-      <Value>http://host.docker.internal:4000</Value>
-    </Config>
-    <Config Name="LiteLLM Model" Target="LITELLM_MODEL" Default="tvcal-analyst" Mode="" Description="Model name to use via the LiteLLM proxy (e.g. gpt-4o, claude-sonnet-4-20250514, or a local model alias)." Type="Variable" Display="always" Required="false">
-      <Value>tvcal-analyst</Value>
-    </Config>
-    <Config Name="OpenRouter API Key" Target="OPENROUTER_API_KEY" Default="" Mode="" Description="Optional: OpenRouter API key for cloud LLM routing. Overrides LiteLLM if set." Type="Variable" Display="always" Required="false">
-      <Value></Value>
-    </Config>
-  </Config>
+  <Config Name="App port" Target="8000" Default="8000" Mode="tcp" Type="Port" Display="always" Required="true" Description="Port for the FastAPI web UI">8000</Config>
+  <Config Name="ZRO Drops Share" Target="/data/zro-drops" Default="/mnt/user/downloads/zro-drops" Mode="rw" Type="Path" Display="always" Required="true" Description="Host path for ZRO CSV auto-import. Map your ColourSpace export folder here, then expose this same host path as an Unraid SMB share so ColourSpace ZRO on Windows can write to it directly.">/mnt/user/downloads/zro-drops</Config>
+  <Config Name="Sessions dir" Target="/app/.sessions" Default="/mnt/user/appdata/tv-calibration/.sessions" Mode="rw" Type="Path" Display="always" Required="false" Description="Persisted session storage. Maps to /mnt/user/appdata/tv-calibration/.sessions">/mnt/user/appdata/tv-calibration/.sessions</Config>
+  <Config Name="History dir" Target="/app/.calibration-history" Default="/mnt/user/appdata/tv-calibration/.calibration-history" Mode="rw" Type="Path" Display="always" Required="false" Description="Persisted calibration history. Maps to /mnt/user/appdata/tv-calibration/.calibration-history">/mnt/user/appdata/tv-calibration/.calibration-history</Config>
+  <Config Name="Prefs file" Target="/app/.prefs.json" Default="/mnt/user/appdata/tv-calibration/.prefs.json" Mode="rw" Type="Path" Display="always" Required="false" Description="User preferences file. Maps to /mnt/user/appdata/tv-calibration/.prefs.json">/mnt/user/appdata/tv-calibration/.prefs.json</Config>
+  <Config Name="Dogegen Agent URL" Target="DOGEGEN_AGENT_URL" Default="" Mode="" Type="Variable" Display="always" Required="false" Description="Optional: URL of a Dogegen Companion Agent (tools/dogegen-agent) running on a separate Windows PC, e.g. http://192.168.1.50:7071. Unraid is a Linux host, so Dogegen.exe cannot be bind-mounted or run in this container — it must run on a Windows PC and be controlled over the network. Leave empty if you aren't using Dogegen."></Config>
+  <Config Name="LiteLLM Endpoint" Target="LITELLM_ENDPOINT" Default="http://host.docker.internal:4000" Mode="" Type="Variable" Display="always" Required="false" Description="LiteLLM proxy URL for AI-assisted analysis. Set this if you run a local LiteLLM proxy on Unraid or elsewhere.">http://host.docker.internal:4000</Config>
+  <Config Name="LiteLLM Model" Target="LITELLM_MODEL" Default="tvcal-analyst" Mode="" Type="Variable" Display="always" Required="false" Description="Model name to use via the LiteLLM proxy (e.g. gpt-4o, claude-sonnet-4-20250514, or a local model alias).">tvcal-analyst</Config>
+  <Config Name="OpenRouter API Key" Target="OPENROUTER_API_KEY" Default="" Mode="" Type="Variable" Display="always" Required="false" Description="Optional: OpenRouter API key for cloud LLM routing. Overrides LiteLLM if set."></Config>
 </Container>


### PR DESCRIPTION
## 📺 Overview

Closes #

### What does this PR do?
* **Type of change:** [x] Bug fix | [ ] New feature | [ ] Refactoring | [ ] CI/CD or Tooling
* **Component(s) affected:** unraid-template.xml

---

## 🛠️ Technical Context & Implementation

* **The Problem:** Every `Config` entry was nested inside an outer `<Config>` wrapper element, with the value stored in a further-nested `<Value>` child, instead of being a direct child of `<Container>` with the value as inline text (the schema Unraid's Docker Manager actually expects). Unraid only recognizes `Config` elements that are direct children of `Container`, so it saw one unrecognized wrapper node with no `Name`/`Target` attributes and rendered *none* of the port/path/variable fields on the "Add Container" screen — confirmed by a user screenshot showing nothing between the Overview text and "Additional Requirements: None Listed".
* **The Solution:** Flattened all 9 `Config` entries to the correct top-level schema (`<Config Name="..." Target="..." ...>value</Config>` as a direct child of `<Container>`), removing the outer wrapper and the nested `<Value>` tags.
* **Impact on existing workflows/APIs:** None on the running container — this only affects how Unraid's Docker Manager renders the "Add Container" / edit-container form. Existing installs already running are unaffected; new installs and template edits will now correctly show the App port, ZRO Drops Share, Sessions/History/Prefs paths, and the four env-var fields (Dogegen Agent URL, LiteLLM Endpoint, LiteLLM Model, OpenRouter API Key).

### Mathematical / Data Integrity Checks (If Applicable)
N/A — no calibration math touched.

---

## 🧪 Testing & Validation

### Environment Details
* **OS / Target Display:** N/A — Unraid Community Applications template only
* **Hardware/Mock Used:** N/A

### Verification Steps
1. Parsed `unraid-template.xml` with `xml.etree.ElementTree` and confirmed 9 `Config` elements are now direct children of `Container`, each with the expected `Name`/`Type`/`Target` attributes and inline value text.
2. Confirmed the file is still well-formed XML.

### Firmware / TV Settings
N/A

---

## 📸 Visual Evidence (UI / Plot Changes)
N/A — no in-app UI changes; the affected UI is Unraid's own Docker Manager template form, which isn't reproducible in this environment. The reported symptom was a user screenshot of the Unraid "Add Container" form showing no Path/Port/Variable fields at all.

---

## 🧼 Checklist
* [x] Code adheres to project style guidelines (formatting, typing, linting).
* [x] No credentials, local absolute paths, or hardware-specific hardcoding leaked.
* [ ] Unit tests added/updated and passing. (N/A — no test coverage for a static XML template)
* [ ] Documentation (README, inline docstrings) updated to reflect changes. (N/A — behavior described in README is unchanged; this fixes template rendering only)


---
_Generated by [Claude Code](https://claude.ai/code/session_01WWTLovSzPrRgJgFtzqdPyV)_