### PR TITLE
Allow windows-companion-tools release to be cut via workflow_dispatch

### DIFF
--- a/.github/workflows/windows-companion-tools-release.yml
+++ b/.github/workflows/windows-companion-tools-release.yml
@@ -11,12 +11,21 @@ name: Windows Companion Tools Release
 #
 # Triggers:
 #   companion-tools-v* tag → release named after the tag
-#   workflow_dispatch       → manual build; uploads to a draft release
+#   workflow_dispatch       → manual build; if a version is given, also
+#                             creates/updates a draft release tagged
+#                             companion-tools-v<version> at the current ref
+#                             (no separate tag push needed); otherwise just
+#                             builds and verifies without releasing.
 
 on:
   push:
     tags: ["companion-tools-v*"]
   workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release, e.g. 1.0.0 (creates tag companion-tools-v1.0.0 + a draft release). Leave blank to just build/verify without releasing."
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -76,9 +85,11 @@ jobs:
           path: tools/windows-companion-tools/windows-companion-tools.zip
 
       - name: Create/update release
-        if: startsWith(github.ref, 'refs/tags/companion-tools-v')
+        if: startsWith(github.ref, 'refs/tags/companion-tools-v') || (github.event_name == 'workflow_dispatch' && inputs.version != '')
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || format('companion-tools-v{0}', inputs.version) }}
+          target_commitish: ${{ github.sha }}
           files: tools/windows-companion-tools/windows-companion-tools.zip
           draft: true
           generate_release_notes: true

--- a/tools/windows-companion-tools/README.md
+++ b/tools/windows-companion-tools/README.md
@@ -89,11 +89,18 @@ machines. See each linked README's Trust model section for details.
 
 ## Releasing (maintainers)
 
-Pushing a tag matching `companion-tools-v*` (e.g. `companion-tools-v1.0.0`)
-triggers the [`windows-companion-tools-release`](../../.github/workflows/windows-companion-tools-release.yml)
-GitHub Actions workflow, which builds `companion.exe` with PyInstaller on
+The [`windows-companion-tools-release`](../../.github/workflows/windows-companion-tools-release.yml)
+GitHub Actions workflow builds `companion.exe` with PyInstaller on
 `windows-latest` and attaches it (plus both example config files) in
-`windows-companion-tools.zip` to a draft GitHub Release for that tag.
-Review and publish the draft once it's built. The workflow can also be run
-manually (`workflow_dispatch`) to sanity-check the build without cutting a
-release.
+`windows-companion-tools.zip` to a draft GitHub Release. Two ways to
+trigger it:
+
+* **Push a tag** matching `companion-tools-v*` (e.g. `companion-tools-v1.0.0`)
+  — creates a draft release named after the tag.
+* **Run it manually** (`workflow_dispatch`, from the Actions tab or the
+  GitHub API) with a `version` input (e.g. `1.0.0`) — creates the tag
+  `companion-tools-v1.0.0` at the triggering commit and a draft release,
+  without needing a separate tag push. Leave `version` blank to just build
+  and verify the `.exe` without releasing.
+
+Either way, review and publish the draft once it's built.


### PR DESCRIPTION
## 📺 Overview

Follow-up to #621. Lets a maintainer (or an assistant with GitHub Actions API access but no git tag-push access) cut a `windows-companion-tools` release without pushing a git tag.

### What does this PR do?
* **Type of change:** [x] New feature | [x] CI/CD or Tooling
* **Component(s) affected:** `.github/workflows/windows-companion-tools-release.yml`, `tools/windows-companion-tools/README.md`

---

## 🛠️ Technical Context & Implementation

* **The Problem:** The release workflow only created a GitHub Release when triggered by a `companion-tools-v*` tag push. A `workflow_dispatch` run built and verified the `.exe` but never released it — so cutting a release required pushing a tag, which some environments (e.g. a restricted git proxy) don't allow even when they do allow triggering Actions workflows via the API.
* **The Solution:** Added a `version` input to `workflow_dispatch`. The release step's condition now also fires when the workflow is manually dispatched with a non-empty `version`, using `tag_name: companion-tools-v<version>` and `target_commitish: ${{ github.sha }}` — `softprops/action-gh-release` creates that tag at the triggering commit if it doesn't already exist, so no separate tag push is needed. Leaving `version` blank on a manual run preserves the old "build and verify only" behavior. Updated the tool's README to document both trigger paths.
* **Impact on existing workflows/APIs:** None for the tag-push path — it's unchanged. Purely additive for `workflow_dispatch`.

---

## 🧪 Testing & Validation

* Validated the updated workflow YAML parses correctly (`yaml.safe_load`).
* Have not yet exercised a real `workflow_dispatch` run with `version` set (requires a `windows-latest` runner); recommend a maintainer trigger it once with a test version to confirm the draft release is created correctly before relying on it.

### Environment Details
* **OS / Target Display:** N/A (tooling/CI change only, no calibration logic touched)

---

## 🧼 Checklist
* [x] Code adheres to project style guidelines (formatting, typing, linting).
* [ ] Unit tests added/updated and passing. *(N/A — CI workflow change, no testable Python logic changed)*
* [x] Documentation (README, inline docstrings) updated to reflect changes.
* [x] No credentials, local absolute paths, or hardware-specific hardcoding leaked.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MNeNDDNAGyuDEdpPjMfq8C)_